### PR TITLE
Warn when HOST_DATA_DIR disagrees with the real /data mount (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ docker compose up -d
 |---|---|---|---|
 | `SECRETS_KEY` | **yes** | — | 64 hex chars (32 bytes). Encrypts stored secrets at rest. |
 | `JWT_SECRET` | **yes** | — | Signs login tokens (sessions last 30 days). |
-| `HOST_DATA_DIR` | **yes**¹ | `DATA_DIR` | The data dir **as the host's Docker daemon sees it** (e.g. `/mnt/user/appdata/ark-manager` on Unraid). Game-container bind mounts resolve on the host, not inside the manager. |
+| `HOST_DATA_DIR` | no¹ | auto-detected | The data dir **as the host's Docker daemon sees it** (e.g. `/mnt/cache/appdata/palisade` on Unraid). Game-container bind mounts resolve on the host, not inside the manager. Leave it unset: the manager reads it off its own `/data` mount at boot. |
 | `DATA_DIR` | no | `./data` | Data dir inside the manager container (mount your volume here, conventionally `/data`). |
 | `DATABASE_URL` | no | `file:./data/db.sqlite` | SQLite path — keep it inside `DATA_DIR`. |
 | `PUBLIC_BASE_URL` | no | `http://localhost:3000` | The address you actually browse to. Used for links and Unraid WebUI buttons. |
@@ -215,8 +215,12 @@ docker compose up -d
 | `PUID` / `PGID` | no | `99` / `100` | Ownership for game files written by the manager (Unraid's `nobody:users` by default). |
 | `TZ` | no | `UTC` | Manager clock; also the default for game containers and schedules (overridable in Settings). |
 
-¹ Required whenever the container path and host path differ — i.e. basically
-always in production.
+¹ Auto-detected at boot from the manager's own `/data` mount, so leave it blank —
+including on Unraid, where the template ships it empty. Only set it if the log says
+auto-detection failed, and then it **must** equal the host path you mapped to `/data`
+("App data" in the Unraid template). A value that disagrees with that mount sends
+every game server's files to a directory you didn't choose; the manager warns about
+this at boot and in `GET /api/health`, but it can't override an explicit setting.
 
 ### Data layout
 

--- a/apps/api/src/config/ensure-host-data-dir.ts
+++ b/apps/api/src/config/ensure-host-data-dir.ts
@@ -16,9 +16,14 @@ import Docker from "dockerode";
  * no socket, a locked-down socket-proxy, running outside Docker — just leaves it unset,
  * and paths.ts falls back to DATA_DIR (correct whenever the two coincide, as they do by
  * default). Never throws.
+ *
+ * When it IS set explicitly, that value still wins, but we compare it against the real
+ * mount and warn on a disagreement: a stale/mistyped value silently scatters game
+ * servers into a directory the user never chose, which is baffling from the outside
+ * (GH #29 — files appeared under the old default instead of the configured App data).
  */
 export async function ensureHostDataDir(log: (msg: string) => void = console.log): Promise<void> {
-  if (process.env.HOST_DATA_DIR) return; // explicit value wins
+  const configured = process.env.HOST_DATA_DIR;
   const dataDir = process.env.DATA_DIR || "/data";
   try {
     const docker = connect();
@@ -26,13 +31,59 @@ export async function ensureHostDataDir(log: (msg: string) => void = console.log
     if (!id) return;
     const info = await docker.getContainer(id).inspect();
     const mount = (info.Mounts ?? []).find((m) => m.Destination === dataDir);
-    if (mount?.Source) {
-      process.env.HOST_DATA_DIR = mount.Source;
-      log(`[host-data-dir] auto-detected HOST_DATA_DIR=${mount.Source} from the manager's own ${dataDir} mount`);
+    const detected = mount?.Source;
+    if (!detected) return;
+
+    const action = hostDataDirAction(configured, detected);
+    if (action.kind === "adopt") {
+      process.env.HOST_DATA_DIR = action.value;
+      log(`[host-data-dir] auto-detected HOST_DATA_DIR=${action.value} from the manager's own ${dataDir} mount`);
+    } else if (action.kind === "mismatch") {
+      mismatch = { configured: action.configured, detected: action.detected };
+      log(`[host-data-dir] WARNING: ${mismatchMessage(action.configured, action.detected, dataDir)}`);
     }
   } catch (e) {
     log(`[host-data-dir] auto-detect skipped (${(e as Error).message}) — falling back to DATA_DIR`);
   }
+}
+
+/**
+ * What to do with an explicitly-set HOST_DATA_DIR once we know where /data really
+ * comes from. An explicit value always wins (someone may have a bind layout we can't
+ * model) — but a disagreement is worth shouting about, because the only symptom is
+ * game files appearing in a directory the user never chose (GH #29).
+ */
+export type HostDataDirAction =
+  | { kind: "adopt"; value: string }
+  | { kind: "mismatch"; configured: string; detected: string }
+  | { kind: "ok" };
+
+export function hostDataDirAction(configured: string | undefined, detected: string): HostDataDirAction {
+  if (!configured) return { kind: "adopt", value: detected };
+  return samePath(configured, detected) ? { kind: "ok" } : { kind: "mismatch", configured, detected };
+}
+
+/** The operator-facing explanation, shared by the boot log and /api/health. */
+export function mismatchMessage(configured: string, detected: string, dataDir = "/data"): string {
+  return (
+    `HOST_DATA_DIR is set to "${configured}", but this container's ${dataDir} actually comes from ` +
+    `"${detected}". Game servers will be created under "${configured}" — not where you pointed App data. ` +
+    `Clear HOST_DATA_DIR to auto-detect it, or set it to "${detected}".`
+  );
+}
+
+/** Same host path, ignoring a trailing slash. */
+export function samePath(a: string, b: string): boolean {
+  const trim = (p: string) => p.replace(/\/+$/, "");
+  return trim(a) === trim(b);
+}
+
+let mismatch: { configured: string; detected: string } | null = null;
+
+/** Set when HOST_DATA_DIR disagrees with the manager's real /data mount, so the
+ *  health endpoint can surface the same warning the boot log printed (GH #29). */
+export function hostDataDirMismatch(): { configured: string; detected: string } | null {
+  return mismatch;
 }
 
 /** Same DOCKER_HOST parsing as DockerService, but reads process.env directly (pre-loadEnv). */

--- a/apps/api/src/config/host-data-dir.test.ts
+++ b/apps/api/src/config/host-data-dir.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { samePath, hostDataDirAction, mismatchMessage } from "./ensure-host-data-dir";
+
+// GH #29: a HOST_DATA_DIR that disagrees with the real /data mount silently puts every
+// game server's files somewhere the user never configured. The comparison that decides
+// whether to warn must not fire on cosmetic differences.
+describe("samePath", () => {
+  it("treats a trailing slash as the same path", () => {
+    expect(samePath("/mnt/cache/appdata/palisade", "/mnt/cache/appdata/palisade/")).toBe(true);
+    expect(samePath("/mnt/cache/appdata/palisade//", "/mnt/cache/appdata/palisade")).toBe(true);
+  });
+
+  it("flags the actual #29 case: a stale default vs the configured App data", () => {
+    expect(samePath("/mnt/cache/appdata/ark-manager", "/mnt/games_nvme/palisade")).toBe(false);
+  });
+
+  it("does not confuse a path with a longer one sharing its prefix", () => {
+    expect(samePath("/mnt/cache/appdata", "/mnt/cache/appdata2")).toBe(false);
+  });
+
+  it("is case-sensitive, as Linux paths are", () => {
+    expect(samePath("/mnt/Cache", "/mnt/cache")).toBe(false);
+  });
+});
+
+describe("hostDataDirAction", () => {
+  it("adopts the detected mount when nothing is configured (the normal path)", () => {
+    expect(hostDataDirAction(undefined, "/mnt/games_nvme/palisade")).toEqual({
+      kind: "adopt",
+      value: "/mnt/games_nvme/palisade",
+    });
+    expect(hostDataDirAction("", "/mnt/x")).toMatchObject({ kind: "adopt" });
+  });
+
+  it("stays quiet when the configured value agrees", () => {
+    expect(hostDataDirAction("/mnt/x", "/mnt/x/")).toEqual({ kind: "ok" });
+  });
+
+  it("reports the #29 mismatch without overriding the explicit value", () => {
+    // Explicit still wins — we warn rather than silently relocating someone's data.
+    expect(hostDataDirAction("/mnt/cache/appdata/ark-manager", "/mnt/games_nvme/palisade")).toEqual({
+      kind: "mismatch",
+      configured: "/mnt/cache/appdata/ark-manager",
+      detected: "/mnt/games_nvme/palisade",
+    });
+  });
+});
+
+describe("mismatchMessage", () => {
+  it("names both paths and how to fix it", () => {
+    const msg = mismatchMessage("/mnt/cache/appdata/ark-manager", "/mnt/games_nvme/palisade");
+    expect(msg).toContain("/mnt/cache/appdata/ark-manager");
+    expect(msg).toContain("/mnt/games_nvme/palisade");
+    expect(msg).toContain("Clear HOST_DATA_DIR");
+  });
+});

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -3,6 +3,7 @@ import { Public } from "../auth/public.decorator";
 import { DockerService } from "../docker/docker.service";
 import { GameEndpointService } from "../docker/game-endpoint.service";
 import { ARK_NETWORK } from "../common/naming";
+import { hostDataDirMismatch, mismatchMessage } from "../config/ensure-host-data-dir";
 
 @Controller("health")
 export class HealthController {
@@ -18,16 +19,21 @@ export class HealthController {
     // resolve them by name — which used to surface only as an opaque RCON DNS
     // error (GH #21). Say so up front. Null = we couldn't tell; stay quiet.
     const missingArkNet = await this.endpoints.managerMissingArkNet().catch(() => null);
+    const dataDir = hostDataDirMismatch();
+    const warnings = [
+      ...(missingArkNet
+        ? [
+            `The manager container is not attached to the "${ARK_NETWORK}" network. Game servers on the bridge are reached by IP where possible, but RCON/player counts may fail for containers with unpublished ports. Fix: docker network connect ${ARK_NETWORK} <manager container>`,
+          ]
+        : []),
+      // A HOST_DATA_DIR that disagrees with the real /data mount puts every game
+      // server somewhere the user never configured (GH #29).
+      ...(dataDir ? [mismatchMessage(dataDir.configured, dataDir.detected)] : []),
+    ];
     return {
       status: "ok",
       docker: (await this.docker.ping()) ? "connected" : "unreachable",
-      ...(missingArkNet
-        ? {
-            warnings: [
-              `The manager container is not attached to the "${ARK_NETWORK}" network. Game servers on the bridge are reached by IP where possible, but RCON/player counts may fail for containers with unpublished ports. Fix: docker network connect ${ARK_NETWORK} <manager container>`,
-            ],
-          }
-        : {}),
+      ...(warnings.length ? { warnings } : {}),
       time: new Date().toISOString(),
     };
   }


### PR DESCRIPTION
Closes #29 (self-resolved by the reporter, but the trap is real).

They pointed **App data** at `/mnt/games_nvme/palisade`, then found game files appearing under `/mnt/cache/appdata/ark-manager`. Cause: `HOST_DATA_DIR` held a stale value, and it silently wins over reality.

## Why it still happened

Auto-detection has existed since **v1.5.0** and the Unraid template ships the field blank, so this only bites when a value *is* present — carried over from an older install, or typed in deliberately. And the README told them to type it in:

| Section | Said |
|---|---|
| Quick start (line 19) | "Leave the secrets and `HOST_DATA_DIR` blank" |
| Env table (line 209) | `HOST_DATA_DIR` — **required**, "basically always in production" |

That table row predated auto-detection and was never updated. Following it produces exactly this bug.

## Changes

**1. Don't fail silently.** `ensureHostDataDir` no longer returns early when the value is set. An explicit value still wins — a bind layout we can't model is a real possibility, and silently relocating someone's data would be worse — but it's now compared against the actual `/data` mount source. On a mismatch it names both paths and the fix, in the boot log and in `GET /api/health` (which already carries a `warnings` array from #21). Silent misplacement becomes a stated one.

```
[host-data-dir] WARNING: HOST_DATA_DIR is set to "/mnt/cache/appdata/ark-manager", but this
container's /data actually comes from "/mnt/games_nvme/palisade". Game servers will be created
under "/mnt/cache/appdata/ark-manager" — not where you pointed App data. Clear HOST_DATA_DIR to
auto-detect it, or set it to "/mnt/games_nvme/palisade".
```

**2. Fix the README.** `HOST_DATA_DIR` is now marked optional/auto-detected, with a footnote covering what a wrong value does and that the manager warns about it. This is the part that actually caused the confusion.

## Scope

Deliberately small — no new UI, no behavior change for correct setups, no auto-override. Three files.

## Verification

- 396 tests pass (8 new) covering the adopt / ok / mismatch branches, trailing-slash equivalence, prefix paths that must not collide (`/mnt/cache/appdata` vs `/mnt/cache/appdata2`), and case sensitivity.
- The branch logic is extracted as a pure function so it's genuinely tested rather than re-implemented in a test. Worth stating plainly: exercising the *whole* path end to end would mean running the manager inside a container with a mismatched mount, which I did not do — the Docker-facing half (`findSelfContainerId` + inspect) is unchanged and already in use for the existing auto-detect.
- `pnpm typecheck` and full `pnpm build` clean.