### PR TITLE
Show which game version a floating image tag points at (#26)

### DIFF
--- a/apps/api/src/images/image-tags.module.ts
+++ b/apps/api/src/images/image-tags.module.ts
@@ -7,5 +7,6 @@ import { GameVersionsController } from "./game-versions.controller";
 @Module({
   controllers: [ImageTagsController, GameVersionsController],
   providers: [ImageTagsService, GameVersionsService],
+  exports: [ImageTagsService], // UpdatesService names the version in its notification (GH #26)
 })
 export class ImageTagsModule {}

--- a/apps/api/src/images/image-tags.service.ts
+++ b/apps/api/src/images/image-tags.service.ts
@@ -43,8 +43,14 @@ export class ImageTagsService {
     const path = repo.includes("/") ? repo : `library/${repo}`; // official images live under library/
     const json = (await this.getJson(
       `https://hub.docker.com/v2/repositories/${path}/tags?page_size=100&ordering=last_updated`,
-    )) as { results?: { name: string; last_updated?: string }[] } | null;
-    return (json?.results ?? []).map((t) => ({ name: t.name, updatedAt: t.last_updated ?? null }));
+    )) as { results?: { name: string; last_updated?: string; digest?: string }[] } | null;
+    // The digest lets a floating tag ("latest") be resolved to the versioned tag
+    // that shares it ("42.20.3-release") — see resolveVersionTag (GH #26).
+    return (json?.results ?? []).map((t) => ({
+      name: t.name,
+      updatedAt: t.last_updated ?? null,
+      digest: t.digest ?? null,
+    }));
   }
 
   /** GHCR: needs an anonymous pull token; tags/list has names only (no timestamps). */

--- a/apps/api/src/updates/image-version.test.ts
+++ b/apps/api/src/updates/image-version.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { resolveVersionTag, describeImageTag, type ImageTag } from "@ark/shared";
+
+// GH #26: "latest" tells an admin nothing about which game build they're on. Images
+// that bake the server in publish versioned aliases sharing one digest — these are
+// the real tags/digests from danixu86/project-zomboid-dedicated-server.
+const ZOMBOID: ImageTag[] = [
+  { name: "latest", digest: "sha256:4501a705" },
+  { name: "latest-release", digest: "sha256:4501a705" },
+  { name: "42.20.3-release", digest: "sha256:4501a705" },
+  { name: "42.20.2-release", digest: "sha256:26bc76b2" },
+  { name: "42.20.0-release", digest: "sha256:89849c2d" },
+  { name: "latest-unstable", digest: "sha256:21065d6a" },
+];
+
+describe("resolveVersionTag", () => {
+  it("resolves latest to the versioned alias sharing its digest", () => {
+    expect(resolveVersionTag(ZOMBOID, "latest")).toBe("42.20.3-release");
+  });
+
+  it("resolves an older pinned tag to itself's siblings only", () => {
+    // 42.20.2 has no alias — nothing else shares that digest.
+    expect(resolveVersionTag(ZOMBOID, "42.20.2-release")).toBeNull();
+  });
+
+  it("never answers with another floating tag", () => {
+    // latest-release shares latest's digest but names a channel, not a build.
+    expect(resolveVersionTag(ZOMBOID, "latest")).not.toBe("latest-release");
+    expect(resolveVersionTag(ZOMBOID, "latest-unstable")).toBeNull();
+  });
+
+  it("prefers the most specific version when several alias one build", () => {
+    // Some images publish a moving major alias next to the full version.
+    const tags: ImageTag[] = [
+      { name: "latest", digest: "d1" },
+      { name: "42", digest: "d1" },
+      { name: "42.20.3-release", digest: "d1" },
+    ];
+    expect(resolveVersionTag(tags, "latest")).toBe("42.20.3-release");
+  });
+
+  it("returns null when the registry lists no digests (GHCR)", () => {
+    // GHCR's tags/list has names only — the feature degrades, it doesn't guess.
+    const tags: ImageTag[] = [
+      { name: "latest", digest: null },
+      { name: "v1.8.1", digest: null },
+    ];
+    expect(resolveVersionTag(tags, "latest")).toBeNull();
+  });
+
+  it("returns null for a tag the registry doesn't list", () => {
+    expect(resolveVersionTag(ZOMBOID, "no-such-tag")).toBeNull();
+  });
+
+  it("ignores non-version aliases like 'stable'", () => {
+    const tags: ImageTag[] = [
+      { name: "latest", digest: "d1" },
+      { name: "stable", digest: "d1" },
+    ];
+    expect(resolveVersionTag(tags, "latest")).toBeNull();
+  });
+});
+
+describe("describeImageTag", () => {
+  it("annotates a floating tag with the build it points at", () => {
+    expect(describeImageTag(ZOMBOID, "latest")).toBe("latest (42.20.3-release)");
+  });
+
+  it("leaves an already-specific tag alone", () => {
+    expect(describeImageTag(ZOMBOID, "42.20.2-release")).toBe("42.20.2-release");
+  });
+});

--- a/apps/api/src/updates/updates.module.ts
+++ b/apps/api/src/updates/updates.module.ts
@@ -1,7 +1,11 @@
 import { Module } from "@nestjs/common";
 import { UpdatesService } from "./updates.service";
+import { ImageTagsModule } from "../images/image-tags.module";
 
 @Module({
+  // ImageTagsModule for the cached registry tag list — the update notification names
+  // the versioned tag a new image corresponds to (GH #26).
+  imports: [ImageTagsModule],
   providers: [UpdatesService],
   exports: [UpdatesService],
 })

--- a/apps/api/src/updates/updates.service.ts
+++ b/apps/api/src/updates/updates.service.ts
@@ -2,12 +2,13 @@ import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import * as cron from "node-cron";
-import { Game, EventType, STEAM_APP_ID } from "@ark/shared";
+import { Game, EventType, STEAM_APP_ID, resolveVersionTag } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { EventsService } from "../events/events.service";
 import { LocalPaths } from "../common/paths";
 import { IMAGE_BAKED_GAMES, imageRefFor, splitImageRef } from "../common/images";
 import { DockerService } from "../docker/docker.service";
+import { ImageTagsService } from "../images/image-tags.service";
 import { digestsDiffer, remoteImageDigest } from "./registry-digest";
 
 // Every 3 hours, offset off the top of the hour. ARK ships updates a few times a
@@ -89,6 +90,7 @@ export class UpdatesService implements OnModuleInit {
     private readonly prisma: PrismaService,
     private readonly events: EventsService,
     private readonly docker: DockerService,
+    private readonly imageTags: ImageTagsService,
   ) {}
 
   onModuleInit(): void {
@@ -177,12 +179,29 @@ export class UpdatesService implements OnModuleInit {
     }
     // Once per false→true transition, like the SteamCMD path.
     if (outdated && !server.updateAvailable) {
+      // Name the actual build when the registry publishes a versioned alias for it —
+      // "a newer image" tells an admin nothing about WHICH game version (GH #26).
+      const version = await this.newVersionName(server.game as Game, tag);
       await this.events.emit({
         type: EventType.UpdateAvailable,
-        message: `Update available for "${server.name}": a newer ${repo}:${tag} image has been published (the game server ships inside the image). Restart the server to pull it.`,
+        message:
+          `Update available for "${server.name}": a newer ${repo}:${tag} image has been published` +
+          (version ? ` (${version})` : "") +
+          ". The game server ships inside the image, so restart the server to pull it.",
         serverId: server.id,
-        data: { installed: local, latest: remote },
+        data: { installed: local, latest: remote, ...(version ? { version } : {}) },
       });
+    }
+  }
+
+  /** The versioned tag a floating tag now points at ("42.20.3-release"), or null when
+   *  the registry lists no digests / publishes no version aliases. Best-effort. */
+  private async newVersionName(game: Game, tag: string): Promise<string | null> {
+    try {
+      const { tags } = await this.imageTags.list(game);
+      return resolveVersionTag(tags, tag);
+    } catch {
+      return null;
     }
   }
 

--- a/apps/web/components/image-version-card.tsx
+++ b/apps/web/components/image-version-card.tsx
@@ -4,6 +4,7 @@ import { Boxes, Save, Check, ChevronDown, Loader2 } from "lucide-react";
 import {
   ServerState,
   GAME_VERSION_PINNING,
+  resolveVersionTag,
   GAME_LABELS,
   type ImageTagsResult,
   type ServerSummary,
@@ -27,17 +28,24 @@ export function ImageVersionCard({ server, onSaved }: { server: ServerSummary; o
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!open || data || loading) return;
+    // Fetched on mount, not on expand: the resolved version badge in the collapsed
+    // header is the whole point (GH #26 — "seeing the actual version it will pull
+    // would be a better admin experience"). The endpoint is cached server-side per
+    // repo for 10 minutes, so this is one cheap call per page view.
+    if (data || loading) return;
     setLoading(true);
     apiGet<ImageTagsResult>(`/games/${server.game}/image-tags`)
       .then(setData)
       .catch((e) => setErr((e as Error).message))
       .finally(() => setLoading(false));
-  }, [open, data, loading, server.game]);
+  }, [data, loading, server.game]);
 
   useEffect(() => setChoice(server.imageTag ?? ""), [server.imageTag]);
 
   const current = server.imageTag ?? data?.defaultTag ?? "default";
+  // A floating tag ("latest") says nothing about WHICH game build you're on. When the
+  // registry publishes a versioned alias for the same digest, show it (GH #26).
+  const currentVersion = data ? resolveVersionTag(data.tags, current) : null;
   const changed = (server.imageTag ?? "") !== choice;
 
   const save = async () => {
@@ -72,6 +80,14 @@ export function ImageVersionCard({ server, onSaved }: { server: ServerSummary; o
           <span className="ml-1 rounded bg-slate-700/60 px-1.5 py-0.5 font-mono text-[11px] font-normal normal-case text-slate-300">
             {current}
           </span>
+          {currentVersion && (
+            <span
+              className="rounded bg-slate-800/80 px-1.5 py-0.5 font-mono text-[11px] font-normal normal-case text-slate-400"
+              title={`"${current}" currently points at ${currentVersion}`}
+            >
+              {currentVersion}
+            </span>
+          )}
         </span>
         <ChevronDown className={`h-4 w-4 text-slate-400 transition-transform ${open ? "rotate-180" : ""}`} />
       </button>

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -119,6 +119,10 @@ export interface ImageTag {
   name: string;
   /** Last-pushed time (Docker Hub only; GHCR doesn't expose it cheaply). */
   updatedAt?: string | null;
+  /** Manifest digest, when the registry lists it (Docker Hub does; GHCR's
+   *  tags/list does not). Tags sharing a digest are aliases for one build, which
+   *  is how a floating tag is resolved to a version — see resolveVersionTag. */
+  digest?: string | null;
 }
 
 /** Available image tags for a game, for the advanced version picker. */

--- a/packages/shared/src/image-version.ts
+++ b/packages/shared/src/image-version.ts
@@ -1,0 +1,45 @@
+import type { ImageTag } from "./dto";
+
+/**
+ * Working out which concrete game version a floating tag currently points at.
+ *
+ * Images that bake the game in (Project Zomboid, and others) publish a moving tag
+ * plus versioned aliases for the SAME build — e.g. `latest`, `latest-release` and
+ * `42.20.3-release` all share one digest. Showing only "latest" leaves an admin with
+ * no way to know WHICH game version they're on or about to pull, which is exactly
+ * the gap reported in GH #26 (the user resorted to watching the boot log scroll by).
+ *
+ * Registries already hand us the per-tag digest in the listing we fetch for the
+ * version picker, so this is pure grouping — no extra requests.
+ */
+
+/** Tags that move (they name a channel, not a build) and so can never be the answer. */
+const FLOATING = /^(latest|stable|release|nightly|unstable|beta|dev|main|master|edge)(-.*)?$/i;
+
+/** Looks like a version: contains a digit, and isn't purely a date-less word. */
+const VERSION_LIKE = /\d/;
+
+/**
+ * The most specific version-looking tag sharing `tag`'s digest, or null when the
+ * registry gave us no digests (GHCR's tag list omits them) or nothing else points
+ * at the same build.
+ *
+ * Prefers the longest candidate so `42.20.3-release` wins over a bare `42`, which
+ * some images also publish as a moving major-version alias.
+ */
+export function resolveVersionTag(tags: readonly ImageTag[], tag: string): string | null {
+  const digest = tags.find((t) => t.name === tag)?.digest;
+  if (!digest) return null;
+  const siblings = tags
+    .filter((t) => t.name !== tag && t.digest === digest)
+    .map((t) => t.name)
+    .filter((name) => VERSION_LIKE.test(name) && !FLOATING.test(name));
+  if (!siblings.length) return null;
+  return siblings.sort((a, b) => b.length - a.length || a.localeCompare(b))[0] ?? null;
+}
+
+/** "latest (42.20.3-release)" for display, or just the tag when unresolvable. */
+export function describeImageTag(tags: readonly ImageTag[], tag: string): string {
+  const version = resolveVersionTag(tags, tag);
+  return version ? `${tag} (${version})` : tag;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,3 +7,4 @@ export * from "./mods";
 export * from "./events";
 export * from "./dto";
 export * from "./notifications";
+export * from "./image-version";


### PR DESCRIPTION
Follow-up request on #26, from the reporter:

> Seeing the actual version it will pull in the latest field would be a better user/admin experience.

With the server baked into the image, the panel showed only `latest` — which says nothing about *which* Project Zomboid build you're on or about to pull. They ended up watching the boot log scroll past to find out, and had no way to see that their image predated the 42.20.3 client update their players had already received.

## Approach

Registries publish versioned aliases beside the floating tag, all sharing one digest:

```
latest            sha256:4501a705…
latest-release    sha256:4501a705…
42.20.3-release   sha256:4501a705…      <- same build
42.20.2-release   sha256:26bc76b2…
```

Docker Hub already returns a per-tag `digest` in the listing `ImageTagsService` fetches for the version picker, so this is **pure grouping over data we already have** — no new requests, no new registry plumbing.

`resolveVersionTag()` (in `@ark/shared`, so API and web share it) picks the most specific version-looking sibling sharing the tag's digest, skipping other floating names (`latest-release`, `stable`, `nightly`) so the answer is always a build rather than another moving target.

## What changes

- **Image version card** shows the resolved build next to the tag: `latest` `42.20.3-release`.
- **Update notification** names the version instead of announcing an opaque "newer image has been published".
- The card now loads its tag list **on mount rather than on expand** — the badge belongs in the collapsed header, and the endpoint is already cached server-side per repo for 10 minutes, so it's one cheap call per page view.

## Degradation

GHCR's `tags/list` omits digests, so its tags resolve to null and the UI shows just the tag, exactly as before. Nothing guesses.

## Verification

- 388 tests pass (9 new), built from the **real** Zomboid tag/digest data: resolving `latest`, refusing to answer with another floating tag, preferring `42.20.3-release` over a bare `42`, and the no-digest (GHCR) path.
- **Live-checked end to end**, since fixtures can't prove the registry actually returns what I assumed: `ImageTagsService.list(ZOMBOID)` → `latest` resolves to `42.20.3-release`, displaying as `latest (42.20.3-release)`. Palisade's own ghcr.io image returned 100 tags with no digests and correctly resolved to `null`.
- `pnpm typecheck` clean, full `pnpm build` clean.