### PR TITLE
Settings link never appeared for admins until a page reload

### DIFF
--- a/apps/web/lib/use-role.ts
+++ b/apps/web/lib/use-role.ts
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import type { Role } from "@ark/shared";
 import { getToken } from "./api";
+import { useAuth } from "./auth";
 
 /** Role from the stored JWT (display gating only — the API enforces for real).
  *  Legacy tokens without a role claim were single-admin installs. */
@@ -16,9 +17,22 @@ export function roleFromToken(): Role {
   }
 }
 
-/** SSR-safe hook: renders as viewer until mounted, then the token's role. */
+/**
+ * SSR-safe hook: renders as viewer until mounted, then the token's role.
+ *
+ * Re-derived whenever the auth token changes, NOT once on mount. AppHeader lives in
+ * the layout and mounts a single time — on /login, before there is a token — so a
+ * mount-only read left every freshly logged-in admin sitting at role "viewer" until
+ * they happened to reload the page. Since /login renders no nav, the visible symptom
+ * was the Settings link simply missing for admins, while Servers and Clusters (gated
+ * on the token, which does update) were there.
+ *
+ * Keying off the token also covers logging out and back in as a different user, where
+ * the previous session's role would otherwise persist.
+ */
 export function useRole(): Role {
   const [role, setRole] = useState<Role>("viewer");
-  useEffect(() => setRole(roleFromToken()), []);
+  const { token } = useAuth();
+  useEffect(() => setRole(roleFromToken()), [token]);
   return role;
 }


### PR DESCRIPTION
Found while investigating #34: an admin logs in and the **Settings** link is missing from the header, so there is no route to backup retention, user management, integrations or notifications. Pressing reload makes it appear.

## Cause

`useRole` read the token **once on mount**, with an empty dependency array:

```ts
const [role, setRole] = useState<Role>("viewer");
useEffect(() => setRole(roleFromToken()), []);
```

`AppHeader` lives in the layout and mounts a single time — on `/login`, before there is a token. It returns `null` for that route, but its hooks still run, so `roleFromToken()` found nothing and returned `"viewer"`. Logging in is a client-side route change: the header re-renders with a token, but that effect never re-runs, so `role` stays `"viewer"` for the life of the page.

Servers and Clusters are gated on `token` (which updates through context), so they render normally. Only Settings is gated on `role`. Hence the confusing shape of it — a user whose JWT plainly says `role: "admin"` with no Settings link.

Broken since **v1.2.0** (2026-07-09), when the role gate was added. Every admin has been affected on every fresh login since.

## Fix

Derive the role from the auth token rather than sampling it once. Also fixes logging out and back in as a different user, where the previous session's role would otherwise persist.

## Verification

Reproduced and fixed against a **production build** (`next build` + `next start`, not dev), driving the real login form rather than injecting a token — injecting one and reloading is what hid this from me at first, since that mounts the header with a token already present.

| | Header links | Token role |
|---|---|---|
| Before, after form login | `Palisade, Servers, Clusters` | `admin` |
| Before, after pressing reload | `Palisade, Servers, Clusters, Settings` | `admin` |
| After this fix, form login, no reload | `Palisade, Servers, Clusters, Settings` | `admin` |

419 tests pass, `pnpm typecheck` clean.

Worth noting this very likely explains #34's first request: the reporter asked to raise a retention limit that isn't a limit — plausibly because they could never reach the Settings page to see the field at all.