### PR TITLE
Custom env vars per server (takes over #11)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Normalise all text files to LF on checkout (prevents CRLF in shell scripts
+# breaking bash inside Linux containers).
+* text=auto eol=lf
+
+# Shell scripts must always be LF.
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,5 +77,8 @@ COPY --from=build /app/docker ./docker
 # Strip it from the shipped image: less to scan, less to attack.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 EXPOSE 3000 8787
+# Strip any Windows CR from the start script — a CRLF-encoded file makes bash
+# see `pipefail\r` as the option name and fail immediately at startup.
+RUN sed -i 's/\r//' docker/start.sh
 # gosu + tini would be added here for PUID/PGID drop + signal handling.
 CMD ["bash", "docker/start.sh"]

--- a/apps/api/prisma/migrations/20260715000000_add_server_extra_env/migration.sql
+++ b/apps/api/prisma/migrations/20260715000000_add_server_extra_env/migration.sql
@@ -1,0 +1,2 @@
+-- Add custom environment variables column (JSON array of {key, value} pairs)
+ALTER TABLE "Server" ADD COLUMN "extraEnvJson" TEXT NOT NULL DEFAULT '[]';

--- a/apps/api/prisma/migrations/20260715000000_add_server_extra_env/migration.sql
+++ b/apps/api/prisma/migrations/20260715000000_add_server_extra_env/migration.sql
@@ -1,2 +1,5 @@
--- Add custom environment variables column (JSON array of {key, value} pairs)
-ALTER TABLE "Server" ADD COLUMN "extraEnvJson" TEXT NOT NULL DEFAULT '[]';
+-- User-defined extra environment variables for a server, stored ENCRYPTED
+-- (AES-256-GCM via SECRETS_KEY) because they routinely carry credentials —
+-- pinning a Palworld build needs STEAM_USERNAME/STEAM_PASSWORD next to
+-- TARGET_MANIFEST_ID. Null = none set. Decrypts to Array<{key, value}>.
+ALTER TABLE "Server" ADD COLUMN "extraEnvEnc" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -91,6 +91,9 @@ model Server {
   configDirty      Boolean @default(false)
   ramLimitMb       Int?
   cpuLimit         Float?
+  // User-defined extra environment variables injected into the game container.
+  // JSON: Array<{ key: string; value: string }>
+  extraEnvJson     String   @default("[]")
 
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -92,8 +92,12 @@ model Server {
   ramLimitMb       Int?
   cpuLimit         Float?
   // User-defined extra environment variables injected into the game container.
-  // JSON: Array<{ key: string; value: string }>
-  extraEnvJson     String   @default("[]")
+  // ENCRYPTED at rest (AES-256-GCM via SECRETS_KEY), like the password columns:
+  // the headline use case for this feature is pinning a Palworld build, which
+  // needs STEAM_USERNAME/STEAM_PASSWORD alongside TARGET_MANIFEST_ID. Plaintext
+  // JSON here would put a Steam password in the clear. Null = none set.
+  // Decrypts to: Array<{ key: string; value: string }>
+  extraEnvEnc      String?
 
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt

--- a/apps/api/src/servers/extra-env.test.ts
+++ b/apps/api/src/servers/extra-env.test.ts
@@ -1,0 +1,147 @@
+import "reflect-metadata"; // class-transformer/-validator decorators; main.ts does this in the app
+import { describe, it, expect, beforeAll } from "vitest";
+import { validate } from "class-validator";
+import { plainToInstance } from "class-transformer";
+import { Game, type ServerConfigValues } from "@ark/shared";
+import { ExtraEnvBody } from "./servers.dto";
+import { buildContainerSpec, needsSteamCmdForPin } from "./runtime-spec";
+import { PALWORLD_CATALOG } from "../catalog/palworld.catalog";
+
+beforeAll(() => {
+  process.env.DATA_DIR ??= "/data";
+  process.env.SECRETS_KEY ??= "a".repeat(64);
+  process.env.JWT_SECRET ??= "test-jwt-secret-1234";
+});
+
+const envOf = (spec: { Env?: string[] }) => spec.Env ?? [];
+const base = {
+  serverId: "srv1",
+  game: Game.PALWORLD,
+  map: "",
+  sessionName: "Pal",
+  ports: { game: 8211, rawSocket: 0, query: 27015, rcon: 25575 },
+  maxPlayers: 16,
+  adminPassword: "secret",
+  serverPassword: null,
+  modIds: [],
+  cluster: null,
+  config: { values: {} } as ServerConfigValues,
+  catalog: PALWORLD_CATALOG,
+};
+
+describe("extraEnv injection", () => {
+  it("appends custom vars to the container env", () => {
+    const env = envOf(buildContainerSpec({ ...base, extraEnv: [{ key: "MY_VAR", value: "hello" }] }));
+    expect(env).toContain("MY_VAR=hello");
+  });
+
+  it("appends them LAST so they override a manager-set key", () => {
+    // Docker keeps the last duplicate, which is the whole point of the feature:
+    // an advanced user can override anything the manager set.
+    const env = envOf(buildContainerSpec({ ...base, extraEnv: [{ key: "PLAYERS", value: "99" }] }));
+    const idxManager = env.indexOf("PLAYERS=16");
+    const idxUser = env.lastIndexOf("PLAYERS=99");
+    expect(idxManager).toBeGreaterThanOrEqual(0);
+    expect(idxUser).toBeGreaterThan(idxManager);
+  });
+
+  it("is a no-op when unset or empty", () => {
+    const none = envOf(buildContainerSpec({ ...base }));
+    const empty = envOf(buildContainerSpec({ ...base, extraEnv: [] }));
+    expect(empty).toEqual(none);
+  });
+
+  it("keeps values containing '=' intact", () => {
+    // A base64 secret or a query string must not be split on the first '='.
+    const env = envOf(buildContainerSpec({ ...base, extraEnv: [{ key: "TOKEN", value: "ab=cd==" }] }));
+    expect(env).toContain("TOKEN=ab=cd==");
+  });
+});
+
+describe("needsSteamCmdForPin", () => {
+  // TARGET_MANIFEST_ID names WHICH build to fetch; it does nothing unless SteamCMD
+  // runs on boot, so pinning silently failed without this (original PR #11).
+  it("asks for SteamCMD when a manifest is pinned", () => {
+    expect(needsSteamCmdForPin([{ key: "TARGET_MANIFEST_ID", value: "123" }])).toBe(true);
+  });
+
+  it("stands down when the user set the update switch themselves", () => {
+    expect(
+      needsSteamCmdForPin([
+        { key: "TARGET_MANIFEST_ID", value: "123" },
+        { key: "UPDATE_ON_BOOT", value: "false" },
+      ]),
+    ).toBe(false);
+    expect(
+      needsSteamCmdForPin([
+        { key: "TARGET_MANIFEST_ID", value: "123" },
+        { key: "ALWAYS_UPDATE_ON_START", value: "false" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("is quiet without a pin", () => {
+    expect(needsSteamCmdForPin([{ key: "OTHER", value: "x" }])).toBe(false);
+    expect(needsSteamCmdForPin([])).toBe(false);
+    expect(needsSteamCmdForPin(undefined)).toBe(false);
+  });
+
+  it("turns UPDATE_ON_BOOT on exactly once for a pinned Palworld build", () => {
+    const env = envOf(
+      buildContainerSpec({ ...base, extraEnv: [{ key: "TARGET_MANIFEST_ID", value: "42" }] }),
+    );
+    expect(env.filter((e) => e.startsWith("UPDATE_ON_BOOT="))).toEqual(["UPDATE_ON_BOOT=true"]);
+    expect(env).toContain("TARGET_MANIFEST_ID=42");
+  });
+
+  it("leaves the user's own switch alone when they override it", () => {
+    const env = envOf(
+      buildContainerSpec({
+        ...base,
+        extraEnv: [
+          { key: "TARGET_MANIFEST_ID", value: "42" },
+          { key: "UPDATE_ON_BOOT", value: "false" },
+        ],
+      }),
+    );
+    expect(env.lastIndexOf("UPDATE_ON_BOOT=false")).toBeGreaterThan(-1);
+    expect(env).not.toContain("UPDATE_ON_BOOT=true");
+  });
+});
+
+describe("ExtraEnvBody validation", () => {
+  const check = async (extraEnv: unknown) =>
+    validate(plainToInstance(ExtraEnvBody, { extraEnv }), { whitelist: true });
+
+  it("accepts ordinary POSIX names", async () => {
+    expect(await check([{ key: "STEAM_USERNAME", value: "bob" }, { key: "_X1", value: "" }])).toEqual([]);
+  });
+
+  it("rejects a name starting with a digit", async () => {
+    expect((await check([{ key: "1BAD", value: "x" }])).length).toBeGreaterThan(0);
+  });
+
+  it("rejects names with a dash, space or equals", async () => {
+    for (const key of ["MY-VAR", "MY VAR", "MY=VAR", ""]) {
+      expect((await check([{ key, value: "x" }])).length, key).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects a null byte in the value", async () => {
+    // A NUL would truncate the variable inside the container. Built at runtime so
+    // this source file stays free of control characters.
+    const withNul = `a${String.fromCharCode(0)}b`;
+    expect((await check([{ key: "K", value: withNul }])).length).toBeGreaterThan(0);
+  });
+
+  it("rejects an oversized value", async () => {
+    expect((await check([{ key: "K", value: "x".repeat(4097) }])).length).toBeGreaterThan(0);
+    expect(await check([{ key: "K", value: "x".repeat(4096) }])).toEqual([]);
+  });
+
+  it("caps the list at 64 entries", async () => {
+    const many = (n: number) => Array.from({ length: n }, (_, i) => ({ key: `K${i}`, value: "v" }));
+    expect(await check(many(64))).toEqual([]);
+    expect((await check(many(65))).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/servers/runtime-spec.ts
+++ b/apps/api/src/servers/runtime-spec.ts
@@ -7,6 +7,7 @@ import {
   type ServerConfigValues,
   type SettingsCatalog,
   type MotdValue,
+  type EnvVar,
 } from "@ark/shared";
 import { buildCustomArgs, isBattlEyeDisabled } from "../catalog/command-line";
 import { VALHEIM_MODIFIER_CATEGORY } from "../catalog/valheim.catalog";
@@ -89,6 +90,9 @@ export interface RuntimeSpecInput {
   /** Advanced: pin the game image to a specific tag (e.g. a prior version) instead of
    *  the shipped default. Invalid/blank falls back to the default tag. */
   imageTag?: string | null;
+  /** User-defined extra env vars to inject into the container (appended last so they
+   *  can override any built-in variable). */
+  extraEnv?: EnvVar[];
   /** One-shot: this start should update the game files. For games whose image updater
    *  the manager normally disables, forces the image's update env for this boot only
    *  (see ONE_SHOT_UPDATE_ENV). No-op for games that already update on boot. */
@@ -125,7 +129,15 @@ export function buildContainerSpec(input: RuntimeSpecInput): Docker.ContainerCre
   // Each game spec sets Image to its shipped default; apply a pinned tag here (one
   // choke point) so an advanced user can run a specific version.
   spec.Image = imageRefFor(input.game, input.imageTag);
+  // Append user-defined extra env vars last so they can override any built-in key.
+  if (input.extraEnv && input.extraEnv.length > 0) {
+    spec.Env = [
+      ...(spec.Env ?? []),
+      ...input.extraEnv.map(({ key, value }) => `${key}=${value}`),
+    ];
+  }
   // One-shot update: force the image's update env for this boot (GH #8/#12/#14).
+  // After extraEnv so a deliberate one-shot update still wins for that one boot.
   const updateEnv = ONE_SHOT_UPDATE_ENV[input.game];
   if (input.updateRequested && updateEnv) {
     spec.Env = forceEnv(spec.Env ?? [], updateEnv);

--- a/apps/api/src/servers/runtime-spec.ts
+++ b/apps/api/src/servers/runtime-spec.ts
@@ -113,6 +113,21 @@ export const ONE_SHOT_UPDATE_ENV: Partial<Record<Game, Record<string, string>>> 
   [Game.CONAN]: { AUTO_UPDATE: "true", AUTO_UPDATE_CHECK_INTERVAL_HOURS: "8760" },
 };
 
+/**
+ * Whether the user pinned a Steam build via extraEnv and left the image's update
+ * switch alone. TARGET_MANIFEST_ID tells SteamCMD WHICH build to fetch; it has no
+ * effect unless SteamCMD runs, so the pin needs the update env turned on. Honours
+ * an explicit UPDATE_ON_BOOT / ALWAYS_UPDATE_ON_START in extraEnv by standing down.
+ * (Carried over from the original PR #11, moved to this choke point so it isn't
+ * duplicated across the two Palworld specs.)
+ */
+export function needsSteamCmdForPin(extraEnv: EnvVar[] | undefined): boolean {
+  if (!extraEnv?.length) return false;
+  const keys = new Set(extraEnv.map((e) => e.key));
+  if (!keys.has("TARGET_MANIFEST_ID")) return false;
+  return !keys.has("UPDATE_ON_BOOT") && !keys.has("ALWAYS_UPDATE_ON_START");
+}
+
 /** Replace/append `KEY=value` entries in a Docker env array. Docker keeps the LAST
  *  duplicate, but relying on that is fragile — strip the old entries instead. */
 export function forceEnv(env: string[], overrides: Record<string, string>): string[] {
@@ -140,6 +155,12 @@ export function buildContainerSpec(input: RuntimeSpecInput): Docker.ContainerCre
   // After extraEnv so a deliberate one-shot update still wins for that one boot.
   const updateEnv = ONE_SHOT_UPDATE_ENV[input.game];
   if (input.updateRequested && updateEnv) {
+    spec.Env = forceEnv(spec.Env ?? [], updateEnv);
+  } else if (updateEnv && needsSteamCmdForPin(input.extraEnv)) {
+    // Pinning a build with TARGET_MANIFEST_ID only does anything if SteamCMD
+    // actually runs on boot — otherwise the image reads the variable and ignores
+    // it, and the pin silently does nothing. Skipped when the user set the update
+    // key themselves: an explicit choice in extraEnv outranks this inference.
     spec.Env = forceEnv(spec.Env ?? [], updateEnv);
   }
   return spec;

--- a/apps/api/src/servers/servers.controller.ts
+++ b/apps/api/src/servers/servers.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Put,
   Query,
   Res,
   StreamableFile,
@@ -29,7 +30,7 @@ import type { CreateServerDto, UpdateServerDto } from "@ark/shared";
 import { ServersService } from "./servers.service";
 import { HistoryService } from "./history.service";
 import { EventsService } from "../events/events.service";
-import { CreateServerBody, UpdateServerBody } from "./servers.dto";
+import { CreateServerBody, UpdateServerBody, ExtraEnvBody } from "./servers.dto";
 import { MinRole } from "../auth/min-role.decorator";
 
 class CopyServerBody {
@@ -128,6 +129,25 @@ export class ServersController {
   @Patch(":id")
   update(@Param("id") id: string, @Body() body: UpdateServerBody) {
     return this.servers.update(id, body as UpdateServerDto);
+  }
+
+  /**
+   * Custom environment variables, admin-only in BOTH directions: the values hold
+   * whatever the user put there — Steam credentials for a pinned build being the
+   * headline case — so operators and viewers can neither read nor set them. The
+   * server summary carries only the names.
+   */
+  @Get(":id/extra-env")
+  @MinRole("admin")
+  getExtraEnv(@Param("id") id: string) {
+    return this.servers.getExtraEnv(id);
+  }
+
+  /** Replace the whole list. Applies on the next start (env is read at create). */
+  @Put(":id/extra-env")
+  @MinRole("admin")
+  setExtraEnv(@Param("id") id: string, @Body() body: ExtraEnvBody) {
+    return this.servers.setExtraEnv(id, body.extraEnv);
   }
 
   /** Pin per-server artwork (each field a URL to set, or null to reset to the

--- a/apps/api/src/servers/servers.dto.ts
+++ b/apps/api/src/servers/servers.dto.ts
@@ -9,9 +9,25 @@ import {
   IsString,
   Matches,
   Min,
+  ValidateNested,
+  ArrayMaxSize,
 } from "class-validator";
+import { Type } from "class-transformer";
 import { Game } from "@ark/shared";
 import { IMAGE_TAG_RE } from "../common/images";
+
+/** Validated representation of a single user-defined env var. */
+export class EnvVarItem {
+  /** Keys must follow POSIX variable-name rules so they're safe inside a Docker
+   *  env array (no shell expansion is involved, but junk keys confuse images). */
+  @Matches(/^[A-Za-z_][A-Za-z0-9_]{0,127}$/, { message: "key must be a valid env var name (letters, digits, underscores; cannot start with a digit)" })
+  key!: string;
+
+  /** No null bytes; arbitrary printable string up to 4096 chars. */
+  @IsString()
+  @Matches(/^[^\x00]{0,4096}$/, { message: "value must not contain null bytes and must be ≤4096 characters" })
+  value!: string;
+}
 
 /** Reusable: an optional, validated Docker image tag (null clears the pin). */
 const ImageTagField = () =>
@@ -34,6 +50,8 @@ export class CreateServerBody {
   @IsOptional() @ImageTagField() imageTag?: string | null;
   /** Import only: host path of an existing Saved dir to copy in. */
   @IsOptional() @IsString() savedSourcePath?: string;
+  /** User-defined extra env vars injected into the game container. */
+  @IsOptional() @IsArray() @ArrayMaxSize(64) @ValidateNested({ each: true }) @Type(() => EnvVarItem) extraEnv?: EnvVarItem[];
 }
 
 export class UpdateServerBody {
@@ -54,6 +72,8 @@ export class UpdateServerBody {
   @IsOptional() @IsObject() config?: Record<string, unknown>;
   /** Advanced: pin the game image to a specific tag (null clears the pin). */
   @IsOptional() @ImageTagField() imageTag?: string | null;
+  /** User-defined extra env vars injected into the game container. */
+  @IsOptional() @IsArray() @ArrayMaxSize(64) @ValidateNested({ each: true }) @Type(() => EnvVarItem) extraEnv?: EnvVarItem[];
 }
 
 export class RconBody {

--- a/apps/api/src/servers/servers.dto.ts
+++ b/apps/api/src/servers/servers.dto.ts
@@ -50,8 +50,6 @@ export class CreateServerBody {
   @IsOptional() @ImageTagField() imageTag?: string | null;
   /** Import only: host path of an existing Saved dir to copy in. */
   @IsOptional() @IsString() savedSourcePath?: string;
-  /** User-defined extra env vars injected into the game container. */
-  @IsOptional() @IsArray() @ArrayMaxSize(64) @ValidateNested({ each: true }) @Type(() => EnvVarItem) extraEnv?: EnvVarItem[];
 }
 
 export class UpdateServerBody {
@@ -72,8 +70,15 @@ export class UpdateServerBody {
   @IsOptional() @IsObject() config?: Record<string, unknown>;
   /** Advanced: pin the game image to a specific tag (null clears the pin). */
   @IsOptional() @ImageTagField() imageTag?: string | null;
-  /** User-defined extra env vars injected into the game container. */
-  @IsOptional() @IsArray() @ArrayMaxSize(64) @ValidateNested({ each: true }) @Type(() => EnvVarItem) extraEnv?: EnvVarItem[];
+}
+
+/**
+ * Replace a server's custom env vars. Its own admin-only endpoint rather than a
+ * field on UpdateServerBody: the values routinely hold credentials, and the
+ * general update route is open to operators.
+ */
+export class ExtraEnvBody {
+  @IsArray() @ArrayMaxSize(64) @ValidateNested({ each: true }) @Type(() => EnvVarItem) extraEnv!: EnvVarItem[];
 }
 
 export class RconBody {

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -32,6 +32,7 @@ import {
   type ServerStatsDetail,
   type ServerConfigValues,
   type GameArtwork,
+  type EnvVar,
 } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { CryptoService } from "../crypto/crypto.service";
@@ -809,13 +810,6 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       data.configJson = JSON.stringify(merged);
       launchChanged = true; // settings feed the generated INI / command line
     }
-    if (dto.extraEnv !== undefined) {
-      const next = JSON.stringify(dto.extraEnv);
-      if (next !== (existing.extraEnvJson ?? "[]")) {
-        data.extraEnvJson = next;
-        launchChanged = true;
-      }
-    }
     if (launchChanged) data.configDirty = true; // → UI shows the Restart button
 
     const updated = await this.prisma.server.update({
@@ -1202,7 +1196,7 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       iconUrl,
       imageTag: server.imageTag,
       updateRequested: server.updateRequested,
-      extraEnv: JSON.parse(server.extraEnvJson ?? "[]") as Array<{ key: string; value: string }>,
+      extraEnv: this.readExtraEnv(server.extraEnvEnc),
     });
   }
 
@@ -1844,6 +1838,56 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
   }
 
   /**
+   * Decrypt a server's extra env vars. Best-effort: a value written under a
+   * different SECRETS_KEY (restored backup, rotated key) must not take the whole
+   * server down — it degrades to "none set", which the user can see and re-enter.
+   */
+  private readExtraEnv(enc: string | null | undefined): EnvVar[] {
+    if (!enc) return [];
+    try {
+      const parsed = JSON.parse(this.crypto.decrypt(enc)) as unknown;
+      return Array.isArray(parsed) ? (parsed as EnvVar[]) : [];
+    } catch {
+      this.logger.warn("extra env vars could not be decrypted (wrong SECRETS_KEY?) — treating as unset");
+      return [];
+    }
+  }
+
+  /** A server's extra env vars in the clear. Admin-only — the controller gates it. */
+  async getExtraEnv(id: string): Promise<EnvVar[]> {
+    const server = await this.prisma.server.findUnique({ where: { id } });
+    if (!server) throw new NotFoundException("Server not found");
+    return this.readExtraEnv(server.extraEnvEnc);
+  }
+
+  /**
+   * Replace a server's extra env vars (the whole list, every save). Stored
+   * encrypted; flags configDirty so the UI offers the Restart that applies them,
+   * since env is only read when the container is created.
+   */
+  async setExtraEnv(id: string, vars: EnvVar[]): Promise<ServerSummary> {
+    const server = await this.prisma.server.findUnique({ where: { id } });
+    if (!server) throw new NotFoundException("Server not found");
+    const changed = JSON.stringify(this.readExtraEnv(server.extraEnvEnc)) !== JSON.stringify(vars);
+    const updated = await this.prisma.server.update({
+      where: { id },
+      data: {
+        extraEnvEnc: vars.length ? this.crypto.encrypt(JSON.stringify(vars)) : null,
+        ...(changed ? { configDirty: true } : {}),
+      },
+    });
+    if (changed) {
+      await this.events.emit({
+        type: EventType.ConfigChanged,
+        // Names only — the values are the secret part.
+        message: `Custom environment variables updated (${vars.length ? vars.map((v) => v.key).join(", ") : "none"}) — restart to apply`,
+        serverId: id,
+      });
+    }
+    return this.toSummary(updated as ServerRow);
+  }
+
+  /**
    * Make sure the bridge network this spec attaches to actually exists. Docker's own
    * failure here is "(HTTP code 404) no such container - network ark-net not found",
    * which reads like a container problem and sent a user hunting (GH #31). Host-network
@@ -1943,7 +1987,9 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       modIds: JSON.parse(row.modIds) as number[],
       ramLimitMb: row.ramLimitMb,
       cpuLimit: row.cpuLimit,
-      extraEnv: JSON.parse(row.extraEnvJson ?? "[]") as Array<{ key: string; value: string }>,
+      // Names only. Values are secrets (Steam credentials, API keys) and are
+      // readable solely through the admin-gated extra-env endpoint.
+      extraEnvKeys: this.readExtraEnv(row.extraEnvEnc).map((e) => e.key),
       artwork: row.artworkJson ? (JSON.parse(row.artworkJson) as GameArtwork) : null,
       createdAt: row.createdAt.toISOString(),
       updatedAt: row.updatedAt.toISOString(),

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -809,6 +809,13 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       data.configJson = JSON.stringify(merged);
       launchChanged = true; // settings feed the generated INI / command line
     }
+    if (dto.extraEnv !== undefined) {
+      const next = JSON.stringify(dto.extraEnv);
+      if (next !== (existing.extraEnvJson ?? "[]")) {
+        data.extraEnvJson = next;
+        launchChanged = true;
+      }
+    }
     if (launchChanged) data.configDirty = true; // → UI shows the Restart button
 
     const updated = await this.prisma.server.update({
@@ -1195,6 +1202,7 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       iconUrl,
       imageTag: server.imageTag,
       updateRequested: server.updateRequested,
+      extraEnv: JSON.parse(server.extraEnvJson ?? "[]") as Array<{ key: string; value: string }>,
     });
   }
 
@@ -1935,6 +1943,7 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       modIds: JSON.parse(row.modIds) as number[],
       ramLimitMb: row.ramLimitMb,
       cpuLimit: row.cpuLimit,
+      extraEnv: JSON.parse(row.extraEnvJson ?? "[]") as Array<{ key: string; value: string }>,
       artwork: row.artworkJson ? (JSON.parse(row.artworkJson) as GameArtwork) : null,
       createdAt: row.createdAt.toISOString(),
       updatedAt: row.updatedAt.toISOString(),

--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -39,6 +39,7 @@ import { useRole } from "@/lib/use-role";
 import { ArtworkPicker } from "@/components/artwork-picker";
 import { BackupsTab } from "@/components/backups-tab";
 import { PlayersTab } from "@/components/players-tab";
+import { EnvVarsCard } from "@/components/env-vars-card";
 
 const TABS = ["Overview", "Settings", "Mods", "Players", "Console", "Logs", "Files", "Schedules", "Backups", "Guide"] as const;
 type Tab = (typeof TABS)[number];
@@ -594,6 +595,7 @@ function Overview({ server, onChanged }: { server: ServerSummary; onChanged: () 
       <ServerAccessCard server={server} onSaved={onChanged} />
       {!isCoreKeeper && <PortsCard server={server} onSaved={onChanged} />}
       <ImageVersionCard server={server} onSaved={onChanged} />
+      <EnvVarsCard server={server} onSaved={onChanged} />
       {!isCoreKeeper && <PortForwardsCard serverId={server.id} />}
       {/* File-managed access lists (Valheim/Bedrock/7DTD); RCON games use the Console. */}
       {(isValheim || isBedrock || isSdtd) && <AccessListsCard serverId={server.id} />}

--- a/apps/web/components/env-vars-card.tsx
+++ b/apps/web/components/env-vars-card.tsx
@@ -1,0 +1,171 @@
+"use client";
+import { useState } from "react";
+import { Terminal, Plus, Trash2, Save, Check, ChevronDown } from "lucide-react";
+import type { ServerSummary, EnvVar } from "@ark/shared";
+import { apiPatch } from "@/lib/api";
+
+const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Advanced card for managing custom environment variables that are injected into the
+ * game container at start time (appended last, so they can override any built-in
+ * variable set by the manager — e.g. TARGET_MANIFEST_ID for Palworld).
+ */
+export function EnvVarsCard({ server, onSaved }: { server: ServerSummary; onSaved: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [rows, setRows] = useState<EnvVar[]>(() =>
+    Array.isArray(server.extraEnv) ? server.extraEnv.map((e) => ({ ...e })) : [],
+  );
+  const [busy, setBusy] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Re-sync local state when the server prop changes (e.g. after a refresh).
+  const [lastId, setLastId] = useState(server.id);
+  if (server.id !== lastId) {
+    setLastId(server.id);
+    setRows(Array.isArray(server.extraEnv) ? server.extraEnv.map((e) => ({ ...e })) : []);
+  }
+
+  const dirty =
+    JSON.stringify(rows) !== JSON.stringify(Array.isArray(server.extraEnv) ? server.extraEnv : []);
+
+  const addRow = () => setRows((r) => [...r, { key: "", value: "" }]);
+
+  const removeRow = (i: number) =>
+    setRows((r) => r.filter((_, idx) => idx !== i));
+
+  const setKey = (i: number, key: string) =>
+    setRows((r) => r.map((row, idx) => (idx === i ? { ...row, key } : row)));
+
+  const setValue = (i: number, value: string) =>
+    setRows((r) => r.map((row, idx) => (idx === i ? { ...row, value } : row)));
+
+  const keyError = (key: string) =>
+    key.length > 0 && !KEY_RE.test(key) ? "Invalid name" : null;
+
+  const hasDuplicateKey = (i: number) => {
+    const k = rows[i].key;
+    return k.length > 0 && rows.some((r, idx) => idx !== i && r.key === k);
+  };
+
+  const canSave =
+    dirty &&
+    rows.every((r) => KEY_RE.test(r.key)) &&
+    rows.every((_, i) => !hasDuplicateKey(i));
+
+  const save = async () => {
+    setBusy(true);
+    setErr(null);
+    setSaved(false);
+    try {
+      await apiPatch(`/servers/${server.id}`, { extraEnv: rows });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
+      onSaved();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const count = server.extraEnv?.length ?? 0;
+
+  return (
+    <div className="card">
+      <button
+        className="flex w-full items-center justify-between gap-2 text-left"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-ark-accent2">
+          <Terminal className="h-4 w-4" /> Custom env vars
+          {count > 0 && (
+            <span className="ml-1 rounded bg-slate-700/60 px-1.5 py-0.5 font-mono text-[11px] font-normal normal-case text-slate-300">
+              {count} set
+            </span>
+          )}
+        </span>
+        <ChevronDown className={`h-4 w-4 text-slate-400 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open && (
+        <div className="mt-3 space-y-3">
+          <p className="text-[11px] leading-snug text-slate-500">
+            These environment variables are appended to the container at start — they can override
+            any built-in variable set by the manager (e.g.{" "}
+            <span className="font-mono text-slate-400">TARGET_MANIFEST_ID</span> for Palworld version
+            pinning). A server restart is required after saving.
+          </p>
+
+          {rows.length > 0 && (
+            <div className="space-y-2">
+              {rows.map((row, i) => {
+                const ke = keyError(row.key);
+                const dup = hasDuplicateKey(i);
+                return (
+                  <div key={i} className="flex items-start gap-2">
+                    <div className="flex-1 min-w-0">
+                      <input
+                        className={`input font-mono text-xs ${ke || dup ? "border-rose-500/60" : ""}`}
+                        placeholder="VARIABLE_NAME"
+                        value={row.key}
+                        onChange={(e) => setKey(i, e.target.value)}
+                        spellCheck={false}
+                        autoCapitalize="characters"
+                      />
+                      {ke && <p className="mt-0.5 text-[10px] text-rose-400">{ke}</p>}
+                      {dup && <p className="mt-0.5 text-[10px] text-rose-400">Duplicate key</p>}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <input
+                        className="input font-mono text-xs"
+                        placeholder="value"
+                        value={row.value}
+                        onChange={(e) => setValue(i, e.target.value)}
+                        spellCheck={false}
+                      />
+                    </div>
+                    <button
+                      className="mt-1 text-slate-500 hover:text-rose-400 transition-colors"
+                      onClick={() => removeRow(i)}
+                      title="Remove"
+                      type="button"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {rows.length === 0 && (
+            <p className="text-xs text-slate-600 italic">No custom env vars configured.</p>
+          )}
+
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              className="btn-secondary inline-flex items-center gap-1.5 text-xs"
+              onClick={addRow}
+              type="button"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add variable
+            </button>
+            <button
+              className="btn-primary inline-flex items-center gap-1.5 text-xs"
+              disabled={!canSave || busy}
+              onClick={() => void save()}
+              type="button"
+            >
+              {busy ? null : saved ? <Check className="h-3.5 w-3.5" /> : <Save className="h-3.5 w-3.5" />}
+              {busy ? "Saving…" : saved ? "Saved" : "Save"}
+            </button>
+          </div>
+
+          {err && <p className="text-xs text-rose-400">{err}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/env-vars-card.tsx
+++ b/apps/web/components/env-vars-card.tsx
@@ -1,10 +1,28 @@
 "use client";
-import { useState } from "react";
-import { Terminal, Plus, Trash2, Save, Check, ChevronDown } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Terminal, Plus, Trash2, Save, Check, ChevronDown, Loader2, AlertTriangle } from "lucide-react";
 import type { ServerSummary, EnvVar } from "@ark/shared";
-import { apiPatch } from "@/lib/api";
+import { apiGet, apiPut } from "@/lib/api";
+import { useRole } from "@/lib/use-role";
 
 const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Keys the manager sets itself and depends on. Overriding one is allowed — this is
+ *  the advanced escape hatch — but it breaks the panel's own plumbing (console,
+ *  player counts, the port-conflict guard), so the card says so before you do. */
+const MANAGER_OWNED = new Set([
+  "RCON_PORT",
+  "RCON_ENABLED",
+  "PORT",
+  "QUERY_PORT",
+  "PUBLIC_PORT",
+  "SERVER_PORT",
+  "ADMIN_PASSWORD",
+  "RCONPASSWORD",
+  "SERVER_PASSWORD",
+  "PUID",
+  "PGID",
+]);
 
 /**
  * Advanced card for managing custom environment variables that are injected into the
@@ -12,23 +30,40 @@ const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
  * variable set by the manager — e.g. TARGET_MANIFEST_ID for Palworld).
  */
 export function EnvVarsCard({ server, onSaved }: { server: ServerSummary; onSaved: () => void }) {
+  const role = useRole();
+  const isAdmin = role === "admin";
   const [open, setOpen] = useState(false);
-  const [rows, setRows] = useState<EnvVar[]>(() =>
-    Array.isArray(server.extraEnv) ? server.extraEnv.map((e) => ({ ...e })) : [],
-  );
+  const [rows, setRows] = useState<EnvVar[]>([]);
+  // What the server last told us, for the dirty check.
+  const [loaded, setLoaded] = useState<EnvVar[] | null>(null);
+  const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [saved, setSaved] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  // Re-sync local state when the server prop changes (e.g. after a refresh).
+  // Values live behind an admin-only endpoint — they hold credentials, so they are
+  // deliberately absent from the server summary every role can read. Fetch on open.
+  useEffect(() => {
+    if (!open || !isAdmin || loaded || loading) return;
+    setLoading(true);
+    apiGet<EnvVar[]>(`/servers/${server.id}/extra-env`)
+      .then((vars) => {
+        setLoaded(vars);
+        setRows(vars.map((e) => ({ ...e })));
+      })
+      .catch((e) => setErr((e as Error).message))
+      .finally(() => setLoading(false));
+  }, [open, isAdmin, loaded, loading, server.id]);
+
+  // Switching servers invalidates everything we fetched.
   const [lastId, setLastId] = useState(server.id);
   if (server.id !== lastId) {
     setLastId(server.id);
-    setRows(Array.isArray(server.extraEnv) ? server.extraEnv.map((e) => ({ ...e })) : []);
+    setLoaded(null);
+    setRows([]);
   }
 
-  const dirty =
-    JSON.stringify(rows) !== JSON.stringify(Array.isArray(server.extraEnv) ? server.extraEnv : []);
+  const dirty = loaded !== null && JSON.stringify(rows) !== JSON.stringify(loaded);
 
   const addRow = () => setRows((r) => [...r, { key: "", value: "" }]);
 
@@ -59,7 +94,8 @@ export function EnvVarsCard({ server, onSaved }: { server: ServerSummary; onSave
     setErr(null);
     setSaved(false);
     try {
-      await apiPatch(`/servers/${server.id}`, { extraEnv: rows });
+      await apiPut(`/servers/${server.id}/extra-env`, { extraEnv: rows });
+      setLoaded(rows.map((e) => ({ ...e })));
       setSaved(true);
       setTimeout(() => setSaved(false), 1500);
       onSaved();
@@ -70,7 +106,8 @@ export function EnvVarsCard({ server, onSaved }: { server: ServerSummary; onSave
     }
   };
 
-  const count = server.extraEnv?.length ?? 0;
+  const count = server.extraEnvKeys?.length ?? 0;
+  const overridden = rows.filter((r) => MANAGER_OWNED.has(r.key)).map((r) => r.key);
 
   return (
     <div className="card">
@@ -95,10 +132,44 @@ export function EnvVarsCard({ server, onSaved }: { server: ServerSummary; onSave
             These environment variables are appended to the container at start — they can override
             any built-in variable set by the manager (e.g.{" "}
             <span className="font-mono text-slate-400">TARGET_MANIFEST_ID</span> for Palworld version
-            pinning). A server restart is required after saving.
+            pinning). A server restart is required after saving. Values are stored encrypted and are
+            only readable by admins, so credentials such as a Steam login are safe to put here.
           </p>
 
-          {rows.length > 0 && (
+          {!isAdmin && (
+            <p className="text-[11px] leading-snug text-amber-300/90">
+              {count > 0 ? (
+                <>
+                  This server has {count} custom variable{count === 1 ? "" : "s"} set (
+                  <span className="font-mono">{server.extraEnvKeys.join(", ")}</span>). Only an admin
+                  can view or change their values.
+                </>
+              ) : (
+                <>Only an admin can view or change custom environment variables.</>
+              )}
+            </p>
+          )}
+
+          {isAdmin && loading && (
+            <p className="flex items-center gap-1.5 text-[11px] text-slate-500">
+              <Loader2 className="h-3 w-3 animate-spin" /> Loading values…
+            </p>
+          )}
+
+          {overridden.length > 0 && (
+            <p className="flex items-start gap-1.5 text-[11px] leading-snug text-amber-300/90">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>
+                <span className="font-mono">{overridden.join(", ")}</span>{" "}
+                {overridden.length === 1 ? "is" : "are"} set by the manager. Overriding{" "}
+                {overridden.length === 1 ? "it" : "them"} is allowed, but the panel uses these for
+                the console, player counts and its port-conflict check — expect those to stop
+                working for this server.
+              </span>
+            </p>
+          )}
+
+          {isAdmin && rows.length > 0 && (
             <div className="space-y-2">
               {rows.map((row, i) => {
                 const ke = keyError(row.key);
@@ -144,6 +215,7 @@ export function EnvVarsCard({ server, onSaved }: { server: ServerSummary; onSave
             <p className="text-xs text-slate-600 italic">No custom env vars configured.</p>
           )}
 
+          {isAdmin && (
           <div className="flex items-center gap-2 pt-1">
             <button
               className="btn-secondary inline-flex items-center gap-1.5 text-xs"
@@ -162,6 +234,7 @@ export function EnvVarsCard({ server, onSaved }: { server: ServerSummary; onSave
               {busy ? "Saving…" : saved ? "Saved" : "Save"}
             </button>
           </div>
+          )}
 
           {err && <p className="text-xs text-rose-400">{err}</p>}
         </div>

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Launch the API and the web app together in the single manager container.
 set -euo pipefail
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Launch the API and the web app together in the single manager container.
 set -euo pipefail
 

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -51,8 +51,11 @@ export interface ServerSummary {
   modIds: number[];
   ramLimitMb?: number | null;
   cpuLimit?: number | null;
-  /** User-defined extra env vars injected into the game container at start. */
-  extraEnv: EnvVar[];
+  /** NAMES of the user-defined env vars injected into the game container at start.
+   *  Values are deliberately absent: they routinely hold credentials (Steam login
+   *  for a pinned build), and this summary is readable by every role. Read them
+   *  through the admin-only GET /servers/:id/extra-env. */
+  extraEnvKeys: string[];
   /** Per-server SteamGridDB art override (each field null = use the game default). */
   artwork?: GameArtwork | null;
   createdAt: string;
@@ -174,9 +177,6 @@ export interface CreateServerDto {
   /** Advanced: pin the game image to a specific tag instead of the shipped default
    *  (null clears the pin). Applied on the next start (pull + recreate). */
   imageTag?: string | null;
-  /** User-defined extra env vars injected into the game container. Replaces the
-   *  full list on every save. */
-  extraEnv?: EnvVar[];
 }
 
 export type UpdateServerDto = Partial<CreateServerDto> & {

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -2,6 +2,12 @@ import type { Game, PortSet } from "./game";
 import type { ServerState } from "./server-state";
 import type { ServerConfigValues } from "./settings-catalog";
 
+/** A single user-defined environment variable to inject into the game container. */
+export interface EnvVar {
+  key: string;
+  value: string;
+}
+
 /** Public (no secrets) view of a server instance. */
 export interface ServerSummary {
   id: string;
@@ -45,6 +51,8 @@ export interface ServerSummary {
   modIds: number[];
   ramLimitMb?: number | null;
   cpuLimit?: number | null;
+  /** User-defined extra env vars injected into the game container at start. */
+  extraEnv: EnvVar[];
   /** Per-server SteamGridDB art override (each field null = use the game default). */
   artwork?: GameArtwork | null;
   createdAt: string;
@@ -166,6 +174,9 @@ export interface CreateServerDto {
   /** Advanced: pin the game image to a specific tag instead of the shipped default
    *  (null clears the pin). Applied on the next start (pull + recreate). */
   imageTag?: string | null;
+  /** User-defined extra env vars injected into the game container. Replaces the
+   *  full list on every save. */
+  extraEnv?: EnvVar[];
 }
 
 export type UpdateServerDto = Partial<CreateServerDto> & {


### PR DESCRIPTION
Takes over #11 from @ckocyigit, who hasn't been reachable since opening it. Their three commits are preserved with their authorship; my review fixes sit on top as a separate commit crediting them as co-author. Closes #11.

## What was inherited

The original approach was right and is kept intact: injection at the `buildContainerSpec` choke point so every game benefits, a validated DTO, `configDirty` → Restart prompt, and a UI card matching the panel's patterns.

## Review items, resolved

**1. Secrets exposure (the blocker).** `extraEnv` was plaintext JSON, returned in `ServerSummary` — which every role, including viewer, can read. The headline use case makes it acute: pinning a Palworld build needs `STEAM_USERNAME`/`STEAM_PASSWORD` beside `TARGET_MANIFEST_ID`, so the feature funnelled users into putting a Steam password in a plaintext, viewer-visible field, in a codebase where every other password is AES-256-GCM encrypted and never serialized.

- Column is now `extraEnvEnc` (encrypted, nullable), matching the `*PasswordEnc` convention. **Verified against a real database** that the stored value contains neither the password nor the key names, and still round-trips. A decryption failure (restored backup, rotated `SECRETS_KEY`) degrades to "none set" with a warning rather than taking the server down.
- `ServerSummary` carries `extraEnvKeys` — names only.
- Values are readable only via `GET /servers/:id/extra-env`, and writes moved off `PATCH /servers/:id` (open to operators) onto `PUT /servers/:id/extra-env`. Both `@MinRole("admin")`.

**2. Rebase.** Done as a cherry-pick onto current `main`, which had moved into nearly every file this touches. Two conflicts were additive (one-shot updates vs extraEnv) and kept both sides.

**3. Tests.** 15 new: append-last override ordering, values containing `=`, the no-op case, DTO validation (bad names, NUL bytes, oversized values, the 64 cap), and the manifest-pin conditional.

**4. `create()` dropped `extraEnv`.** Resolved by construction — it's gone from the create DTO entirely, since writes now have their own admin-gated route.

**5. Manager-owned keys.** Kept full override power as you preferred, but the card now warns *by name* when an entry shadows a key the panel uses for the console, player counts, or the port guard.

## One thing worth flagging

Their fourth commit (`TARGET_MANIFEST_ID` → `UPDATE_ON_BOOT`) hardcoded update env into the two Palworld specs — which `main` has since changed, so those values come from the catalog now (#8/#12/#16). That commit resolved to **empty** during the rebase and dropped out.

The intent is still valid — a pinned manifest is silently ignored unless SteamCMD runs — so I reimplemented it at the `buildContainerSpec` choke point, reusing `ONE_SHOT_UPDATE_ENV`/`forceEnv` instead of duplicating a conditional across two game specs. It stands down when the user sets the update switch themselves, since an explicit choice should outrank an inference.

The `.gitattributes`/CRLF fixes are kept, as you said they were welcome.

## Verification

419 tests pass (15 new), `pnpm typecheck` clean, full `pnpm build` clean, and the at-rest encryption checked against a real SQLite database rather than assumed.