### PR TITLE
Resolve game endpoints from the container, not GAME_HOST_NETWORK (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,27 @@ can't see it. Opting in and out is just which tag your container tracks:
 point the image at `ghcr.io/shakes63/palisade:nightly` to ride prereleases,
 and back at `:latest` to rejoin stable at the next release.
 
+### Troubleshooting
+
+**Player counts stay empty, or RCON says `getaddrinfo ENOTFOUND <container name>`.**
+The manager couldn't resolve the game container by name. Games with no usable query
+protocol (Palworld, ASA, Minecraft) read their player list over RCON, so this shows
+up as "no players" rather than an obvious error.
+
+Palisade works out how to reach each container from the container itself — its IP on
+a network you share, the host gateway when it uses host networking or publishes the
+port — so this only bites when none of those apply. The usual cause is the manager
+not being attached to `ark-net` while game servers are. Check `GET /api/health`: it
+reports a warning naming this exact condition. To fix:
+
+```bash
+docker network connect ark-net <manager container>
+```
+
+On Unraid, make sure the Palisade container's **Network Type** is `ark-net` (the
+template sets it, but it's easy to change). If you use `GAME_HOST_NETWORK=true`,
+the manager instead needs `--add-host host.docker.internal:host-gateway`.
+
 ---
 
 ## Integrations (all optional, all in Settings)

--- a/apps/api/src/common/game-endpoint.test.ts
+++ b/apps/api/src/common/game-endpoint.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import {
+  ContainerNetworkFacts,
+  ManagerNetworkFacts,
+  explainEndpointFailure,
+  hostGatewayAddress,
+  resolveGameEndpoint,
+} from "./game-endpoint";
+
+// GH #21: Palworld player counts go through RCON, and RCON's host used to be guessed
+// from the global GAME_HOST_NETWORK flag. When the flag and the deployment disagreed
+// the connection was attempted against a name nothing could resolve, and the user saw
+// only `getaddrinfo ENOTFOUND palworld-…`. These cover the shapes that produced that.
+
+const managerOnArkNet: ManagerNetworkFacts = {
+  inContainer: true,
+  hostNetwork: false,
+  networks: ["ark-net"],
+};
+/** The misconfiguration behind #21: manager on the default bridge, not ark-net. */
+const managerOffArkNet: ManagerNetworkFacts = {
+  inContainer: true,
+  hostNetwork: false,
+  networks: ["bridge"],
+};
+const managerOnHost: ManagerNetworkFacts = {
+  inContainer: true,
+  hostNetwork: true,
+  networks: ["host"],
+};
+const managerOnDevBox: ManagerNetworkFacts = {
+  inContainer: false,
+  hostNetwork: false,
+  networks: [],
+};
+
+const onArkNet = (ip: string | null, ports: ContainerNetworkFacts["ports"] = {}): ContainerNetworkFacts => ({
+  networkMode: "ark-net",
+  networks: { "ark-net": ip },
+  ports,
+});
+
+const resolve = (facts: ContainerNetworkFacts | null, manager: ManagerNetworkFacts) =>
+  resolveGameEndpoint({ facts, manager, containerPort: 7780, fallbackHost: "palworld-mysrv-abc123" });
+
+describe("resolveGameEndpoint", () => {
+  it("dials the container's ark-net IP when the manager shares that network", () => {
+    // The fix: an IP needs no DNS, so this can't fail the way a name can.
+    expect(resolve(onArkNet("172.20.0.5"), managerOnArkNet)).toEqual({
+      host: "172.20.0.5",
+      port: 7780,
+      via: "shared-network",
+    });
+  });
+
+  it("goes through the host gateway for a host-networked container", () => {
+    const hostNetworked: ContainerNetworkFacts = { networkMode: "host", networks: { host: null }, ports: {} };
+    expect(resolve(hostNetworked, managerOnArkNet)).toEqual({
+      host: "host.docker.internal",
+      port: 7780,
+      via: "host-network",
+    });
+  });
+
+  it("uses the published host port when the two share no network (the #21 setup)", () => {
+    // Manager on `bridge`, game on `ark-net`: the name would never resolve, but the
+    // published port is reachable through the host, so RCON works anyway.
+    const facts = onArkNet("172.20.0.5", { "7780/tcp": [{ HostIp: "0.0.0.0", HostPort: "7780" }] });
+    expect(resolve(facts, managerOffArkNet)).toEqual({
+      host: "host.docker.internal",
+      port: 7780,
+      via: "published-port",
+    });
+  });
+
+  it("honours a published port that differs from the container port", () => {
+    const facts = onArkNet("172.20.0.5", { "7780/tcp": [{ HostPort: "17780" }] });
+    expect(resolve(facts, managerOffArkNet)).toMatchObject({ port: 17780, via: "published-port" });
+  });
+
+  it("prefers ark-net over another shared network", () => {
+    const facts: ContainerNetworkFacts = {
+      networkMode: "ark-net",
+      networks: { other: "10.0.0.9", "ark-net": "172.20.0.5" },
+      ports: {},
+    };
+    expect(resolve(facts, { ...managerOnArkNet, networks: ["other", "ark-net"] })).toMatchObject({
+      host: "172.20.0.5",
+    });
+  });
+
+  it("falls back to the container name when nothing is shared and nothing is published", () => {
+    // Preserves the historical behaviour rather than breaking a setup we can't model.
+    expect(resolve(onArkNet("172.20.0.5"), managerOffArkNet)).toEqual({
+      host: "palworld-mysrv-abc123",
+      port: 7780,
+      via: "container-name",
+    });
+  });
+
+  it("falls back to the container name when Docker tells us nothing", () => {
+    // Locked-down socket-proxy or a container that vanished mid-probe.
+    expect(resolve(null, managerOnArkNet)).toEqual({
+      host: "palworld-mysrv-abc123",
+      port: 7780,
+      via: "container-name",
+    });
+  });
+
+  it("ignores a shared network the container has no IP on", () => {
+    // A created-but-not-started container has the network with an empty IP.
+    const facts = onArkNet("", { "7780/tcp": [{ HostPort: "7780" }] });
+    expect(resolve(facts, managerOnArkNet)).toMatchObject({ via: "published-port" });
+  });
+
+  it("matches the port's own protocol, not just its number", () => {
+    // A UDP query port published as UDP must not be found under tcp (and vice versa).
+    const facts = onArkNet(null, { "27015/udp": [{ HostPort: "27015" }] });
+    const udp = resolveGameEndpoint({
+      facts,
+      manager: managerOffArkNet,
+      containerPort: 27015,
+      protocol: "udp",
+      fallbackHost: "ark-x",
+    });
+    const tcp = resolveGameEndpoint({
+      facts,
+      manager: managerOffArkNet,
+      containerPort: 27015,
+      protocol: "tcp",
+      fallbackHost: "ark-x",
+    });
+    expect(udp.via).toBe("published-port");
+    expect(tcp.via).toBe("container-name");
+  });
+});
+
+describe("hostGatewayAddress", () => {
+  it("uses the host gateway from inside a bridged container", () => {
+    expect(hostGatewayAddress(managerOnArkNet)).toBe("host.docker.internal");
+  });
+  it("uses loopback when the manager is on the host network", () => {
+    expect(hostGatewayAddress(managerOnHost)).toBe("127.0.0.1");
+  });
+  it("uses loopback in dev, where the manager isn't containerised at all", () => {
+    // host.docker.internal doesn't exist outside Docker — this made dev probes fail too.
+    expect(hostGatewayAddress(managerOnDevBox)).toBe("127.0.0.1");
+  });
+});
+
+describe("explainEndpointFailure", () => {
+  const dns = Object.assign(new Error("getaddrinfo ENOTFOUND palworld-mysrv-abc123"), {
+    code: "ENOTFOUND",
+  });
+  const byName = { host: "palworld-mysrv-abc123", port: 7780, via: "container-name" } as const;
+
+  it("names the missing ark-net attachment as the cause", () => {
+    const hint = explainEndpointFailure({
+      error: dns,
+      endpoint: byName,
+      manager: managerOffArkNet,
+      gameOnArkNet: true,
+    });
+    expect(hint).toContain("not attached");
+    expect(hint).toContain("docker network connect ark-net");
+  });
+
+  it("explains a name failure when the container is off ark-net entirely", () => {
+    const hint = explainEndpointFailure({
+      error: dns,
+      endpoint: byName,
+      manager: managerOnArkNet,
+      gameOnArkNet: false,
+    });
+    expect(hint).toContain("did not resolve");
+    expect(hint).not.toContain("docker network connect");
+  });
+
+  it("points at the missing --add-host when the host gateway is unresolvable", () => {
+    const err = Object.assign(new Error("getaddrinfo ENOTFOUND host.docker.internal"), {
+      code: "ENOTFOUND",
+    });
+    const hint = explainEndpointFailure({
+      error: err,
+      endpoint: { host: "host.docker.internal", port: 7780, via: "host-network" },
+      manager: managerOnArkNet,
+      gameOnArkNet: false,
+    });
+    expect(hint).toContain("host-gateway");
+  });
+
+  it("distinguishes a refused connection from an addressing problem", () => {
+    const err = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    const hint = explainEndpointFailure({
+      error: err,
+      endpoint: { host: "172.20.0.5", port: 7780, via: "shared-network" },
+      manager: managerOnArkNet,
+      gameOnArkNet: true,
+    });
+    expect(hint).toContain("nothing is listening on 172.20.0.5:7780");
+  });
+
+  it("stays silent about failures that aren't ours to explain", () => {
+    // A wrong RCON password isn't an addressing problem — don't editorialise.
+    const hint = explainEndpointFailure({
+      error: new Error("Authentication failed"),
+      endpoint: { host: "172.20.0.5", port: 7780, via: "shared-network" },
+      manager: managerOnArkNet,
+      gameOnArkNet: true,
+    });
+    expect(hint).toBeNull();
+  });
+});

--- a/apps/api/src/common/game-endpoint.ts
+++ b/apps/api/src/common/game-endpoint.ts
@@ -1,0 +1,151 @@
+import { ARK_NETWORK } from "./naming";
+
+/**
+ * Where the manager should connect to reach a game container's admin port (RCON,
+ * a status HTTP endpoint, the A2S query port…).
+ *
+ * Historically every call site guessed this from the global GAME_HOST_NETWORK flag:
+ * host networking → `host.docker.internal`, otherwise the container name resolved
+ * over Docker's embedded DNS on ark-net. That guess is only right when the whole
+ * deployment matches the flag, and nothing verified it — so a manager that isn't
+ * actually attached to ark-net (Unraid's template Network field is easy to change),
+ * or a container created while the flag had the other value, failed with a bare
+ * `getaddrinfo ENOTFOUND palworld-…` and no indication of why (GH #21).
+ *
+ * We now derive it from what the container actually IS, which is knowable: one
+ * inspect tells us its network mode, its IPs, and its published ports.
+ */
+
+/** The subset of `docker inspect` this resolution needs. */
+export interface ContainerNetworkFacts {
+  /** HostConfig.NetworkMode — "host", "bridge", a network name, "container:…". */
+  networkMode: string;
+  /** NetworkSettings.Networks — network name → the container's IP on it. */
+  networks: Record<string, string | null>;
+  /** NetworkSettings.Ports — "7780/tcp" → host bindings (empty/absent = unpublished). */
+  ports: Record<string, Array<{ HostIp?: string; HostPort?: string }> | null>;
+}
+
+/** What the manager itself is attached to, so we know what it can reach. */
+export interface ManagerNetworkFacts {
+  /** False when the manager runs outside Docker (dev) — then the host IS localhost. */
+  inContainer: boolean;
+  /** True when the manager container itself uses host networking. */
+  hostNetwork: boolean;
+  /** Names of the Docker networks the manager is attached to. */
+  networks: string[];
+}
+
+export interface ResolvedEndpoint {
+  host: string;
+  port: number;
+  /** How we got here — surfaced in errors/logs so a bad setup explains itself. */
+  via: "host-network" | "shared-network" | "published-port" | "container-name";
+}
+
+/**
+ * The host-side address of a port bound on the Docker host. A manager on the host
+ * network (or outside Docker entirely) reaches it on loopback; one inside a bridge
+ * needs the host gateway, which requires `--add-host host.docker.internal:host-gateway`.
+ */
+export function hostGatewayAddress(manager: ManagerNetworkFacts): string {
+  return !manager.inContainer || manager.hostNetwork ? "127.0.0.1" : "host.docker.internal";
+}
+
+/** True when the container runs in the host's network namespace. */
+function usesHostNetwork(c: ContainerNetworkFacts): boolean {
+  return c.networkMode === "host" || "host" in c.networks;
+}
+
+/**
+ * The first network both ends share, preferring ark-net. Connecting to the
+ * container's IP on a shared network skips Docker's embedded DNS entirely — which
+ * is the specific thing that was failing — and works even if the container was
+ * renamed out from under us.
+ */
+function sharedNetworkIp(c: ContainerNetworkFacts, manager: ManagerNetworkFacts): string | null {
+  const shared = Object.keys(c.networks).filter((n) => manager.networks.includes(n));
+  const preferred = shared.includes(ARK_NETWORK) ? ARK_NETWORK : shared[0];
+  const ip = preferred ? c.networks[preferred] : null;
+  return ip || null;
+}
+
+/** The host port `containerPort` is published on, if any. */
+function publishedPort(c: ContainerNetworkFacts, containerPort: number, proto: "tcp" | "udp"): number | null {
+  const binding = c.ports[`${containerPort}/${proto}`]?.[0]?.HostPort;
+  const port = binding ? Number(binding) : NaN;
+  return Number.isFinite(port) && port > 0 ? port : null;
+}
+
+/**
+ * Resolve the address to reach `containerPort` on a game container.
+ *
+ * Ordered most- to least-direct; each step is only taken when we can see it will
+ * work, so we degrade toward the old container-name behaviour rather than failing
+ * outright when Docker tells us nothing (`facts` null — inspect denied or the
+ * container is gone).
+ */
+export function resolveGameEndpoint(input: {
+  facts: ContainerNetworkFacts | null;
+  manager: ManagerNetworkFacts;
+  containerPort: number;
+  protocol?: "tcp" | "udp";
+  /** Container name, used as the last resort (and when we can't inspect). */
+  fallbackHost: string;
+}): ResolvedEndpoint {
+  const { facts, manager, containerPort, fallbackHost } = input;
+  const protocol = input.protocol ?? "tcp";
+  if (!facts) return { host: fallbackHost, port: containerPort, via: "container-name" };
+
+  // Host networking: the game binds straight onto the host, so go via the host side.
+  if (usesHostNetwork(facts)) {
+    return { host: hostGatewayAddress(manager), port: containerPort, via: "host-network" };
+  }
+
+  // Same network as us: dial the container's IP directly, no DNS involved.
+  const ip = sharedNetworkIp(facts, manager);
+  if (ip) return { host: ip, port: containerPort, via: "shared-network" };
+
+  // Different networks, but the port is published — reach it through the host.
+  const published = publishedPort(facts, containerPort, protocol);
+  if (published) {
+    return { host: hostGatewayAddress(manager), port: published, via: "published-port" };
+  }
+
+  // Nothing verifiable left. Keep the historical behaviour so a working, unusual
+  // setup we failed to model isn't broken by this change.
+  return { host: fallbackHost, port: containerPort, via: "container-name" };
+}
+
+/**
+ * Why a connection to a resolved endpoint could not be made, in terms the user can
+ * act on. Returns null when the failure isn't one of the addressing problems we can
+ * explain (a wrong password or a server that isn't listening yet is not our business).
+ */
+export function explainEndpointFailure(input: {
+  error: Error;
+  endpoint: ResolvedEndpoint;
+  manager: ManagerNetworkFacts;
+  gameOnArkNet: boolean;
+}): string | null {
+  const { endpoint, manager, gameOnArkNet } = input;
+  const code = (input.error as NodeJS.ErrnoException).code;
+  const dnsFailure = code === "ENOTFOUND" || code === "EAI_AGAIN";
+
+  if (dnsFailure && endpoint.via === "container-name") {
+    if (gameOnArkNet && manager.inContainer && !manager.networks.includes(ARK_NETWORK)) {
+      return `the manager container is not attached to the "${ARK_NETWORK}" network, so it cannot resolve game containers by name — run: docker network connect ${ARK_NETWORK} <manager container>`;
+    }
+    return `the name "${endpoint.host}" did not resolve — the game container is not on a network this manager shares, and its port is not published to the host`;
+  }
+
+  if (dnsFailure && endpoint.host === "host.docker.internal") {
+    return "host.docker.internal did not resolve — start the manager with `--add-host host.docker.internal:host-gateway` (required when game servers use host networking)";
+  }
+
+  if (code === "ECONNREFUSED") {
+    return `nothing is listening on ${endpoint.host}:${endpoint.port} — the server may still be starting, or RCON may be disabled/bound to a different port`;
+  }
+
+  return null;
+}

--- a/apps/api/src/config/ensure-host-data-dir.ts
+++ b/apps/api/src/config/ensure-host-data-dir.ts
@@ -45,8 +45,9 @@ function connect(): Docker {
 
 /** Our own container id: the hostname is the short id by default; if that's been
  *  overridden, the full id still appears in /proc/self/{mountinfo,cgroup}. Each
- *  candidate is confirmed by an inspect() so we never guess wrong. */
-async function findSelfContainerId(docker: Docker): Promise<string | null> {
+ *  candidate is confirmed by an inspect() so we never guess wrong. Returns null
+ *  when we aren't running in a container at all (dev on the host). */
+export async function findSelfContainerId(docker: Docker): Promise<string | null> {
   const candidates: string[] = [];
   const hn = hostname();
   if (/^[0-9a-f]{12,64}$/i.test(hn)) candidates.push(hn);

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -40,8 +40,12 @@ const schema = z.object({
   // Run game-server containers on the host network instead of the ark-net
   // bridge. Removes the Docker NAT layer so ASA/EOS advertises the host's real
   // address (more reliable public/Unofficial listing + join). When on, the
-  // manager reaches RCON via the host gateway instead of the container name, so
-  // the manager must be started with `--add-host host.docker.internal:host-gateway`.
+  // manager reaches RCON via the host gateway, so it must be started with
+  // `--add-host host.docker.internal:host-gateway`.
+  //
+  // This flag decides how containers are CREATED only. How the manager then
+  // reaches them is read back off each container (common/game-endpoint.ts), so a
+  // flag flipped after a container was created no longer strands RCON (GH #21).
   GAME_HOST_NETWORK: z
     .string()
     .default("false")

--- a/apps/api/src/docker/docker.module.ts
+++ b/apps/api/src/docker/docker.module.ts
@@ -1,9 +1,10 @@
 import { Global, Module } from "@nestjs/common";
 import { DockerService } from "./docker.service";
+import { GameEndpointService } from "./game-endpoint.service";
 
 @Global()
 @Module({
-  providers: [DockerService],
-  exports: [DockerService],
+  providers: [DockerService, GameEndpointService],
+  exports: [DockerService, GameEndpointService],
 })
 export class DockerModule {}

--- a/apps/api/src/docker/docker.service.ts
+++ b/apps/api/src/docker/docker.service.ts
@@ -11,6 +11,16 @@ export interface RunResult {
 /** Strip ANSI colour/escape sequences so log lines render cleanly in the UI. */
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
 
+/**
+ * Which of a server's labelled containers to inspect for live networking. A running
+ * one always wins: a stopped container has no IP and isn't in Docker's DNS, and more
+ * than one can carry the label (an adoption leaves the original behind, stopped).
+ * Returns null when there is nothing labelled for that server.
+ */
+export function pickServerContainer(list: Array<{ Id: string; State?: string }>): string | null {
+  return (list.find((c) => c.State === "running") ?? list[0])?.Id ?? null;
+}
+
 /** Demultiplex Docker's non-TTY log buffer (8-byte frame header per chunk). */
 function demuxLog(buf: Buffer): string {
   let out = "";
@@ -235,6 +245,15 @@ export class DockerService {
     for (const c of list) {
       await this.docker.getContainer(c.Id).remove({ force }).catch(() => undefined);
     }
+  }
+
+  /** A server's container id by the ark.serverId label — like removeByServerId, robust
+   *  to renames. */
+  async findContainerIdByServerId(serverId: string): Promise<string | null> {
+    const list = await this.docker
+      .listContainers({ all: true, filters: { label: [`ark.serverId=${serverId}`] } })
+      .catch(() => [] as Docker.ContainerInfo[]);
+    return pickServerContainer(list);
   }
 
   async inspect(id: string) {

--- a/apps/api/src/docker/game-endpoint.service.ts
+++ b/apps/api/src/docker/game-endpoint.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, Logger } from "@nestjs/common";
+import type Docker from "dockerode";
+import { DockerService } from "./docker.service";
+import { findSelfContainerId } from "../config/ensure-host-data-dir";
+import { ARK_NETWORK } from "../common/naming";
+import {
+  ContainerNetworkFacts,
+  ManagerNetworkFacts,
+  ResolvedEndpoint,
+  explainEndpointFailure,
+  resolveGameEndpoint,
+} from "../common/game-endpoint";
+
+/**
+ * Resolves the address the manager should use to reach a game container's admin
+ * ports, from the container's real networking rather than a global assumption
+ * (GH #21 — see common/game-endpoint.ts for the why).
+ *
+ * Every lookup is best-effort: if Docker won't tell us (locked-down socket-proxy,
+ * container already gone), resolution falls back to the historical container-name
+ * behaviour instead of failing.
+ */
+@Injectable()
+export class GameEndpointService {
+  private readonly logger = new Logger(GameEndpointService.name);
+  /** The manager's own networking can't change while the process runs — resolve once. */
+  private managerFacts: Promise<ManagerNetworkFacts> | null = null;
+
+  constructor(private readonly docker: DockerService) {}
+
+  /**
+   * Where to reach `containerPort` on the given server's container.
+   *
+   * Deliberately uncached: a container recreate changes its IP, and a stale address
+   * would strand RCON until the entry expired. The cost is one inspect per RCON
+   * connect (connections are pooled) or per player-probe cache miss.
+   */
+  async resolve(
+    serverId: string,
+    containerPort: number,
+    fallbackHost: string,
+    protocol: "tcp" | "udp" = "tcp",
+  ): Promise<ResolvedEndpoint> {
+    const [facts, manager] = await Promise.all([
+      this.containerFacts(serverId),
+      this.manager(),
+    ]);
+    const endpoint = resolveGameEndpoint({ facts, manager, containerPort, protocol, fallbackHost });
+    if (endpoint.via === "container-name" && facts) {
+      // We inspected it and still had nothing better — the setup is unusual enough
+      // that the next failure will be worth explaining.
+      this.logger.debug(
+        `server ${serverId}: falling back to the container name "${fallbackHost}" — not on a shared network and :${containerPort} is unpublished`,
+      );
+    }
+    return endpoint;
+  }
+
+  /**
+   * Turn a connection failure into an actionable message, or null when the cause
+   * isn't an addressing problem we can explain.
+   */
+  async explain(serverId: string, error: Error, endpoint: ResolvedEndpoint): Promise<string | null> {
+    const [facts, manager] = await Promise.all([
+      this.containerFacts(serverId).catch(() => null),
+      this.manager(),
+    ]);
+    return explainEndpointFailure({
+      error,
+      endpoint,
+      manager,
+      gameOnArkNet: facts ? ARK_NETWORK in facts.networks : false,
+    });
+  }
+
+  /** True when the manager runs in a container that ISN'T on ark-net — the setup
+   *  that silently breaks name-based RCON. Null when we can't tell. */
+  async managerMissingArkNet(): Promise<boolean | null> {
+    const manager = await this.manager();
+    if (!manager.inContainer || manager.hostNetwork) return false;
+    if (!manager.networks.length) return null; // inspect denied — don't cry wolf
+    return !manager.networks.includes(ARK_NETWORK);
+  }
+
+  /** The game container's networking, or null if we can't see it. */
+  private async containerFacts(serverId: string): Promise<ContainerNetworkFacts | null> {
+    try {
+      const id = await this.docker.findContainerIdByServerId(serverId);
+      if (!id) return null;
+      return toFacts(await this.docker.inspect(id));
+    } catch (err) {
+      this.logger.debug(`server ${serverId}: container inspect failed (${(err as Error).message})`);
+      return null;
+    }
+  }
+
+  private manager(): Promise<ManagerNetworkFacts> {
+    // Memoized on the promise so concurrent probes share one inspect.
+    return (this.managerFacts ??= this.loadManagerFacts());
+  }
+
+  private async loadManagerFacts(): Promise<ManagerNetworkFacts> {
+    const unknown: ManagerNetworkFacts = { inContainer: false, hostNetwork: false, networks: [] };
+    try {
+      const id = await findSelfContainerId(this.docker.client);
+      if (!id) return unknown; // not in a container (dev on the host)
+      const info = await this.docker.inspect(id);
+      const networks = Object.keys(info.NetworkSettings?.Networks ?? {});
+      const facts: ManagerNetworkFacts = {
+        inContainer: true,
+        hostNetwork: info.HostConfig?.NetworkMode === "host" || networks.includes("host"),
+        networks,
+      };
+      this.logger.log(
+        `manager networking: ${facts.hostNetwork ? "host" : networks.join(", ") || "none detected"}`,
+      );
+      return facts;
+    } catch (err) {
+      this.logger.warn(
+        `could not determine the manager's own networking (${(err as Error).message}) — game endpoints fall back to container names`,
+      );
+      return unknown;
+    }
+  }
+}
+
+/** Narrow a dockerode inspect down to the fields resolution actually uses. */
+function toFacts(info: Docker.ContainerInspectInfo): ContainerNetworkFacts {
+  const networks: Record<string, string | null> = {};
+  for (const [name, net] of Object.entries(info.NetworkSettings?.Networks ?? {})) {
+    networks[name] = net?.IPAddress || null;
+  }
+  return {
+    networkMode: info.HostConfig?.NetworkMode ?? "",
+    networks,
+    ports: info.NetworkSettings?.Ports ?? {},
+  };
+}

--- a/apps/api/src/docker/pick-server-container.test.ts
+++ b/apps/api/src/docker/pick-server-container.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { pickServerContainer } from "./docker.service";
+
+// Endpoint resolution (GH #21) inspects this container for its live IP, so picking a
+// stopped one would resolve to no address at all.
+describe("pickServerContainer", () => {
+  it("prefers the running container over a stopped one carrying the same label", () => {
+    // Adoption leaves the original stopped, so both can match the ark.serverId label.
+    expect(
+      pickServerContainer([
+        { Id: "old", State: "exited" },
+        { Id: "live", State: "running" },
+      ]),
+    ).toBe("live");
+  });
+
+  it("falls back to the only container when none is running", () => {
+    // A stopped server still needs an id for non-networking callers.
+    expect(pickServerContainer([{ Id: "stopped", State: "exited" }])).toBe("stopped");
+  });
+
+  it("returns null when nothing is labelled for the server", () => {
+    expect(pickServerContainer([])).toBeNull();
+  });
+});

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,17 +1,33 @@
 import { Controller, Get } from "@nestjs/common";
 import { Public } from "../auth/public.decorator";
 import { DockerService } from "../docker/docker.service";
+import { GameEndpointService } from "../docker/game-endpoint.service";
+import { ARK_NETWORK } from "../common/naming";
 
 @Controller("health")
 export class HealthController {
-  constructor(private readonly docker: DockerService) {}
+  constructor(
+    private readonly docker: DockerService,
+    private readonly endpoints: GameEndpointService,
+  ) {}
 
   @Public()
   @Get()
   async health() {
+    // A manager that isn't on ark-net can still run every container, but can't
+    // resolve them by name — which used to surface only as an opaque RCON DNS
+    // error (GH #21). Say so up front. Null = we couldn't tell; stay quiet.
+    const missingArkNet = await this.endpoints.managerMissingArkNet().catch(() => null);
     return {
       status: "ok",
       docker: (await this.docker.ping()) ? "connected" : "unreachable",
+      ...(missingArkNet
+        ? {
+            warnings: [
+              `The manager container is not attached to the "${ARK_NETWORK}" network. Game servers on the bridge are reached by IP where possible, but RCON/player counts may fail for containers with unpublished ports. Fix: docker network connect ${ARK_NETWORK} <manager container>`,
+            ],
+          }
+        : {}),
       time: new Date().toISOString(),
     };
   }

--- a/apps/api/src/players/players.service.ts
+++ b/apps/api/src/players/players.service.ts
@@ -5,7 +5,7 @@ import { RconService } from "../rcon/rcon.service";
 import { CryptoService } from "../crypto/crypto.service";
 import { satisfactoryQueryState } from "./satisfactory-api";
 import { containerName } from "../common/naming";
-import { loadEnv } from "../config/env";
+import { GameEndpointService } from "../docker/game-endpoint.service";
 import { a2sInfo, raknetPing, type QueryCount } from "./query-protocols";
 import { ProbeHealthTracker } from "./probe-health";
 
@@ -55,6 +55,7 @@ export class PlayersService {
     private readonly prisma: PrismaService,
     private readonly rcon: RconService,
     private readonly crypto: CryptoService,
+    private readonly endpoints: GameEndpointService,
   ) {}
 
   /**
@@ -104,23 +105,26 @@ export class PlayersService {
     server: NonNullable<Awaited<ReturnType<PrismaService["server"]["findUnique"]>>>,
   ): Promise<QueryCount | null> {
     const game = server.game as Game;
-    // Same reachability rule as RCON: host networking → via the host gateway;
-    // bridge → the container name resolves on ark-net.
-    const host = loadEnv().GAME_HOST_NETWORK
-      ? "host.docker.internal"
-      : containerName(serverId, game, server.name);
+    // Same reachability rule as RCON, and derived the same way — from the container's
+    // real networking rather than a global flag (GH #21). Resolved per probe because
+    // each protocol below targets a different port.
+    const fallbackHost = containerName(serverId, game, server.name);
+    const at = (port: number, protocol: "tcp" | "udp") =>
+      this.endpoints.resolve(serverId, port, fallbackHost, protocol);
     try {
       if (A2S_GAMES.has(game)) {
-        const count = await a2sInfo(host, server.queryPort);
+        const { host, port } = await at(server.queryPort, "udp");
+        const count = await a2sInfo(host, port);
         return { online: count.online, max: count.max ?? server.maxPlayers };
       }
       if (game === Game.VALHEIM) {
         // The lloesche image's built-in HTTP status endpoint (STATUS_HTTP), on
         // game port + 3 by our convention (set in buildValheimSpec).
+        const { host, port } = await at(server.gamePort + 3, "tcp");
         const controller = new AbortController();
         const t = setTimeout(() => controller.abort(), 2500);
         try {
-          const res = await fetch(`http://${host}:${server.gamePort + 3}/status.json`, {
+          const res = await fetch(`http://${host}:${port}/status.json`, {
             signal: controller.signal,
           });
           if (!res.ok) return null;
@@ -132,7 +136,8 @@ export class PlayersService {
         }
       }
       if (game === Game.BEDROCK) {
-        const count = await raknetPing(host, server.gamePort);
+        const { host, port } = await at(server.gamePort, "udp");
+        const count = await raknetPing(host, port);
         return { online: count.online, max: count.max ?? server.maxPlayers };
       }
       if (game === Game.TERRARIA) {
@@ -140,11 +145,12 @@ export class PlayersService {
         // returns playercount + maxplayers as JSON.
         if (!server.adminPasswordEnc) return null;
         const token = this.crypto.decrypt(server.adminPasswordEnc);
+        const { host, port } = await at(server.rconPort, "tcp");
         const controller = new AbortController();
         const t = setTimeout(() => controller.abort(), 2500);
         try {
           const res = await fetch(
-            `http://${host}:${server.rconPort}/v2/server/status?token=${encodeURIComponent(token)}`,
+            `http://${host}:${port}/v2/server/status?token=${encodeURIComponent(token)}`,
             { signal: controller.signal },
           );
           if (!res.ok) return null;
@@ -158,9 +164,10 @@ export class PlayersService {
       if (game === Game.SATISFACTORY) {
         // The game's HTTPS API on the game port (no A2S). Passwordless Client
         // login unless a join password forces the admin-password fallback.
+        const { host, port } = await at(server.gamePort, "tcp");
         const state = await satisfactoryQueryState(
           host,
-          server.gamePort,
+          port,
           server.adminPasswordEnc ? this.crypto.decrypt(server.adminPasswordEnc) : null,
         );
         return state ? { online: state.online, max: state.max || server.maxPlayers } : null;

--- a/apps/api/src/players/satisfactory.service.ts
+++ b/apps/api/src/players/satisfactory.service.ts
@@ -4,7 +4,7 @@ import { PrismaService } from "../prisma/prisma.service";
 import { CryptoService } from "../crypto/crypto.service";
 import { EventsService } from "../events/events.service";
 import { containerName } from "../common/naming";
-import { loadEnv } from "../config/env";
+import { GameEndpointService } from "../docker/game-endpoint.service";
 import { satisfactoryClaim } from "./satisfactory-api";
 
 const POLL_MS = 60_000;
@@ -26,6 +26,7 @@ export class SatisfactoryService implements OnModuleInit {
     private readonly prisma: PrismaService,
     private readonly crypto: CryptoService,
     private readonly events: EventsService,
+    private readonly endpoints: GameEndpointService,
   ) {}
 
   onModuleInit(): void {
@@ -38,13 +39,15 @@ export class SatisfactoryService implements OnModuleInit {
       .catch(() => []);
     for (const s of rows) {
       if (!s.adminPasswordEnc) continue; // nothing to claim with — in-game claim applies
-      const host = loadEnv().GAME_HOST_NETWORK
-        ? "host.docker.internal"
-        : containerName(s.id, Game.SATISFACTORY, s.name);
       try {
+        const { host, port } = await this.endpoints.resolve(
+          s.id,
+          s.gamePort,
+          containerName(s.id, Game.SATISFACTORY, s.name),
+        );
         const result = await satisfactoryClaim(
           host,
-          s.gamePort,
+          port,
           s.name,
           this.crypto.decrypt(s.adminPasswordEnc),
           s.serverPasswordEnc ? this.crypto.decrypt(s.serverPasswordEnc) : null,

--- a/apps/api/src/rcon/rcon.service.ts
+++ b/apps/api/src/rcon/rcon.service.ts
@@ -10,7 +10,8 @@ import { SourceRcon } from "./source-rcon";
 import { TelnetRcon } from "./telnet-rcon";
 import { rconArg } from "./rcon-arg";
 import { containerName } from "../common/naming";
-import { loadEnv } from "../config/env";
+import { GameEndpointService } from "../docker/game-endpoint.service";
+import type { ResolvedEndpoint } from "../common/game-endpoint";
 
 /** The slice of a connection RconService uses — satisfied by both rcon-client's
  *  Rcon (ARK/ASE) and our lenient SourceRcon (Conan). */
@@ -29,6 +30,9 @@ interface RconConn {
 export class RconService {
   private readonly logger = new Logger(RconService.name);
   private readonly pool = new Map<string, RconConn>();
+  /** The endpoint each connection was opened to, so a failure can explain itself in
+   *  terms of the address we actually dialled. Bounded by the server count. */
+  private readonly dialled = new Map<string, ResolvedEndpoint>();
 
   constructor(
     private readonly prisma: PrismaService,
@@ -36,6 +40,7 @@ export class RconService {
     private readonly events: EventsService,
     private readonly realtime: RealtimeGateway,
     private readonly logCapture: LogCaptureService,
+    private readonly endpoints: GameEndpointService,
   ) {}
 
   private async connect(serverId: string): Promise<RconConn> {
@@ -48,12 +53,16 @@ export class RconService {
       throw new BadRequestException("Server has no admin password set");
 
     const password = this.crypto.decrypt(server.adminPasswordEnc);
-    // On the bridge, game containers are reachable by name on ark-net. With host
-    // networking they bind on the host, so reach RCON via the host gateway (the
-    // manager must run with --add-host host.docker.internal:host-gateway).
-    const host = loadEnv().GAME_HOST_NETWORK
-      ? "host.docker.internal"
-      : containerName(serverId, server.game as Game, server.name);
+    // Derived from the container's real networking — its IP on a network we share,
+    // the host gateway when it's on the host or its port is published, and only then
+    // the container name. Guessing this from GAME_HOST_NETWORK alone broke every
+    // deployment where the flag and reality disagreed (GH #21).
+    const endpoint = await this.endpoints.resolve(
+      serverId,
+      server.rconPort,
+      containerName(serverId, server.game as Game, server.name),
+    );
+    this.dialled.set(serverId, endpoint);
     // 2s (the lib default) is too tight over the container network; 10s keeps
     // interactive commands snappy without spurious timeouts. (The world save on
     // stop is handled by the container's graceful SIGTERM shutdown, not by waiting
@@ -70,7 +79,7 @@ export class RconService {
     // makes rcon-client's strict id matching time out on every command (auth still
     // succeeds). Route Conan through our lenient SourceRcon; ARK/ASE keep
     // rcon-client, which they work with. (See source-rcon.ts.)
-    const opts = { host, port: server.rconPort, password, timeout: 10_000 };
+    const opts = { host: endpoint.host, port: endpoint.port, password, timeout: 10_000 };
     // Conan AND Palworld reply with non-matching packet ids that time out
     // rcon-client's strict matching — route both through the lenient SourceRcon.
     // 7 Days to Die has no Source RCON at all — its console is telnet on 8081, so it
@@ -110,8 +119,20 @@ export class RconService {
       return response;
     } catch (err) {
       this.pool.delete(serverId);
-      throw new BadRequestException(`RCON failed: ${(err as Error).message}`);
+      throw new BadRequestException(`RCON failed: ${await this.describeFailure(serverId, err as Error)}`);
     }
+  }
+
+  /**
+   * The raw error, plus a plain-English cause when the failure is one we can pin on
+   * how the manager reaches the container. A bare `getaddrinfo ENOTFOUND palworld-…`
+   * told users nothing about what to change (GH #21).
+   */
+  private async describeFailure(serverId: string, err: Error): Promise<string> {
+    const endpoint = this.dialled.get(serverId);
+    if (!endpoint) return err.message;
+    const hint = await this.endpoints.explain(serverId, err, endpoint).catch(() => null);
+    return hint ? `${err.message} — ${hint}` : err.message;
   }
 
   // ── Convenience wrappers ───────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #21.

## The bug

Palworld has no usable query protocol, so its player counts go through RCON `ShowPlayers`. RCON's host was guessed from the global `GAME_HOST_NETWORK` flag:

```ts
const host = loadEnv().GAME_HOST_NETWORK
  ? "host.docker.internal"
  : containerName(serverId, server.game as Game, server.name);
```

`ENOTFOUND` is a DNS failure — the name never resolved, so the connection was never attempted. The bridge branch assumes both that the game container is on `ark-net` *and* that the manager is too. Nothing verified either, and the raw Node error was surfaced verbatim.

Several environments produce that exact error and the code couldn't tell them apart: the manager not actually being attached to `ark-net` (the Unraid template's Network field is easy to change), `GAME_HOST_NETWORK` disagreeing with how a container was really created, or `ark-net` having been recreated. The reporter's RCON port and password were correct — matching `docs/games/palworld.md`.

A2S games probe their query port directly and were unaffected, which is why this looked Palworld-specific rather than like the general addressing bug it is.

## The fix

Derive the endpoint from what the container actually *is*, via one `inspect`, ordered most- to least-direct:

1. **Host networking** → the host gateway (loopback when the manager is itself host-networked or not containerised).
2. **A network we share** → the container's IP on it, preferring `ark-net`. An IP involves no DNS, so it cannot fail the way a name can.
3. **Port published** → the host gateway on the published host port. This makes the reported setup work even with the manager off `ark-net`.
4. **Otherwise** → the container name, exactly as before, so an unusual-but-working setup this doesn't model isn't broken by the change.

Applied to all three call sites that made the same guess: `RconService`, `PlayersService` (per-probe, since each protocol targets a different port), and the Satisfactory claim poller. Every lookup is best-effort — a locked-down socket-proxy or a vanished container degrades to the old behaviour rather than failing.

Incidental win: probes now work in dev, where the manager isn't in a container and `host.docker.internal` never resolved.

## Diagnostics

Failures that remain explain themselves instead of leaking a raw DNS error:

> RCON failed: getaddrinfo ENOTFOUND palworld-mysrv-abc123 — the manager container is not attached to the "ark-net" network, so it cannot resolve game containers by name — run: docker network connect ark-net &lt;manager container&gt;

`GET /api/health` also reports a warning when the manager is containerised but off `ark-net`. It stays silent when it can't tell (inspect denied) rather than crying wolf. A README troubleshooting entry covers the symptom.

`GAME_HOST_NETWORK` still decides how containers are **created**; it just no longer decides how they're **reached**.

## Verification

- 352 tests pass (20 new); `pnpm typecheck` clean across all packages.
- Exercised against real Docker, not just mocks: a labelled container on a user-defined network with a published port resolved to `{host: "127.0.0.1", port: 17780, via: "published-port"}` (reading real `inspect` output, including its `null` port entries); a `--network host` container resolved to `{host: "127.0.0.1", port: 7780, via: "host-network"}`; unpublished ports and unknown servers fell back to the container name; the health warning correctly stayed silent outside a container.

I could not reproduce the reporter's environment directly, so the root cause is inferred from the error semantics. The fix removes the fragile assumption entirely rather than targeting one of the three causes, and the health warning will confirm which it was if they report back.