### PR TITLE
Exempt manual backups from retention (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ player administration, and even your router's port-forwards.
   endpoint) with 1-hour sparklines, plus a **Players** roster captured from
   player lists and join logs — kick / ban / whitelist / admin per game.
 - Backups: manual + scheduled with retention, restore, browser download, and
-  saves import. The manager also snapshots its own database nightly.
+  saves import. Retention (default 10, up to 500) rotates only the **automatic**
+  snapshots — scheduled ones and the safety copies taken before an update, restart
+  or restore. Backups you take yourself are kept until you delete them, on the
+  replication target too. The manager also snapshots its own database nightly.
 - Schedules (restart / update / backup / stop / start) with in-game countdown
   warnings, pre-action snapshots, and a "skip while players are online" guard.
 - **Version pinning** from registry-populated dropdowns: pin the **game version /
@@ -234,7 +237,7 @@ Everything lives under your data dir — one directory to back up:
 /data
 ├── db.sqlite            # server definitions, schedules, players, settings
 ├── instances/<id>/      # each server's game files + world saves
-├── backups/<id>/        # world snapshots (retention-rotated)
+├── backups/<id>/        # world snapshots (automatic ones retention-rotated)
 ├── backups/_manager/    # nightly self-backups of db.sqlite (newest 14)
 └── clusters/<id>/       # ARK cluster transfer dirs
 ```

--- a/apps/api/src/backups/backups.service.ts
+++ b/apps/api/src/backups/backups.service.ts
@@ -10,6 +10,7 @@ import { EventsService } from "../events/events.service";
 import { RconService } from "../rcon/rcon.service";
 import { ManagerSettingsService } from "../manager-settings/manager-settings.service";
 import { LocalPaths } from "../common/paths";
+import { snapshotsToPrune } from "./retention";
 import { extractTarGzSafe } from "../common/safe-extract";
 import { SERVER_UID, SERVER_GID } from "../common/images";
 import { loadEnv } from "../config/env";
@@ -289,14 +290,16 @@ export class BackupsService {
     return { ok: true };
   }
 
-  /** Keep the newest N backups per server (N from settings); delete the rest. */
+  /**
+   * Keep the newest N AUTOMATIC backups per server (N from settings); delete the
+   * rest. Manual backups are exempt and uncounted — a backup someone took on
+   * purpose shouldn't be rotated away by the scheduled ones that follow it, and
+   * "keep 10" should still mean ten automatic restore points (GH #34).
+   */
   private async applyRetention(serverId: string): Promise<void> {
     const keep = await this.settings.getBackupKeep();
-    const all = await this.prisma.snapshot.findMany({
-      where: { serverId },
-      orderBy: { createdAt: "desc" },
-    });
-    for (const old of all.slice(keep)) {
+    const all = await this.prisma.snapshot.findMany({ where: { serverId } });
+    for (const old of snapshotsToPrune(all, keep)) {
       await rm(old.path, { recursive: true, force: true }).catch(() => undefined);
       await this.prisma.snapshot.delete({ where: { id: old.id } }).catch(() => undefined);
     }

--- a/apps/api/src/backups/retention.test.ts
+++ b/apps/api/src/backups/retention.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  artifactTimestamp,
+  artifactsToPrune,
+  isManualArtifact,
+  isManualReason,
+  snapshotsToPrune,
+} from "./retention";
+
+// GH #34: retention kept the newest N of EVERYTHING, so a backup someone took by
+// hand before a risky change was silently rotated out by the scheduled ones after
+// it. This is deletion logic — the exemption has to hold in both directions.
+
+const at = (iso: string) => new Date(iso);
+const snap = (id: string, reason: string, iso: string) => ({ id, reason, createdAt: at(iso) });
+
+describe("snapshotsToPrune", () => {
+  it("never prunes a manual backup, however old", () => {
+    const snaps = [
+      snap("m", "manual", "2026-01-01T00:00:00Z"),
+      snap("a", "scheduled", "2026-06-01T00:00:00Z"),
+      snap("b", "scheduled", "2026-06-02T00:00:00Z"),
+    ];
+    expect(snapshotsToPrune(snaps, 1).map((s) => s.id)).toEqual(["a"]);
+  });
+
+  it("does not count manual backups against the keep budget", () => {
+    // "keep 2" means two automatic restore points, no matter how many manual ones
+    // sit beside them — otherwise manual backups would starve the rotation.
+    const snaps = [
+      snap("m1", "manual", "2026-01-01T00:00:00Z"),
+      snap("m2", "manual", "2026-01-02T00:00:00Z"),
+      snap("a", "scheduled", "2026-06-01T00:00:00Z"),
+      snap("b", "scheduled", "2026-06-02T00:00:00Z"),
+    ];
+    expect(snapshotsToPrune(snaps, 2)).toEqual([]);
+  });
+
+  it("keeps the newest N automatic and prunes the rest", () => {
+    const snaps = [
+      snap("old", "scheduled", "2026-06-01T00:00:00Z"),
+      snap("mid", "pre-update", "2026-06-02T00:00:00Z"),
+      snap("new", "auto-stop", "2026-06-03T00:00:00Z"),
+    ];
+    expect(snapshotsToPrune(snaps, 1).map((s) => s.id).sort()).toEqual(["mid", "old"]);
+  });
+
+  it("treats every non-manual reason as automatic", () => {
+    for (const reason of ["scheduled", "pre-update", "pre-restart", "pre-restore", "pre-import", "auto-stop"]) {
+      expect(isManualReason(reason), reason).toBe(false);
+      expect(snapshotsToPrune([snap("x", reason, "2026-01-01T00:00:00Z")], 0)).toHaveLength(1);
+    }
+    expect(isManualReason("manual")).toBe(true);
+  });
+
+  it("is insensitive to input order", () => {
+    const snaps = [
+      snap("b", "scheduled", "2026-06-02T00:00:00Z"),
+      snap("old", "scheduled", "2026-06-01T00:00:00Z"),
+      snap("c", "scheduled", "2026-06-03T00:00:00Z"),
+    ];
+    expect(snapshotsToPrune([...snaps].reverse(), 2)).toEqual(snapshotsToPrune(snaps, 2));
+    expect(snapshotsToPrune(snaps, 2).map((s) => s.id)).toEqual(["old"]);
+  });
+
+  it("prunes every automatic backup when keep is 0", () => {
+    const snaps = [snap("m", "manual", "2026-01-01T00:00:00Z"), snap("a", "scheduled", "2026-06-01T00:00:00Z")];
+    expect(snapshotsToPrune(snaps, 0).map((s) => s.id)).toEqual(["a"]);
+  });
+
+  it("prunes nothing when there are fewer automatic backups than keep", () => {
+    expect(snapshotsToPrune([snap("a", "scheduled", "2026-06-01T00:00:00Z")], 10)).toEqual([]);
+  });
+});
+
+describe("artifactsToPrune (replication target)", () => {
+  it("keeps manual artifacts and leaves them out of the count", () => {
+    const files = [
+      "manual-2026-01-01T00-00-00-000Z.tar.gz",
+      "scheduled-2026-06-01T00-00-00-000Z.tar.gz",
+      "scheduled-2026-06-02T00-00-00-000Z.tar.gz",
+    ];
+    expect(artifactsToPrune(files, 2)).toEqual([]);
+    expect(artifactsToPrune(files, 1)).toEqual(["scheduled-2026-06-01T00-00-00-000Z.tar.gz"]);
+  });
+
+  it("orders by timestamp, not by filename", () => {
+    // Names start with the reason, so a plain sort would delete the alphabetically
+    // first prefix wholesale — here every auto-stop before the older scheduled one.
+    const files = [
+      "auto-stop-2026-06-05T00-00-00-000Z.tar.gz",
+      "scheduled-2026-06-01T00-00-00-000Z.tar.gz",
+    ];
+    expect(artifactsToPrune(files, 1)).toEqual(["scheduled-2026-06-01T00-00-00-000Z.tar.gz"]);
+  });
+
+  it("recognises manual artifacts by prefix only", () => {
+    expect(isManualArtifact("manual-2026-06-01T00-00-00-000Z.tar.gz")).toBe(true);
+    // A server whose reason merely contains the word must not be mistaken for one.
+    expect(isManualArtifact("pre-manual-2026-06-01T00-00-00-000Z.tar.gz")).toBe(false);
+    expect(isManualArtifact("scheduled-2026-06-01T00-00-00-000Z.tar.gz")).toBe(false);
+  });
+
+  it("extracts the timestamp from both directory and artifact names", () => {
+    expect(artifactTimestamp("scheduled-2026-06-01T00-00-00-000Z.tar.gz")).toBe("2026-06-01T00-00-00-000Z");
+    expect(artifactTimestamp("pre-update-2026-06-01T00-00-00-000Z")).toBe("update-2026-06-01T00-00-00-000Z");
+  });
+
+  it("sorts an unparseable name first, so it is pruned before anything understood", () => {
+    const files = ["garbage.tar.gz", "scheduled-2026-06-01T00-00-00-000Z.tar.gz"];
+    expect(artifactsToPrune(files, 1)).toEqual(["garbage.tar.gz"]);
+  });
+
+  it("prunes nothing when under the limit", () => {
+    expect(artifactsToPrune(["scheduled-2026-06-01T00-00-00-000Z.tar.gz"], 10)).toEqual([]);
+  });
+});

--- a/apps/api/src/backups/retention.ts
+++ b/apps/api/src/backups/retention.ts
@@ -1,0 +1,71 @@
+/**
+ * Which backups retention is allowed to delete.
+ *
+ * Every snapshot records WHY it was taken (`Snapshot.reason`): `manual` when a user
+ * pressed Backup, and `scheduled` / `pre-<action>` / `auto-stop` when Palisade took
+ * one on its own. Retention used to ignore that and simply keep the newest N of
+ * everything, so a manual backup taken before a risky change was silently rotated
+ * out by the scheduled ones that followed it (GH #34).
+ *
+ * Manual backups are now never pruned — they are kept until deleted by hand, and
+ * they do not count against the keep-N budget either, so "keep 10" means ten
+ * automatic restore points regardless of how many manual ones sit beside them.
+ */
+
+/** The reason recorded for a user-initiated backup. */
+export const MANUAL_REASON = "manual";
+
+/** True for a backup a person asked for, as opposed to one Palisade took itself. */
+export function isManualReason(reason: string): boolean {
+  return reason === MANUAL_REASON;
+}
+
+/**
+ * Snapshot directories are named `<reason>-<ISO stamp>`, and the replication target
+ * stores them as `<reason>-<ISO stamp>.tar.gz` — so the remote side can tell manual
+ * artifacts apart without consulting the database.
+ */
+export function isManualArtifact(fileName: string): boolean {
+  return fileName.startsWith(`${MANUAL_REASON}-`);
+}
+
+/**
+ * The timestamp portion of such a name, for ordering. Returns "" when the name
+ * doesn't parse, which sorts first — an unrecognised artifact is treated as oldest
+ * and so is pruned before anything we understand.
+ *
+ * Sorting matters remotely: artifact names begin with the reason, so a plain
+ * alphabetical sort groups by reason and would delete every `auto-stop-*` before any
+ * `scheduled-*`, no matter which was older.
+ */
+export function artifactTimestamp(fileName: string): string {
+  const base = fileName.replace(/\.tar\.gz$/, "");
+  const dash = base.indexOf("-");
+  return dash === -1 ? "" : base.slice(dash + 1);
+}
+
+/**
+ * The snapshots to delete so that only the newest `keep` AUTOMATIC ones survive.
+ * Manual snapshots are never returned. Input order doesn't matter.
+ */
+export function snapshotsToPrune<T extends { reason: string; createdAt: Date }>(
+  snapshots: readonly T[],
+  keep: number,
+): T[] {
+  const automatic = snapshots
+    .filter((s) => !isManualReason(s.reason))
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  return automatic.slice(Math.max(0, keep));
+}
+
+/**
+ * The remote artifact filenames to delete, same rule as above: manual artifacts are
+ * kept and excluded from the count, the rest are ordered oldest-first by their
+ * timestamp and trimmed to `keep`.
+ */
+export function artifactsToPrune(fileNames: readonly string[], keep: number): string[] {
+  const automatic = fileNames
+    .filter((f) => !isManualArtifact(f))
+    .sort((a, b) => artifactTimestamp(a).localeCompare(artifactTimestamp(b)));
+  return automatic.slice(0, Math.max(0, automatic.length - Math.max(0, keep)));
+}

--- a/apps/api/src/replication/replication.service.ts
+++ b/apps/api/src/replication/replication.service.ts
@@ -11,6 +11,7 @@ import { PrismaService } from "../prisma/prisma.service";
 import { EventsService } from "../events/events.service";
 import { ManagerSettingsService, SettingKeys } from "../manager-settings/manager-settings.service";
 import { loadEnv } from "../config/env";
+import { artifactsToPrune } from "../backups/retention";
 
 /** Off-box replication config — stored as one encrypted setting. */
 export interface ReplicationConfig {
@@ -179,9 +180,13 @@ export class ReplicationService implements OnModuleInit {
         await this.uploadTarGz(snap.path, dest, this.remoteJoin(config, serverId, artifact));
         uploaded++;
       }
-      // Remote retention mirrors local keep-N (manifest excluded from the count).
-      const artifacts = (await dest.list(dir)).filter((f) => f.endsWith(".tar.gz")).sort();
-      for (const stale of artifacts.slice(0, Math.max(0, artifacts.length - keep))) {
+      // Remote retention mirrors local keep-N (manifest excluded from the count) —
+      // including the manual exemption, or the copies we just protected locally
+      // would still be deleted off the target (GH #34). Ordering is by the artifact's
+      // timestamp, not its name: names start with the reason, so a plain sort would
+      // delete every "auto-stop-*" before any older "scheduled-*".
+      const artifacts = (await dest.list(dir)).filter((f) => f.endsWith(".tar.gz"));
+      for (const stale of artifactsToPrune(artifacts, keep)) {
         await dest.remove(this.remoteJoin(config, serverId, stale)).catch(() => undefined);
       }
     }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -306,7 +306,7 @@ export default function SettingsPage() {
           <div className="card space-y-4">
             <h2 className="text-sm font-semibold uppercase tracking-wide text-ark-accent2">Backups</h2>
             <div>
-              <label className="label">Keep last N backups (per server)</label>
+              <label className="label">Keep last N automatic backups (per server)</label>
               <input
                 type="number"
                 min={1}
@@ -316,8 +316,19 @@ export default function SettingsPage() {
                 onChange={(e) => setBackupKeep(e.target.value)}
               />
               <p className="mt-1 text-xs text-slate-500">
-                Older snapshots beyond this count are deleted automatically. Default 10. Each backup is
-                just the live world, players, and config (ARK&apos;s own dated copies + logs are skipped).
+                Applies to <span className="text-slate-400">automatic</span> backups only — scheduled
+                ones and the safety copies taken before an update, restart or restore. Older automatic
+                snapshots beyond this count are deleted. Anything up to 500 works here; 10 is just the
+                default, not a limit.
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                Backups you take yourself with the <span className="text-slate-400">Backup</span> button
+                are never deleted by retention and don&apos;t count towards this number — remove those
+                from the server&apos;s Backups tab when you no longer want them.
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                Each backup is just the live world, players, and config (ARK&apos;s own dated copies +
+                logs are skipped).
               </p>
             </div>
             <CardSave card="backups" onClick={saveBackups} />

--- a/apps/web/components/backups-tab.tsx
+++ b/apps/web/components/backups-tab.tsx
@@ -116,7 +116,17 @@ export function BackupsTab({ serverId }: { serverId: string }) {
                 <Archive className="h-5 w-5 text-ark-accent2" />
                 <div>
                   <div className="font-medium">{new Date(b.createdAt).toLocaleString()}</div>
-                  <div className="text-xs text-slate-500">{b.reason}</div>
+                  <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                    {b.reason}
+                    {b.reason === "manual" && (
+                      <span
+                        className="rounded bg-slate-700/60 px-1.5 py-0.5 text-[10px] text-slate-300"
+                        title="Backups you take yourself are never removed by retention — delete this one when you no longer want it."
+                      >
+                        kept
+                      </span>
+                    )}
+                  </div>
                 </div>
               </div>
               <div className="flex gap-2">


### PR DESCRIPTION
Addresses #34.

## Request 2 — manual backups deleted by retention (real bug, fixed)

`applyRetention` kept the newest N of *everything*, so a backup someone took by hand before a risky change was silently rotated out by the scheduled ones that followed it. `Snapshot.reason` already recorded who asked for each backup (`manual` vs `scheduled` / `pre-<action>` / `auto-stop`) — retention just ignored it.

Manual backups are now never pruned, and **don't count against the budget** either: "keep 10" means ten automatic restore points however many manual ones sit beside them, rather than manual backups starving the rotation. They're kept until deleted by hand from the Backups tab, where they now carry a `kept` badge.

**This had to reach the replication target too.** `syncSnapshots` mirrors local keep-N, so protecting manual backups locally while the remote copy still deleted them would have been a half fix. Its ordering is corrected while I was there: remote artifacts are named `<reason>-<stamp>`, so the old plain `.sort()` deleted every `auto-stop-*` before any older `scheduled-*`. Pruning now orders by the timestamp portion.

## Request 1 — "let me specify more than 10" (no cap exists)

There's nothing to raise. The field has accepted **1–500** since v1.0.0, in both the API (`@Min(1) @Max(500)`) and the settings input (`min={1} max={500}`), and I traced the save path end to end — values above 10 persist and reload correctly. **10 is only the default.**

So this is a discoverability problem, and the label earns it: *"Keep last N backups (per server)"*, prefilled with 10 and no range stated, reads like a ceiling. It now says **automatic**, states that anything up to 500 works and that 10 is the default rather than a limit, and explains the manual exemption.

## Design note

Manual backups exempt from retention accumulate until someone deletes them. That's exactly what was asked for, it matches the mental model that a manual backup is one you took deliberately, and Palisade already warns on low disk — so I chose an unconditional exemption over adding a toggle. Easy to make configurable later if anyone wants pruning back.

I deliberately did **not** extend the exemption to `pre-restore` / `pre-import`, even though those are arguably your undo for a destructive action. They're automatic, nobody asked, and silently keeping them forever would surprise people. Worth considering separately.

## Verification

- 432 tests pass (13 new) covering the exemption, the uncounted budget, input-order independence, `keep = 0`, under-limit, timestamp-vs-filename ordering, unparseable artifact names, and the prefix check that must not mistake `pre-manual-…` for a manual backup.
- **Checked end to end against a real database**: with one manual and three scheduled snapshots at `keep = 2`, the new code prunes only the oldest scheduled one, while the old newest-2-of-everything rule would have deleted the manual backup. Logged both for comparison.
- `pnpm typecheck` clean, full `pnpm build` clean.