### PR TITLE
Backup retention is per server; the global setting now covers Palisade's own

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,12 @@ player administration, and even your router's port-forwards.
 - Live player counts for every game (A2S / RakNet ping / RCON / Valheim status
   endpoint) with 1-hour sparklines, plus a **Players** roster captured from
   player lists and join logs — kick / ban / whitelist / admin per game.
-- Backups: manual + scheduled with retention, restore, browser download, and
-  saves import. Retention (default 10, up to 500) rotates only the **automatic**
-  snapshots — scheduled ones and the safety copies taken before an update, restart
-  or restore. Backups you take yourself are kept until you delete them, on the
-  replication target too. The manager also snapshots its own database nightly.
+- Backups: manual + scheduled with restore, browser download, and saves import.
+  **Retention is set per server** (on its Backups tab; default 10, up to 500) and
+  rotates only the **automatic** snapshots — scheduled ones and the safety copies
+  taken before an update, restart or restore. Backups you take yourself are kept
+  until you delete them, on the replication target too. The manager also snapshots
+  its own database nightly, with its own retention in Settings → Backups.
 - Schedules (restart / update / backup / stop / start) with in-game countdown
   warnings, pre-action snapshots, and a "skip while players are online" guard.
 - **Version pinning** from registry-populated dropdowns: pin the **game version /
@@ -237,8 +238,8 @@ Everything lives under your data dir — one directory to back up:
 /data
 ├── db.sqlite            # server definitions, schedules, players, settings
 ├── instances/<id>/      # each server's game files + world saves
-├── backups/<id>/        # world snapshots (automatic ones retention-rotated)
-├── backups/_manager/    # nightly self-backups of db.sqlite (newest 14)
+├── backups/<id>/        # world snapshots (automatic ones rotated per server)
+├── backups/_manager/    # nightly self-backups of db.sqlite (retention in Settings)
 └── clusters/<id>/       # ARK cluster transfer dirs
 ```
 

--- a/apps/api/prisma/migrations/20260829000000_per_server_backup_keep/migration.sql
+++ b/apps/api/prisma/migrations/20260829000000_per_server_backup_keep/migration.sql
@@ -1,0 +1,14 @@
+-- Per-server backup retention. Null = the built-in default.
+ALTER TABLE "Server" ADD COLUMN "backupKeep" INTEGER;
+
+-- Carry the old GLOBAL retention onto every existing server so nobody's effective
+-- retention changes on upgrade. The global "backup_keep" setting is repurposed to
+-- Palisade's own database backups, and is no longer read for game servers.
+UPDATE "Server"
+SET "backupKeep" = (
+  SELECT CAST("value" AS INTEGER) FROM "ManagerSetting" WHERE "key" = 'backup_keep'
+)
+WHERE EXISTS (
+  SELECT 1 FROM "ManagerSetting"
+  WHERE "key" = 'backup_keep' AND CAST("value" AS INTEGER) >= 1
+);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -91,6 +91,11 @@ model Server {
   configDirty      Boolean @default(false)
   ramLimitMb       Int?
   cpuLimit         Float?
+  // How many AUTOMATIC backups to keep for this server (newest N). Null = the
+  // built-in default. Retention is per-server because servers differ wildly in
+  // save size and how much history is worth keeping; the global setting now
+  // governs Palisade's own database backups instead.
+  backupKeep       Int?
   // User-defined extra environment variables injected into the game container.
   // ENCRYPTED at rest (AES-256-GCM via SECRETS_KEY), like the password columns:
   // the headline use case for this feature is pinning a Palworld build, which

--- a/apps/api/src/backups/backups.service.ts
+++ b/apps/api/src/backups/backups.service.ts
@@ -8,7 +8,7 @@ import { ServerState, EventType, Game } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { EventsService } from "../events/events.service";
 import { RconService } from "../rcon/rcon.service";
-import { ManagerSettingsService } from "../manager-settings/manager-settings.service";
+import { ManagerSettingsService, DEFAULT_BACKUP_KEEP } from "../manager-settings/manager-settings.service";
 import { LocalPaths } from "../common/paths";
 import { snapshotsToPrune } from "./retention";
 import { extractTarGzSafe } from "../common/safe-extract";
@@ -291,13 +291,14 @@ export class BackupsService {
   }
 
   /**
-   * Keep the newest N AUTOMATIC backups per server (N from settings); delete the
-   * rest. Manual backups are exempt and uncounted — a backup someone took on
+   * Keep the newest N AUTOMATIC backups for this server (N from the server's own
+   * backupKeep, else the built-in default); delete the rest. Manual backups are exempt and uncounted — a backup someone took on
    * purpose shouldn't be rotated away by the scheduled ones that follow it, and
    * "keep 10" should still mean ten automatic restore points (GH #34).
    */
   private async applyRetention(serverId: string): Promise<void> {
-    const keep = await this.settings.getBackupKeep();
+    const server = await this.prisma.server.findUnique({ where: { id: serverId } });
+    const keep = server?.backupKeep ?? DEFAULT_BACKUP_KEEP;
     const all = await this.prisma.snapshot.findMany({ where: { serverId } });
     for (const old of snapshotsToPrune(all, keep)) {
       await rm(old.path, { recursive: true, force: true }).catch(() => undefined);

--- a/apps/api/src/backups/retention.test.ts
+++ b/apps/api/src/backups/retention.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { DEFAULT_BACKUP_KEEP, DEFAULT_MANAGER_BACKUP_KEEP } from "../manager-settings/manager-settings.service";
 import {
   artifactTimestamp,
   artifactsToPrune,
@@ -113,5 +114,40 @@ describe("artifactsToPrune (replication target)", () => {
 
   it("prunes nothing when under the limit", () => {
     expect(artifactsToPrune(["scheduled-2026-06-01T00-00-00-000Z.tar.gz"], 10)).toEqual([]);
+  });
+});
+
+// Retention became PER SERVER: save sizes and useful history differ too much between
+// games for one global number, and the global setting now governs Palisade's own
+// database snapshots instead.
+describe("per-server keep resolution", () => {
+  const resolve = (backupKeep: number | null) => backupKeep ?? DEFAULT_BACKUP_KEEP;
+
+  it("uses the server's own value when set", () => {
+    expect(resolve(25)).toBe(25);
+  });
+
+  it("falls back to the built-in default when the server sets none", () => {
+    expect(resolve(null)).toBe(DEFAULT_BACKUP_KEEP);
+    expect(DEFAULT_BACKUP_KEEP).toBe(10);
+  });
+
+  it("keeps a per-server value independent of the manager-backup default", () => {
+    // The two numbers are unrelated now; a shared constant would re-couple them.
+    expect(DEFAULT_MANAGER_BACKUP_KEEP).toBe(14);
+    expect(DEFAULT_MANAGER_BACKUP_KEEP).not.toBe(DEFAULT_BACKUP_KEEP);
+  });
+
+  it("prunes to the server's own depth, manual backups still exempt", () => {
+    const snaps = [
+      snap("m", "manual", "2026-01-01T00:00:00Z"),
+      snap("a", "scheduled", "2026-06-01T00:00:00Z"),
+      snap("b", "scheduled", "2026-06-02T00:00:00Z"),
+      snap("c", "scheduled", "2026-06-03T00:00:00Z"),
+    ];
+    // A server that asked for 1 keeps one automatic backup; a server that asked for
+    // 3 keeps all three. Neither touches the manual one.
+    expect(snapshotsToPrune(snaps, resolve(1)).map((s) => s.id)).toEqual(["b", "a"]);
+    expect(snapshotsToPrune(snaps, resolve(3))).toEqual([]);
   });
 });

--- a/apps/api/src/dbbackup/dbbackup.service.ts
+++ b/apps/api/src/dbbackup/dbbackup.service.ts
@@ -12,7 +12,8 @@ import { ManagerSettingsService } from "../manager-settings/manager-settings.ser
 const execFileP = promisify(execFile);
 
 /** Newest N manager-DB snapshots kept (one per day → two weeks of history). */
-const KEEP = 14;
+// Retention is configurable (Settings -> Backups). This constant is gone; see
+// ManagerSettingsService.getManagerBackupKeep().
 
 /**
  * Self-backup of the manager's own SQLite DB (server definitions, schedules,
@@ -92,10 +93,11 @@ export class DbBackupService implements OnModuleInit {
     }
   }
 
-  /** Keep the newest KEEP snapshots (a snapshot = db-*.sqlite plus its sidecars). */
+  /** Keep the newest N snapshots (a snapshot = db-*.sqlite plus its sidecars). */
   private async prune(dir: string): Promise<void> {
+    const keep = await this.settings.getManagerBackupKeep();
     const entries = (await readdir(dir)).filter((f) => /^db-.*\.sqlite$/.test(f)).sort();
-    for (const stale of entries.slice(0, Math.max(0, entries.length - KEEP))) {
+    for (const stale of entries.slice(0, Math.max(0, entries.length - keep))) {
       await rm(join(dir, stale), { force: true });
       await rm(join(dir, `${stale}-wal`), { force: true }).catch(() => undefined);
       await rm(join(dir, `${stale}-shm`), { force: true }).catch(() => undefined);

--- a/apps/api/src/manager-settings/manager-settings.controller.ts
+++ b/apps/api/src/manager-settings/manager-settings.controller.ts
@@ -10,7 +10,8 @@ class UpdateSettingsBody {
   @IsOptional() @IsString() curseForgeApiKey?: string;
   @IsOptional() @IsString() steamWebApiKey?: string;
   @IsOptional() @IsString() steamGridDbApiKey?: string;
-  @IsOptional() @IsInt() @Min(1) @Max(500) backupKeep?: number;
+  /** Palisade's own database snapshots. Game-server retention is per-server. */
+  @IsOptional() @IsInt() @Min(1) @Max(500) managerBackupKeep?: number;
   @IsOptional() @IsBoolean() autoStopOnStart?: boolean;
   @IsOptional() @IsString() pfsenseHost?: string;
   @IsOptional() @IsString() pfsenseApiKey?: string;
@@ -49,8 +50,8 @@ export class ManagerSettingsController {
       await this.settings.set(SettingKeys.SteamWebApiKey, body.steamWebApiKey);
     if (body.steamGridDbApiKey)
       await this.settings.set(SettingKeys.SteamGridDbApiKey, body.steamGridDbApiKey);
-    if (body.backupKeep !== undefined)
-      await this.settings.set(SettingKeys.BackupKeep, String(body.backupKeep));
+    if (body.managerBackupKeep !== undefined)
+      await this.settings.set(SettingKeys.ManagerBackupKeep, String(body.managerBackupKeep));
     if (body.autoStopOnStart !== undefined)
       await this.settings.set(SettingKeys.AutoStopOnStart, String(body.autoStopOnStart));
     if (body.pfsenseHost !== undefined) await this.settings.set(SettingKeys.PfsenseHost, body.pfsenseHost);

--- a/apps/api/src/manager-settings/manager-settings.service.ts
+++ b/apps/api/src/manager-settings/manager-settings.service.ts
@@ -14,7 +14,10 @@ export const SettingKeys = {
   BackupReplicationStatus: "backup_replication_status", // non-secret sync status JSON
   SteamGridDbApiKey: "steamgriddb_api_key", // secret
   ArtworkCache: "artwork_cache", // non-secret JSON: per-game SGDB art URLs
-  BackupKeep: "backup_keep",
+  // Palisade's OWN database backups (backups/_manager). Game-server retention is
+  // per-server (Server.backupKeep) — the legacy "backup_keep" row is migrated onto
+  // each server and no longer read.
+  ManagerBackupKeep: "manager_backup_keep",
   AutoStopOnStart: "auto_stop_on_start",
   // pfSense REST API (jaredhendrickson13 package) for one-click port-forwards.
   PfsenseHost: "pfsense_host",
@@ -23,8 +26,13 @@ export const SettingKeys = {
   Initialized: "initialized",
 } as const;
 
-/** Default number of backups kept per server (newest N) when unset. */
+/** Default number of AUTOMATIC backups kept per game server (newest N) when the
+ *  server doesn't set its own. Manual backups are exempt entirely (GH #34). */
 export const DEFAULT_BACKUP_KEEP = 10;
+
+/** Default number of Palisade database snapshots kept (newest N). Matches the
+ *  count this was hardcoded to before it became configurable. */
+export const DEFAULT_MANAGER_BACKUP_KEEP = 14;
 
 const SECRET_KEYS = new Set<string>([
   SettingKeys.CurseForgeApiKey,
@@ -61,10 +69,11 @@ export class ManagerSettingsService {
     return (await this.get(SettingKeys.Timezone)) || DEFAULT_TIMEZONE;
   }
 
-  /** How many backups to keep per server (newest N). Clamped to a sane floor. */
-  async getBackupKeep(): Promise<number> {
-    const n = parseInt((await this.get(SettingKeys.BackupKeep)) ?? "", 10);
-    return Number.isFinite(n) && n >= 1 ? n : DEFAULT_BACKUP_KEEP;
+  /** How many of Palisade's own database snapshots to keep (newest N). Clamped to
+   *  a sane floor. Game-server retention lives on each server. */
+  async getManagerBackupKeep(): Promise<number> {
+    const n = parseInt((await this.get(SettingKeys.ManagerBackupKeep)) ?? "", 10);
+    return Number.isFinite(n) && n >= 1 ? n : DEFAULT_MANAGER_BACKUP_KEEP;
   }
 
   /** Whether starting a server may offer to back up + stop a running one to free

--- a/apps/api/src/replication/replication.service.ts
+++ b/apps/api/src/replication/replication.service.ts
@@ -12,6 +12,7 @@ import { EventsService } from "../events/events.service";
 import { ManagerSettingsService, SettingKeys } from "../manager-settings/manager-settings.service";
 import { loadEnv } from "../config/env";
 import { artifactsToPrune } from "../backups/retention";
+import { DEFAULT_BACKUP_KEEP } from "../manager-settings/manager-settings.service";
 
 /** Off-box replication config — stored as one encrypted setting. */
 export interface ReplicationConfig {
@@ -151,7 +152,6 @@ export class ReplicationService implements OnModuleInit {
   }
 
   private async syncSnapshots(config: ReplicationConfig, dest: Destination): Promise<number> {
-    const keep = await this.settings.getBackupKeep();
     const snapshots = await this.prisma.snapshot.findMany({ include: { server: true } });
     const byServer = new Map<string, typeof snapshots>();
     for (const s of snapshots) {
@@ -185,6 +185,9 @@ export class ReplicationService implements OnModuleInit {
       // would still be deleted off the target (GH #34). Ordering is by the artifact's
       // timestamp, not its name: names start with the reason, so a plain sort would
       // delete every "auto-stop-*" before any older "scheduled-*".
+      // Retention is the SERVER's own (GH #34 follow-up) — mirroring a single global
+      // number would prune a target back to the wrong depth for every server.
+      const keep = server.backupKeep ?? DEFAULT_BACKUP_KEEP;
       const artifacts = (await dest.list(dir)).filter((f) => f.endsWith(".tar.gz"));
       for (const stale of artifactsToPrune(artifacts, keep)) {
         await dest.remove(this.remoteJoin(config, serverId, stale)).catch(() => undefined);

--- a/apps/api/src/servers/servers.dto.ts
+++ b/apps/api/src/servers/servers.dto.ts
@@ -8,7 +8,9 @@ import {
   IsOptional,
   IsString,
   Matches,
+  Max,
   Min,
+  ValidateIf,
   ValidateNested,
   ArrayMaxSize,
 } from "class-validator";
@@ -70,6 +72,8 @@ export class UpdateServerBody {
   @IsOptional() @IsObject() config?: Record<string, unknown>;
   /** Advanced: pin the game image to a specific tag (null clears the pin). */
   @IsOptional() @ImageTagField() imageTag?: string | null;
+  /** Automatic-backup retention for this server; null clears it back to the default. */
+  @IsOptional() @ValidateIf((_o, v) => v !== null) @IsInt() @Min(1) @Max(500) backupKeep?: number | null;
 }
 
 /**

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -810,6 +810,9 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       data.configJson = JSON.stringify(merged);
       launchChanged = true; // settings feed the generated INI / command line
     }
+    // Retention is not a launch parameter — it changes what the next backup prunes,
+    // so no restart is needed.
+    if (dto.backupKeep !== undefined) data.backupKeep = dto.backupKeep;
     if (launchChanged) data.configDirty = true; // → UI shows the Restart button
 
     const updated = await this.prisma.server.update({
@@ -1987,6 +1990,7 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       modIds: JSON.parse(row.modIds) as number[],
       ramLimitMb: row.ramLimitMb,
       cpuLimit: row.cpuLimit,
+      backupKeep: row.backupKeep,
       // Names only. Values are secrets (Steam credentials, API keys) and are
       // readable solely through the admin-gated extra-env endpoint.
       extraEnvKeys: this.readExtraEnv(row.extraEnvEnc).map((e) => e.key),

--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -369,7 +369,7 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
       {tab === "Logs" && <LogsTab serverId={id} />}
       {tab === "Files" && <FilesTab serverId={id} />}
       {tab === "Schedules" && <ScheduleList serverId={id} />}
-      {tab === "Backups" && <BackupsTab serverId={id} />}
+      {tab === "Backups" && <BackupsTab serverId={id} server={server} onChanged={refresh} />}
       {tab === "Guide" && <GuideTab game={server.game} />}
     </div>
   );

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -19,7 +19,7 @@ export default function SettingsPage() {
   const [steamWebApiKey, setSteamWebApiKey] = useState("");
   const [steamGridDbApiKey, setSteamGridDbApiKey] = useState("");
   const [artMsg, setArtMsg] = useState<string | null>(null);
-  const [backupKeep, setBackupKeep] = useState("10");
+  const [managerBackupKeep, setManagerBackupKeep] = useState("14");
   const [autoStop, setAutoStop] = useState(true);
   const [pfsenseHost, setPfsenseHost] = useState("");
   const [pfsenseApiKey, setPfsenseApiKey] = useState("");
@@ -36,7 +36,8 @@ export default function SettingsPage() {
         // Pre-select the user's detected zone when nothing is saved yet, so they
         // rarely have to touch it.
         setTimezone(typeof v.timezone === "string" && v.timezone ? v.timezone : detectZone());
-        if (typeof v.backup_keep === "string" && v.backup_keep) setBackupKeep(v.backup_keep);
+        if (typeof v.manager_backup_keep === "string" && v.manager_backup_keep)
+          setManagerBackupKeep(v.manager_backup_keep);
         setAutoStop(v.auto_stop_on_start !== "false"); // default on when unset
         if (typeof v.pfsense_host === "string") setPfsenseHost(v.pfsense_host);
         if (typeof v.pfsense_target_ip === "string") setPfsenseTargetIp(v.pfsense_target_ip);
@@ -100,9 +101,9 @@ export default function SettingsPage() {
   };
 
   const saveBackups = () => {
-    const keep = parseInt(backupKeep, 10);
+    const keep = parseInt(managerBackupKeep, 10);
     if (!Number.isFinite(keep) || keep < 1) return alert("Keep count must be a number ≥ 1.");
-    void saveCard("backups", { backupKeep: keep });
+    void saveCard("backups", { managerBackupKeep: keep });
   };
 
   const saveGeneral = () => void saveCard("general", timezone ? { timezone } : {});
@@ -306,29 +307,24 @@ export default function SettingsPage() {
           <div className="card space-y-4">
             <h2 className="text-sm font-semibold uppercase tracking-wide text-ark-accent2">Backups</h2>
             <div>
-              <label className="label">Keep last N automatic backups (per server)</label>
+              <label className="label">Keep last N Palisade database backups</label>
               <input
                 type="number"
                 min={1}
                 max={500}
                 className="input w-32"
-                value={backupKeep}
-                onChange={(e) => setBackupKeep(e.target.value)}
+                value={managerBackupKeep}
+                onChange={(e) => setManagerBackupKeep(e.target.value)}
               />
               <p className="mt-1 text-xs text-slate-500">
-                Applies to <span className="text-slate-400">automatic</span> backups only — scheduled
-                ones and the safety copies taken before an update, restart or restore. Older automatic
-                snapshots beyond this count are deleted. Anything up to 500 works here; 10 is just the
-                default, not a limit.
+                Palisade snapshots its own database (servers, settings, schedules, players)
+                nightly into <span className="font-mono">backups/_manager</span>. This is how many
+                of those to keep. Default 14; anything from 1 to 500 works.
               </p>
               <p className="mt-1 text-xs text-slate-500">
-                Backups you take yourself with the <span className="text-slate-400">Backup</span> button
-                are never deleted by retention and don&apos;t count towards this number — remove those
-                from the server&apos;s Backups tab when you no longer want them.
-              </p>
-              <p className="mt-1 text-xs text-slate-500">
-                Each backup is just the live world, players, and config (ARK&apos;s own dated copies +
-                logs are skipped).
+                <span className="text-slate-400">Game-server backups are configured per server</span>
+                , on each server&apos;s Backups tab — save sizes and useful history differ too much
+                between games for one number. Backups you take by hand are never rotated away.
               </p>
             </div>
             <CardSave card="backups" onClick={saveBackups} />

--- a/apps/web/components/backups-tab.tsx
+++ b/apps/web/components/backups-tab.tsx
@@ -1,7 +1,12 @@
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Archive, DatabaseBackup, Download, RotateCcw, Trash2, Upload, Loader2 } from "lucide-react";
-import { apiDelete, apiDownload, apiGet, apiPost, apiUpload } from "@/lib/api";
+import { apiDelete, apiDownload, apiGet, apiPatch, apiPost, apiUpload } from "@/lib/api";
+import type { ServerSummary } from "@ark/shared";
+
+/** Matches the API's own bound and the built-in default when a server sets none. */
+const KEEP_MAX = 500;
+const KEEP_DEFAULT = 10;
 
 interface Snapshot {
   id: string;
@@ -10,8 +15,21 @@ interface Snapshot {
   createdAt: string;
 }
 
-export function BackupsTab({ serverId }: { serverId: string }) {
+export function BackupsTab({
+  serverId,
+  server,
+  onChanged,
+}: {
+  serverId: string;
+  server: ServerSummary;
+  onChanged: () => void;
+}) {
   const [backups, setBackups] = useState<Snapshot[]>([]);
+  // "" means "use the default" — retention is per-server (the global setting now
+  // governs Palisade's own database backups).
+  const [keep, setKeep] = useState<string>(server.backupKeep == null ? "" : String(server.backupKeep));
+  const [savingKeep, setSavingKeep] = useState(false);
+  const [keepSaved, setKeepSaved] = useState(false);
   const [busy, setBusy] = useState(false);
   const [downloading, setDownloading] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -21,6 +39,25 @@ export function BackupsTab({ serverId }: { serverId: string }) {
     apiGet<Snapshot[]>(`/servers/${serverId}/backups`).then(setBackups).catch(() => undefined);
   }, [serverId]);
   useEffect(() => refresh(), [refresh]);
+  useEffect(() => setKeep(server.backupKeep == null ? "" : String(server.backupKeep)), [server.backupKeep]);
+
+  const keepDirty = (server.backupKeep == null ? "" : String(server.backupKeep)) !== keep.trim();
+  const keepValid =
+    keep.trim() === "" || (Number.isInteger(Number(keep)) && Number(keep) >= 1 && Number(keep) <= KEEP_MAX);
+
+  const saveKeep = async () => {
+    setSavingKeep(true);
+    try {
+      await apiPatch(`/servers/${serverId}`, { backupKeep: keep.trim() === "" ? null : Number(keep) });
+      setKeepSaved(true);
+      setTimeout(() => setKeepSaved(false), 1500);
+      onChanged();
+    } catch (err) {
+      alert((err as Error).message);
+    } finally {
+      setSavingKeep(false);
+    }
+  };
 
   const create = async () => {
     setBusy(true);
@@ -78,8 +115,8 @@ export function BackupsTab({ serverId }: { serverId: string }) {
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="text-sm text-slate-400">
-          Backups copy the saved world. The newest 10 are kept; scheduled/disruptive actions
-          snapshot automatically.
+          Backups copy the saved world. Scheduled and disruptive actions snapshot
+          automatically; backups you take here are kept until you delete them.
         </p>
         <div className="flex gap-2">
           <button className="btn-secondary" onClick={() => uploadInput.current?.click()} disabled={uploading}>
@@ -101,6 +138,37 @@ export function BackupsTab({ serverId }: { serverId: string }) {
             <DatabaseBackup className="h-4 w-4" /> {busy ? "Backing up…" : "Back up now"}
           </button>
         </div>
+      </div>
+
+      {/* Retention is per-server: save sizes and how much history is worth keeping
+          differ wildly between games. The global setting covers Palisade's own
+          database backups instead. */}
+      <div className="card flex flex-wrap items-center gap-3">
+        <label className="text-sm text-slate-300" htmlFor="backup-keep">
+          Keep last
+        </label>
+        <input
+          id="backup-keep"
+          type="number"
+          min={1}
+          max={KEEP_MAX}
+          placeholder={`${KEEP_DEFAULT}`}
+          className={`input w-24 ${keepValid ? "" : "border-rose-500/60"}`}
+          value={keep}
+          onChange={(e) => setKeep(e.target.value)}
+        />
+        <span className="text-sm text-slate-300">automatic backups for this server</span>
+        {keepDirty && (
+          <button className="btn-primary text-xs" disabled={!keepValid || savingKeep} onClick={() => void saveKeep()}>
+            {savingKeep ? "Saving…" : "Save"}
+          </button>
+        )}
+        {keepSaved && <span className="text-xs text-emerald-400">Saved</span>}
+        <p className="w-full text-[11px] leading-snug text-slate-500">
+          Leave blank for the default ({KEEP_DEFAULT}). Anything from 1 to {KEEP_MAX} works. Only
+          automatic backups are counted and rotated — the ones you take with{" "}
+          <span className="text-slate-400">Back up now</span> are never removed by retention.
+        </p>
       </div>
 
       {backups.length === 0 ? (

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -51,6 +51,9 @@ export interface ServerSummary {
   modIds: number[];
   ramLimitMb?: number | null;
   cpuLimit?: number | null;
+  /** How many AUTOMATIC backups to keep for this server. Null = the built-in
+   *  default. Manual backups are exempt and uncounted (GH #34). */
+  backupKeep?: number | null;
   /** NAMES of the user-defined env vars injected into the game container at start.
    *  Values are deliberately absent: they routinely hold credentials (Steam login
    *  for a pinned build), and this summary is readable by every role. Read them
@@ -177,6 +180,8 @@ export interface CreateServerDto {
   /** Advanced: pin the game image to a specific tag instead of the shipped default
    *  (null clears the pin). Applied on the next start (pull + recreate). */
   imageTag?: string | null;
+  /** How many automatic backups to keep for this server (null = default). */
+  backupKeep?: number | null;
 }
 
 export type UpdateServerDto = Partial<CreateServerDto> & {


### PR DESCRIPTION
Follow-up to #34. One retention number for every server never fitted — a Palworld save is a few hundred MB and an ARK one is gigabytes, and how much history is worth keeping differs just as much.

## What changes

- **Each server has its own retention**, set on its **Backups tab** — where the backups actually are, and where people look for the setting. Blank means the built-in default (10); 1–500 accepted.
- **Settings → Backups now governs Palisade's own database snapshots** (`backups/_manager`), which were previously pinned to a hardcoded `KEEP = 14` with no way to change them.
- The existing #34 behaviour is unchanged: only **automatic** backups are rotated, and manual ones are exempt and uncounted.

## Nobody's retention changes on upgrade

This is the part worth scrutinising, since getting it wrong deletes people's backups.

- The migration **copies the old global value onto every existing server**, so effective behaviour is identical after upgrading.
- The manager-backup count moves to its **own key** (`manager_backup_keep`, default 14) rather than inheriting the old `backup_keep` value — otherwise someone who had set 3 would silently drop from 14 database snapshots to 3.

Verified against a synthetic pre-migration database: a global of `25` lands on both servers; a missing row or a non-numeric value leaves `backupKeep` null (the built-in default) rather than writing garbage.

## Replication

`syncSnapshots` mirrored the single global depth to the target. Left alone it would now prune every server's remote copies to the wrong number, so it reads each server's own value.

## Notes

- Changing retention does **not** flag `configDirty` or ask for a restart — it isn't a launch parameter, it only affects what the next backup prunes.
- The tab's old copy said "The newest 10 are kept", which was hardcoded and already wrong once retention became configurable. It now shows the live value.
- **Trade-off worth flagging:** with the global field repurposed, there's no longer a way to set a default for *all* servers at once — someone running twenty servers who wants 25 everywhere must set it twenty times. Easy to add a "default for new servers" later if that bites; I didn't add it now since it would reintroduce the ambiguity of a global number that servers may or may not follow.

## Verification

- 436 tests pass (4 new covering per-server resolution, the fallback, and that the two defaults stay independent).
- Migration tested directly against a hand-built pre-migration SQLite for all three cases above.
- Exercised end to end on a running instance: `backupKeep` defaults to null, accepts 25, clears back to null, rejects 600 with HTTP 400 — and a save driven through the **real UI** persisted as 30.
- `pnpm typecheck` clean, full `pnpm build` clean.