### PR TITLE
Widen the RCON endpoint fallback and surface it in the UI (#21 follow-up)

### DIFF
--- a/apps/api/src/common/game-endpoint.test.ts
+++ b/apps/api/src/common/game-endpoint.test.ts
@@ -73,6 +73,35 @@ describe("resolveGameEndpoint", () => {
     });
   });
 
+  it("falls back to HostConfig.PortBindings when the runtime view is empty", () => {
+    // Reported on #21 after the first fix shipped: the manager was off ark-net and
+    // resolution still fell through to the container name even though the spec
+    // publishes RCON. NetworkSettings.Ports is Docker's runtime view and isn't always
+    // populated; the requested bindings say the same thing, so consult both.
+    const facts: ContainerNetworkFacts = {
+      networkMode: "ark-net",
+      networks: { "ark-net": "172.20.0.5" },
+      ports: {},
+      requestedPorts: { "7780/tcp": [{ HostIp: "0.0.0.0", HostPort: "7780" }] },
+    };
+    expect(resolve(facts, managerOffArkNet)).toEqual({
+      host: "host.docker.internal",
+      port: 7780,
+      via: "published-port",
+    });
+  });
+
+  it("prefers the runtime binding over the requested one when they disagree", () => {
+    const facts: ContainerNetworkFacts = {
+      networkMode: "ark-net",
+      networks: { "ark-net": "172.20.0.5" },
+      ports: { "7780/tcp": [{ HostPort: "17780" }] },
+      requestedPorts: { "7780/tcp": [{ HostPort: "7780" }] },
+    };
+    // The runtime value is what the host is actually listening on.
+    expect(resolve(facts, managerOffArkNet)).toMatchObject({ port: 17780 });
+  });
+
   it("honours a published port that differs from the container port", () => {
     const facts = onArkNet("172.20.0.5", { "7780/tcp": [{ HostPort: "17780" }] });
     expect(resolve(facts, managerOffArkNet)).toMatchObject({ port: 17780, via: "published-port" });
@@ -163,6 +192,24 @@ describe("explainEndpointFailure", () => {
     });
     expect(hint).toContain("not attached");
     expect(hint).toContain("docker network connect ark-net");
+  });
+
+  it("names the manager's actual container so the command is copy-pasteable", () => {
+    // "<manager container>" made the user go find the name themselves (#21 follow-up).
+    const hint = explainEndpointFailure({
+      error: dns,
+      endpoint: byName,
+      manager: { ...managerOffArkNet, name: "palisade" },
+      gameOnArkNet: true,
+    });
+    expect(hint).toContain("docker network connect ark-net palisade");
+    expect(hint).not.toContain("<manager container>");
+  });
+
+  it("keeps a placeholder when the manager's name is unknown", () => {
+    expect(
+      explainEndpointFailure({ error: dns, endpoint: byName, manager: managerOffArkNet, gameOnArkNet: true }),
+    ).toContain("<manager container>");
   });
 
   it("explains a name failure when the container is off ark-net entirely", () => {

--- a/apps/api/src/common/game-endpoint.ts
+++ b/apps/api/src/common/game-endpoint.ts
@@ -22,8 +22,14 @@ export interface ContainerNetworkFacts {
   networkMode: string;
   /** NetworkSettings.Networks — network name → the container's IP on it. */
   networks: Record<string, string | null>;
-  /** NetworkSettings.Ports — "7780/tcp" → host bindings (empty/absent = unpublished). */
+  /** NetworkSettings.Ports — "7780/tcp" → host bindings (empty/absent = unpublished).
+   *  The RUNTIME view of publishing. */
   ports: Record<string, Array<{ HostIp?: string; HostPort?: string }> | null>;
+  /** HostConfig.PortBindings — the same mapping as REQUESTED at create time. Docker
+   *  normally mirrors it into NetworkSettings.Ports once running, but not on every
+   *  version/runtime (and not at all before start), so we consult both before
+   *  concluding a port isn't published. */
+  requestedPorts?: Record<string, Array<{ HostIp?: string; HostPort?: string }> | null>;
 }
 
 /** What the manager itself is attached to, so we know what it can reach. */
@@ -34,6 +40,9 @@ export interface ManagerNetworkFacts {
   hostNetwork: boolean;
   /** Names of the Docker networks the manager is attached to. */
   networks: string[];
+  /** The manager's own container name, so a suggested fix is copy-pasteable rather
+   *  than a `<placeholder>` the user has to go look up. */
+  name?: string | null;
 }
 
 export interface ResolvedEndpoint {
@@ -72,7 +81,8 @@ function sharedNetworkIp(c: ContainerNetworkFacts, manager: ManagerNetworkFacts)
 
 /** The host port `containerPort` is published on, if any. */
 function publishedPort(c: ContainerNetworkFacts, containerPort: number, proto: "tcp" | "udp"): number | null {
-  const binding = c.ports[`${containerPort}/${proto}`]?.[0]?.HostPort;
+  const key = `${containerPort}/${proto}`;
+  const binding = c.ports[key]?.[0]?.HostPort ?? c.requestedPorts?.[key]?.[0]?.HostPort;
   const port = binding ? Number(binding) : NaN;
   return Number.isFinite(port) && port > 0 ? port : null;
 }
@@ -134,7 +144,7 @@ export function explainEndpointFailure(input: {
 
   if (dnsFailure && endpoint.via === "container-name") {
     if (gameOnArkNet && manager.inContainer && !manager.networks.includes(ARK_NETWORK)) {
-      return `the manager container is not attached to the "${ARK_NETWORK}" network, so it cannot resolve game containers by name — run: docker network connect ${ARK_NETWORK} <manager container>`;
+      return `the manager container is not attached to the "${ARK_NETWORK}" network, so it cannot resolve game containers by name, and this server's RCON port is not published to the host either — run: docker network connect ${ARK_NETWORK} ${manager.name || "<manager container>"} (on Unraid: edit the Palisade container and set Network Type to ${ARK_NETWORK}), then restart this server`;
     }
     return `the name "${endpoint.host}" did not resolve — the game container is not on a network this manager shares, and its port is not published to the host`;
   }

--- a/apps/api/src/docker/game-endpoint.service.ts
+++ b/apps/api/src/docker/game-endpoint.service.ts
@@ -25,6 +25,12 @@ export class GameEndpointService {
   private readonly logger = new Logger(GameEndpointService.name);
   /** The manager's own networking can't change while the process runs — resolve once. */
   private managerFacts: Promise<ManagerNetworkFacts> | null = null;
+  /** How each server was last reached, for the sync per-server health note. */
+  private readonly lastVia = new Map<string, ResolvedEndpoint["via"]>();
+  /** Cached from the manager facts so `addressingNote` can stay synchronous.
+   *  Null until the first resolve has loaded them. */
+  private missingArkNet: boolean | null = null;
+  private managerName: string | null = null;
 
   constructor(private readonly docker: DockerService) {}
 
@@ -46,6 +52,7 @@ export class GameEndpointService {
       this.manager(),
     ]);
     const endpoint = resolveGameEndpoint({ facts, manager, containerPort, protocol, fallbackHost });
+    this.lastVia.set(serverId, endpoint.via);
     if (endpoint.via === "container-name" && facts) {
       // We inspected it and still had nothing better — the setup is unusual enough
       // that the next failure will be worth explaining.
@@ -82,6 +89,23 @@ export class GameEndpointService {
     return !manager.networks.includes(ARK_NETWORK);
   }
 
+  /**
+   * Sync note for a server Palisade genuinely cannot reach — the manager is off
+   * ark-net AND this server's last resolve had to fall back to the container name
+   * (no shared network, no published port), so RCON/player counts will fail.
+   *
+   * Deliberately narrow: being off ark-net is harmless when ports are published, so
+   * this only speaks up for servers that actually failed. Surfaces in the UI's
+   * health banner because "check /api/health" is not something a panel user should
+   * have to know how to do (GH #21).
+   */
+  addressingNote(serverId: string): string | null {
+    if (this.missingArkNet !== true) return null;
+    if (this.lastVia.get(serverId) !== "container-name") return null;
+    const target = this.managerName || "<manager container>";
+    return `Palisade can't reach this server's RCON/query port — the manager container isn't attached to the "${ARK_NETWORK}" network and this server's ports aren't published to the host, so player counts and the console won't work. Fix: run \`docker network connect ${ARK_NETWORK} ${target}\` (on Unraid: edit the Palisade container and set Network Type to ${ARK_NETWORK}), then restart this server.`;
+  }
+
   /** The game container's networking, or null if we can't see it. */
   private async containerFacts(serverId: string): Promise<ContainerNetworkFacts | null> {
     try {
@@ -110,7 +134,10 @@ export class GameEndpointService {
         inContainer: true,
         hostNetwork: info.HostConfig?.NetworkMode === "host" || networks.includes("host"),
         networks,
+        name: info.Name?.replace(/^\//, "") || null,
       };
+      this.managerName = facts.name ?? null;
+      this.missingArkNet = facts.hostNetwork ? false : !networks.includes(ARK_NETWORK);
       this.logger.log(
         `manager networking: ${facts.hostNetwork ? "host" : networks.join(", ") || "none detected"}`,
       );
@@ -134,5 +161,6 @@ function toFacts(info: Docker.ContainerInspectInfo): ContainerNetworkFacts {
     networkMode: info.HostConfig?.NetworkMode ?? "",
     networks,
     ports: info.NetworkSettings?.Ports ?? {},
+    requestedPorts: info.HostConfig?.PortBindings ?? {},
   };
 }

--- a/apps/api/src/servers/lifecycle-harness.ts
+++ b/apps/api/src/servers/lifecycle-harness.ts
@@ -234,6 +234,7 @@ export async function makeService(row: ServerRow, docker: FakeDocker) {
     logCapture as never,
     { create: noop } as never,
     { count: async () => ({ online: 0 }) } as never,
+    { addressingNote: () => null } as never, // endpoints
     configWriter,
     { getAll: async () => ({}) } as never, // artwork
   );

--- a/apps/api/src/servers/reconcile.test.ts
+++ b/apps/api/src/servers/reconcile.test.ts
@@ -54,6 +54,7 @@ function makeService(rows: Row[], containers: Array<{ id: string; serverId: stri
     {} as never, // logCapture
     {} as never, // backups
     { cached: () => null, count: async () => null } as never, // players
+    { addressingNote: () => null } as never, // endpoints
     { writeInis: async () => undefined } as never, // configWriter
     { getAll: async () => ({}) } as never, // artwork
   );

--- a/apps/api/src/servers/servers-artwork.test.ts
+++ b/apps/api/src/servers/servers-artwork.test.ts
@@ -69,6 +69,7 @@ function makeSvc(initialArtworkJson: string | null = null) {
     {} as never,
     {} as never,
     players as never,
+    { addressingNote: () => null } as never, // endpoints
     {} as never,
     { getAll: async () => ({}) } as never, // artwork
   );

--- a/apps/api/src/servers/servers-update.test.ts
+++ b/apps/api/src/servers/servers-update.test.ts
@@ -65,6 +65,7 @@ function makeSvc(overrides: Record<string, unknown> = {}) {
     {} as never, // logCapture
     {} as never, // backups
     { cached: () => null, probeFailingSince: () => null } as never, // players
+    { addressingNote: () => null } as never, // endpoints
     { writeInis: async () => undefined } as never, // configWriter
     { getAll: async () => ({}) } as never, // artwork
   );

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -50,6 +50,7 @@ import { BackupsService } from "../backups/backups.service";
 import { PlayersService } from "../players/players.service";
 import { buildContainerSpec, ONE_SHOT_UPDATE_ENV } from "./runtime-spec";
 import { detectPalWineProxyDlls } from "../palmods/palmods.service";
+import { GameEndpointService } from "../docker/game-endpoint.service";
 import { portsFor, serverPortSet } from "../catalog/ports";
 import { LocalPaths } from "../common/paths";
 import { containerName } from "../common/naming";
@@ -282,6 +283,7 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
     private readonly logCapture: LogCaptureService,
     private readonly backups: BackupsService,
     private readonly players: PlayersService,
+    private readonly endpoints: GameEndpointService,
     private readonly configWriter: ServerConfigWriter,
     private readonly artwork: ArtworkService,
   ) {}
@@ -1849,6 +1851,11 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
         return "Caves shard not linked — waiting for the automatic relink restart after the Klei outage.";
       }
     }
+    // Unreachable by any good path (manager off ark-net, ports unpublished): the
+    // game is fine, but Palisade can't talk to it, so this is exactly the
+    // "running but degraded" case — and it names the fix (GH #21).
+    const addressing = this.endpoints.addressingNote(id);
+    if (addressing) return addressing;
     // Generic (all queryable games): the player-count probe was answering this
     // run and has gone silent — the game process is likely hung even though its
     // container is up. Only fires after a successful probe, so games with no


### PR DESCRIPTION
Follow-up to #22, from the reporter's reply on #21.

They updated (their error text is the new diagnostic, so the fix is deployed) and it **correctly identified their setup** — manager container not attached to `ark-net`. But resolution still fell all the way through to the container name, so RCON stayed broken. It shouldn't have: the published-port step exists for exactly this case, and Palworld's spec publishes RCON to the host.

Three changes:

**1. Read both port sources (the likely mechanism).** `publishedPort` consulted only `NetworkSettings.Ports` — Docker's *runtime* view of publishing. It now also consults `HostConfig.PortBindings`, the mapping as requested at create time. They normally agree (verified against a live container: both populated, consistent), but the runtime view isn't always filled in, and when it isn't, a port that genuinely *is* published reads as unpublished and we drop to the container name. Runtime value still wins when both are present, since that's what the host is actually listening on.

**2. Copy-pasteable fix in the message.** It said `docker network connect ark-net <manager container>`, leaving the user to go find the name — we know it from our own inspect, so it now says e.g. `... ark-net palisade`. Also mentions the Unraid **Network Type** field and to restart the server afterwards (changing a port without a restart is one way the DB's `rconPort` and the container's published port drift apart, which produces this same fall-through).

**3. Surface it in the UI.** The reporter's words: *"Not sure how to get /api/health."* Fair — that's not something a panel user should need to know. A server Palisade can't reach is running-but-degraded, so it now populates `healthNote` and renders in the existing amber `HealthBanner` on the server page with the same fix text. Deliberately narrow: only when the manager is off `ark-net` **and** that server's last resolve fell back to the container name — being off `ark-net` is harmless when ports are published, so those setups stay quiet.

## Honesty about the root cause

I have **not** confirmed which of these explains the reporter's specific failure — I can't reproduce their environment, and the three candidate mechanisms (unpopulated runtime ports, a port changed without a restart, ports genuinely unpublished) are indistinguishable from the error text alone. I've asked them for `docker inspect` output on the issue. (1) is the plausible mechanism and is a strict robustness win regardless; (2) and (3) make the problem self-service either way, since `docker network connect` fixes it outright in all three.

## Verification

- 364 tests pass (4 new: `HostConfig.PortBindings` fallback, runtime-wins-on-conflict, named manager in the hint, placeholder when unknown). `pnpm typecheck` clean, web build clean.
- Checked a live container: `NetworkSettings.Ports` and `HostConfig.PortBindings` both populated and agreeing, and `Name` arrives as `/pal-t21` (the leading slash is stripped).
- The four direct `new ServersService(...)` sites in tests/harness got the new stub.