### PR TITLE
Rename the shared network to palisade-net, and migrate installs onto it

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ manager injects config, watches logs, and talks RCON/telnet/query protocols.
 
 - Docker on a Linux host (Unraid, Debian/Ubuntu, etc.). 16 GB+ RAM recommended —
   a single populated game server wants 2–16 GB depending on the game.
-- A Docker bridge network, `ark-net` — the manager and the game containers it
+- A Docker bridge network, `palisade-net` — the manager and the game containers it
   spawns share it (unless you use host networking). **Palisade creates it on
   demand and attaches itself to it**, so there is normally nothing to do — including
   when the manager runs on an Unraid custom/macvlan network, where it keeps its own
@@ -135,9 +135,13 @@ manager injects config, watches logs, and talks RCON/telnet/query protocols.
   with `NETWORKS=0` can neither create networks nor attach to them):
 
   ```bash
-  docker network create ark-net
-  docker network connect ark-net <your Palisade container>
+  docker network create palisade-net
+  docker network connect palisade-net <your Palisade container>
   ```
+
+  Installs from before v1.11 use `ark-net`. Nothing to do: each server moves across
+  the next time you start it, and Palisade holds both networks until they all have.
+  See [Moving off `ark-net`](#moving-off-ark-net).
 
 - Two secrets (generate once, keep safe — `SECRETS_KEY` encrypts stored API
   keys/passwords, so losing it means re-entering them):
@@ -161,7 +165,7 @@ Palisade is in [Community Applications](https://ca.unraid.net): open the
 **Apps** tab, search for **Palisade**, and install. The template pre-fills
 everything except your two secrets (`SECRETS_KEY`, `JWT_SECRET` — generators
 above) and the app-data path. The prerequisites above still apply: create the
-`ark-net` network and set the `vm.max_map_count` sysctl once.
+`palisade-net` network and set the `vm.max_map_count` sysctl once.
 
 Two Unraid-specific notes baked into the template:
 - Use a path on the cache disk itself (`/mnt/cache/appdata/...`), **not**
@@ -178,7 +182,7 @@ Two Unraid-specific notes baked into the template:
 ```bash
 docker run -d \
   --name palisade \
-  --network ark-net \
+  --network palisade-net \
   --restart unless-stopped \
   -p 8970:3000 \
   -v /opt/palisade:/data \
@@ -221,7 +225,8 @@ docker compose up -d
 | `DATABASE_URL` | no | `file:./data/db.sqlite` | SQLite path — keep it inside `DATA_DIR`. |
 | `PUBLIC_BASE_URL` | no | `http://localhost:3000` | The address you actually browse to. Used for links and Unraid WebUI buttons. |
 | `GAME_HOST_NETWORK` | no | `false` | `true` = game containers use host networking (recommended — ASA/EOS and Steam query behave better without Docker NAT). Requires the `--add-host host.docker.internal:host-gateway` flag on the manager so it can still reach RCON/query. |
-| `AUTO_CREATE_NETWORK` | no | `true` | Let Palisade manage `ark-net`: create it when a game server needs it, and attach itself to it when it isn't already (added live — existing networks and a static IP are kept). Set `false` to manage Docker networks yourself. |
+| `AUTO_CREATE_NETWORK` | no | `true` | Let Palisade manage its bridge: create it when a game server needs it, attach itself to it when it isn't already (added live — existing networks and a static IP are kept), and drop the legacy `ark-net` once nothing uses it. Set `false` to manage Docker networks yourself. |
+| `SHARED_NETWORK` | no | `palisade-net` | Name of that bridge. The default is chosen so Unraid resolves the manager's WebUI link correctly on a custom network (see [Moving off `ark-net`](#moving-off-ark-net)); change it only if you manage the network yourself. |
 | `DOCKER_HOST` | no | unix socket | Point at `tcp://socket-proxy:2375` for least-privilege Docker access ([docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy)). |
 | `PUID` / `PGID` | no | `99` / `100` | Ownership for game files written by the manager (Unraid's `nobody:users` by default). |
 | `TZ` | no | `UTC` | Manager clock; also the default for game containers and schedules (overridable in Settings). |
@@ -286,16 +291,34 @@ up as "no players" rather than an obvious error.
 Palisade works out how to reach each container from the container itself — its IP on
 a network you share, the host gateway when it uses host networking or publishes the
 port — so this only bites when none of those apply. The usual cause is the manager
-not being attached to `ark-net` while game servers are. Check `GET /api/health`: it
-reports a warning naming this exact condition. To fix:
+not being attached to `palisade-net` while game servers are. Check `GET /api/health`:
+it reports a warning naming this exact condition. To fix:
 
 ```bash
-docker network connect ark-net <manager container>
+docker network connect palisade-net <manager container>
 ```
 
-On Unraid, make sure the Palisade container's **Network Type** is `ark-net` (the
-template sets it, but it's easy to change). If you use `GAME_HOST_NETWORK=true`,
+On Unraid, make sure the Palisade container's **Network Type** is `palisade-net`
+(the template sets it, but it's easy to change). If you use `GAME_HOST_NETWORK=true`,
 the manager instead needs `--add-host host.docker.internal:host-gateway`.
+
+### Moving off `ark-net`
+
+The shared bridge was called `ark-net` before v1.11. The rename is not cosmetic: on
+Unraid, a container's WebUI link is built from the **first** of its networks sorted by
+name, so as soon as Palisade attached itself to `ark-net` it sorted ahead of `br0` and
+the button on a custom/macvlan install started pointing at the bridge IP instead of the
+LAN one. `palisade-net` sorts after `br0`, `bond0` and `eth0`, so the link stays right.
+
+It migrates itself, and a half-migrated install works throughout:
+
+- New servers are created on `palisade-net`. Existing ones move the next time you
+  start them — Palisade recreates the container on every start anyway.
+- The manager holds **both** networks until the last server has moved, then drops
+  `ark-net` on its next restart. It never lets go early, and never at all when Docker
+  is reached through a socket-proxy or another container is still on that network —
+  in those cases the Servers page tells you the one step left.
+- To keep the old name, set `SHARED_NETWORK=ark-net`.
 
 ---
 

--- a/apps/api/src/common/game-endpoint.test.ts
+++ b/apps/api/src/common/game-endpoint.test.ts
@@ -3,6 +3,7 @@ import {
   ContainerNetworkFacts,
   ManagerNetworkFacts,
   explainEndpointFailure,
+  gameBridgeNetwork,
   hostGatewayAddress,
   resolveGameEndpoint,
 } from "./game-endpoint";
@@ -12,31 +13,35 @@ import {
 // the connection was attempted against a name nothing could resolve, and the user saw
 // only `getaddrinfo ENOTFOUND palworld-…`. These cover the shapes that produced that.
 
-const managerOnArkNet: ManagerNetworkFacts = {
+const managerOnShared: ManagerNetworkFacts = {
   inContainer: true,
   hostNetwork: false,
-  networks: ["ark-net"],
+  networks: ["palisade-net"],
+  sharedNetwork: "palisade-net",
 };
-/** The misconfiguration behind #21: manager on the default bridge, not ark-net. */
-const managerOffArkNet: ManagerNetworkFacts = {
+/** The misconfiguration behind #21: manager on the default bridge, not the shared bridge. */
+const managerOffShared: ManagerNetworkFacts = {
   inContainer: true,
   hostNetwork: false,
   networks: ["bridge"],
+  sharedNetwork: "palisade-net",
 };
 const managerOnHost: ManagerNetworkFacts = {
   inContainer: true,
   hostNetwork: true,
   networks: ["host"],
+  sharedNetwork: "palisade-net",
 };
 const managerOnDevBox: ManagerNetworkFacts = {
   inContainer: false,
   hostNetwork: false,
   networks: [],
+  sharedNetwork: "palisade-net",
 };
 
-const onArkNet = (ip: string | null, ports: ContainerNetworkFacts["ports"] = {}): ContainerNetworkFacts => ({
-  networkMode: "ark-net",
-  networks: { "ark-net": ip },
+const onShared = (ip: string | null, ports: ContainerNetworkFacts["ports"] = {}): ContainerNetworkFacts => ({
+  networkMode: "palisade-net",
+  networks: { "palisade-net": ip },
   ports,
 });
 
@@ -44,9 +49,9 @@ const resolve = (facts: ContainerNetworkFacts | null, manager: ManagerNetworkFac
   resolveGameEndpoint({ facts, manager, containerPort: 7780, fallbackHost: "palworld-mysrv-abc123" });
 
 describe("resolveGameEndpoint", () => {
-  it("dials the container's ark-net IP when the manager shares that network", () => {
+  it("dials the container's shared-network IP when the manager shares that network", () => {
     // The fix: an IP needs no DNS, so this can't fail the way a name can.
-    expect(resolve(onArkNet("172.20.0.5"), managerOnArkNet)).toEqual({
+    expect(resolve(onShared("172.20.0.5"), managerOnShared)).toEqual({
       host: "172.20.0.5",
       port: 7780,
       via: "shared-network",
@@ -55,7 +60,7 @@ describe("resolveGameEndpoint", () => {
 
   it("goes through the host gateway for a host-networked container", () => {
     const hostNetworked: ContainerNetworkFacts = { networkMode: "host", networks: { host: null }, ports: {} };
-    expect(resolve(hostNetworked, managerOnArkNet)).toEqual({
+    expect(resolve(hostNetworked, managerOnShared)).toEqual({
       host: "host.docker.internal",
       port: 7780,
       via: "host-network",
@@ -63,10 +68,10 @@ describe("resolveGameEndpoint", () => {
   });
 
   it("uses the published host port when the two share no network (the #21 setup)", () => {
-    // Manager on `bridge`, game on `ark-net`: the name would never resolve, but the
+    // Manager on `bridge`, game on `palisade-net`: the name would never resolve, but the
     // published port is reachable through the host, so RCON works anyway.
-    const facts = onArkNet("172.20.0.5", { "7780/tcp": [{ HostIp: "0.0.0.0", HostPort: "7780" }] });
-    expect(resolve(facts, managerOffArkNet)).toEqual({
+    const facts = onShared("172.20.0.5", { "7780/tcp": [{ HostIp: "0.0.0.0", HostPort: "7780" }] });
+    expect(resolve(facts, managerOffShared)).toEqual({
       host: "host.docker.internal",
       port: 7780,
       via: "published-port",
@@ -74,17 +79,17 @@ describe("resolveGameEndpoint", () => {
   });
 
   it("falls back to HostConfig.PortBindings when the runtime view is empty", () => {
-    // Reported on #21 after the first fix shipped: the manager was off ark-net and
+    // Reported on #21 after the first fix shipped: the manager was off the shared network and
     // resolution still fell through to the container name even though the spec
     // publishes RCON. NetworkSettings.Ports is Docker's runtime view and isn't always
     // populated; the requested bindings say the same thing, so consult both.
     const facts: ContainerNetworkFacts = {
-      networkMode: "ark-net",
-      networks: { "ark-net": "172.20.0.5" },
+      networkMode: "palisade-net",
+      networks: { "palisade-net": "172.20.0.5" },
       ports: {},
       requestedPorts: { "7780/tcp": [{ HostIp: "0.0.0.0", HostPort: "7780" }] },
     };
-    expect(resolve(facts, managerOffArkNet)).toEqual({
+    expect(resolve(facts, managerOffShared)).toEqual({
       host: "host.docker.internal",
       port: 7780,
       via: "published-port",
@@ -93,34 +98,34 @@ describe("resolveGameEndpoint", () => {
 
   it("prefers the runtime binding over the requested one when they disagree", () => {
     const facts: ContainerNetworkFacts = {
-      networkMode: "ark-net",
-      networks: { "ark-net": "172.20.0.5" },
+      networkMode: "palisade-net",
+      networks: { "palisade-net": "172.20.0.5" },
       ports: { "7780/tcp": [{ HostPort: "17780" }] },
       requestedPorts: { "7780/tcp": [{ HostPort: "7780" }] },
     };
     // The runtime value is what the host is actually listening on.
-    expect(resolve(facts, managerOffArkNet)).toMatchObject({ port: 17780 });
+    expect(resolve(facts, managerOffShared)).toMatchObject({ port: 17780 });
   });
 
   it("honours a published port that differs from the container port", () => {
-    const facts = onArkNet("172.20.0.5", { "7780/tcp": [{ HostPort: "17780" }] });
-    expect(resolve(facts, managerOffArkNet)).toMatchObject({ port: 17780, via: "published-port" });
+    const facts = onShared("172.20.0.5", { "7780/tcp": [{ HostPort: "17780" }] });
+    expect(resolve(facts, managerOffShared)).toMatchObject({ port: 17780, via: "published-port" });
   });
 
-  it("prefers ark-net over another shared network", () => {
+  it("prefers the shared network over another shared network", () => {
     const facts: ContainerNetworkFacts = {
-      networkMode: "ark-net",
-      networks: { other: "10.0.0.9", "ark-net": "172.20.0.5" },
+      networkMode: "palisade-net",
+      networks: { other: "10.0.0.9", "palisade-net": "172.20.0.5" },
       ports: {},
     };
-    expect(resolve(facts, { ...managerOnArkNet, networks: ["other", "ark-net"] })).toMatchObject({
+    expect(resolve(facts, { ...managerOnShared, networks: ["other", "palisade-net"] })).toMatchObject({
       host: "172.20.0.5",
     });
   });
 
   it("falls back to the container name when nothing is shared and nothing is published", () => {
     // Preserves the historical behaviour rather than breaking a setup we can't model.
-    expect(resolve(onArkNet("172.20.0.5"), managerOffArkNet)).toEqual({
+    expect(resolve(onShared("172.20.0.5"), managerOffShared)).toEqual({
       host: "palworld-mysrv-abc123",
       port: 7780,
       via: "container-name",
@@ -129,7 +134,7 @@ describe("resolveGameEndpoint", () => {
 
   it("falls back to the container name when Docker tells us nothing", () => {
     // Locked-down socket-proxy or a container that vanished mid-probe.
-    expect(resolve(null, managerOnArkNet)).toEqual({
+    expect(resolve(null, managerOnShared)).toEqual({
       host: "palworld-mysrv-abc123",
       port: 7780,
       via: "container-name",
@@ -138,23 +143,23 @@ describe("resolveGameEndpoint", () => {
 
   it("ignores a shared network the container has no IP on", () => {
     // A created-but-not-started container has the network with an empty IP.
-    const facts = onArkNet("", { "7780/tcp": [{ HostPort: "7780" }] });
-    expect(resolve(facts, managerOnArkNet)).toMatchObject({ via: "published-port" });
+    const facts = onShared("", { "7780/tcp": [{ HostPort: "7780" }] });
+    expect(resolve(facts, managerOnShared)).toMatchObject({ via: "published-port" });
   });
 
   it("matches the port's own protocol, not just its number", () => {
     // A UDP query port published as UDP must not be found under tcp (and vice versa).
-    const facts = onArkNet(null, { "27015/udp": [{ HostPort: "27015" }] });
+    const facts = onShared(null, { "27015/udp": [{ HostPort: "27015" }] });
     const udp = resolveGameEndpoint({
       facts,
-      manager: managerOffArkNet,
+      manager: managerOffShared,
       containerPort: 27015,
       protocol: "udp",
       fallbackHost: "ark-x",
     });
     const tcp = resolveGameEndpoint({
       facts,
-      manager: managerOffArkNet,
+      manager: managerOffShared,
       containerPort: 27015,
       protocol: "tcp",
       fallbackHost: "ark-x",
@@ -166,7 +171,7 @@ describe("resolveGameEndpoint", () => {
 
 describe("hostGatewayAddress", () => {
   it("uses the host gateway from inside a bridged container", () => {
-    expect(hostGatewayAddress(managerOnArkNet)).toBe("host.docker.internal");
+    expect(hostGatewayAddress(managerOnShared)).toBe("host.docker.internal");
   });
   it("uses loopback when the manager is on the host network", () => {
     expect(hostGatewayAddress(managerOnHost)).toBe("127.0.0.1");
@@ -183,15 +188,15 @@ describe("explainEndpointFailure", () => {
   });
   const byName = { host: "palworld-mysrv-abc123", port: 7780, via: "container-name" } as const;
 
-  it("names the missing ark-net attachment as the cause", () => {
+  it("names the missing shared-network attachment as the cause", () => {
     const hint = explainEndpointFailure({
       error: dns,
       endpoint: byName,
-      manager: managerOffArkNet,
-      gameOnArkNet: true,
+      manager: managerOffShared,
+      gameNetwork: "palisade-net",
     });
     expect(hint).toContain("not attached");
-    expect(hint).toContain("docker network connect ark-net");
+    expect(hint).toContain("docker network connect palisade-net");
   });
 
   it("names the manager's actual container so the command is copy-pasteable", () => {
@@ -199,25 +204,25 @@ describe("explainEndpointFailure", () => {
     const hint = explainEndpointFailure({
       error: dns,
       endpoint: byName,
-      manager: { ...managerOffArkNet, name: "palisade" },
-      gameOnArkNet: true,
+      manager: { ...managerOffShared, name: "palisade" },
+      gameNetwork: "palisade-net",
     });
-    expect(hint).toContain("docker network connect ark-net palisade");
+    expect(hint).toContain("docker network connect palisade-net palisade");
     expect(hint).not.toContain("<manager container>");
   });
 
   it("keeps a placeholder when the manager's name is unknown", () => {
     expect(
-      explainEndpointFailure({ error: dns, endpoint: byName, manager: managerOffArkNet, gameOnArkNet: true }),
+      explainEndpointFailure({ error: dns, endpoint: byName, manager: managerOffShared, gameNetwork: "palisade-net" }),
     ).toContain("<manager container>");
   });
 
-  it("explains a name failure when the container is off ark-net entirely", () => {
+  it("explains a name failure when the container is off the shared network entirely", () => {
     const hint = explainEndpointFailure({
       error: dns,
       endpoint: byName,
-      manager: managerOnArkNet,
-      gameOnArkNet: false,
+      manager: managerOnShared,
+      gameNetwork: null,
     });
     expect(hint).toContain("did not resolve");
     expect(hint).not.toContain("docker network connect");
@@ -230,8 +235,8 @@ describe("explainEndpointFailure", () => {
     const hint = explainEndpointFailure({
       error: err,
       endpoint: { host: "host.docker.internal", port: 7780, via: "host-network" },
-      manager: managerOnArkNet,
-      gameOnArkNet: false,
+      manager: managerOnShared,
+      gameNetwork: null,
     });
     expect(hint).toContain("host-gateway");
   });
@@ -246,17 +251,17 @@ describe("explainEndpointFailure", () => {
     const hint = explainEndpointFailure({
       error: err,
       endpoint: { host: "host.docker.internal", port: 27020, via: "host-network" },
-      manager: { ...managerOffArkNet, networks: ["br0"], name: "palisade" },
-      gameOnArkNet: false,
+      manager: { ...managerOffShared, networks: ["br0"], name: "palisade" },
+      gameNetwork: null,
     });
     expect(hint).toContain("no route");
     expect(hint).toContain("macvlan");
-    expect(hint).toContain("docker network connect ark-net palisade");
+    expect(hint).toContain("docker network connect palisade-net palisade");
     expect(hint).toContain("GAME_HOST_NETWORK=false");
   });
 
   it("explains a no-route failure to a container IP without the host-network advice", () => {
-    // Bridge mode, manager elsewhere: attaching to ark-net is the fix, but telling
+    // Bridge mode, manager elsewhere: attaching to the shared network is the fix, but telling
     // them to set GAME_HOST_NETWORK=false would be nonsense — they already have.
     const err = Object.assign(new Error("connect EHOSTUNREACH 172.19.0.3:27020"), {
       code: "EHOSTUNREACH",
@@ -264,11 +269,11 @@ describe("explainEndpointFailure", () => {
     const hint = explainEndpointFailure({
       error: err,
       endpoint: { host: "172.19.0.3", port: 27020, via: "shared-network" },
-      manager: { ...managerOffArkNet, networks: ["br0"], name: "palisade" },
-      gameOnArkNet: true,
+      manager: { ...managerOffShared, networks: ["br0"], name: "palisade" },
+      gameNetwork: "palisade-net",
     });
     expect(hint).toContain("no route");
-    expect(hint).toContain("docker network connect ark-net palisade");
+    expect(hint).toContain("docker network connect palisade-net palisade");
     expect(hint).not.toContain("GAME_HOST_NETWORK=false");
   });
 
@@ -278,8 +283,8 @@ describe("explainEndpointFailure", () => {
       explainEndpointFailure({
         error: err,
         endpoint: { host: "172.17.0.1", port: 27020, via: "published-port" },
-        manager: managerOffArkNet,
-        gameOnArkNet: false,
+        manager: managerOffShared,
+        gameNetwork: null,
       }),
     ).toContain("no route");
   });
@@ -289,8 +294,8 @@ describe("explainEndpointFailure", () => {
     const hint = explainEndpointFailure({
       error: err,
       endpoint: { host: "172.20.0.5", port: 7780, via: "shared-network" },
-      manager: managerOnArkNet,
-      gameOnArkNet: true,
+      manager: managerOnShared,
+      gameNetwork: "palisade-net",
     });
     expect(hint).toContain("nothing is listening on 172.20.0.5:7780");
   });
@@ -300,9 +305,83 @@ describe("explainEndpointFailure", () => {
     const hint = explainEndpointFailure({
       error: new Error("Authentication failed"),
       endpoint: { host: "172.20.0.5", port: 7780, via: "shared-network" },
-      manager: managerOnArkNet,
-      gameOnArkNet: true,
+      manager: managerOnShared,
+      gameNetwork: "palisade-net",
     });
     expect(hint).toBeNull();
+  });
+});
+
+// The move off "ark-net" (GH #31 follow-up) recreates each server on the new bridge
+// as it is restarted, so an install spends real time with servers on both. Resolution
+// has to work either way round, and any advice has to name the network the server is
+// ACTUALLY on rather than the one new servers would get.
+describe("during the ark-net → palisade-net migration", () => {
+  const managerOnBoth: ManagerNetworkFacts = {
+    inContainer: true,
+    hostNetwork: false,
+    networks: ["br0", "palisade-net", "ark-net"],
+    sharedNetwork: "palisade-net",
+    name: "Palisade",
+  };
+  const stillOnLegacy: ContainerNetworkFacts = {
+    networkMode: "ark-net",
+    networks: { "ark-net": "172.19.0.7" },
+    ports: {},
+  };
+
+  it("reaches a not-yet-migrated server on the old bridge", () => {
+    expect(resolve(stillOnLegacy, managerOnBoth)).toEqual({
+      host: "172.19.0.7",
+      port: 7780,
+      via: "shared-network",
+    });
+  });
+
+  it("prefers the new bridge for a server that has moved", () => {
+    const onBoth: ContainerNetworkFacts = {
+      networkMode: "palisade-net",
+      networks: { "ark-net": "172.19.0.7", "palisade-net": "172.22.0.4" },
+      ports: {},
+    };
+    expect(resolve(onBoth, managerOnBoth)).toMatchObject({ host: "172.22.0.4" });
+  });
+
+  it("names the old network in the fix when that is where the server sits", () => {
+    // Telling someone to connect to palisade-net would not make them meet.
+    const hint = explainEndpointFailure({
+      error: Object.assign(new Error("getaddrinfo ENOTFOUND palworld-mysrv-abc123"), {
+        code: "ENOTFOUND",
+      }),
+      endpoint: { host: "palworld-mysrv-abc123", port: 7780, via: "container-name" },
+      manager: { ...managerOnBoth, networks: ["br0", "palisade-net"] },
+      gameNetwork: "ark-net",
+    });
+    expect(hint).toContain("docker network connect ark-net Palisade");
+  });
+
+  describe("gameBridgeNetwork", () => {
+    it("picks the new bridge over the old one", () => {
+      const onBoth: ContainerNetworkFacts = {
+        networkMode: "palisade-net",
+        networks: { "ark-net": "172.19.0.7", "palisade-net": "172.22.0.4" },
+        ports: {},
+      };
+      expect(gameBridgeNetwork(onBoth, managerOnBoth)).toBe("palisade-net");
+    });
+
+    it("reports the old bridge for a server that has not moved yet", () => {
+      expect(gameBridgeNetwork(stillOnLegacy, managerOnBoth)).toBe("ark-net");
+    });
+
+    it("has nothing to name for a host-networked or invisible container", () => {
+      const hostNetworked: ContainerNetworkFacts = {
+        networkMode: "host",
+        networks: { host: null },
+        ports: {},
+      };
+      expect(gameBridgeNetwork(hostNetworked, managerOnBoth)).toBeNull();
+      expect(gameBridgeNetwork(null, managerOnBoth)).toBeNull();
+    });
   });
 });

--- a/apps/api/src/common/game-endpoint.ts
+++ b/apps/api/src/common/game-endpoint.ts
@@ -1,4 +1,4 @@
-import { ARK_NETWORK } from "./naming";
+import { LEGACY_NETWORK } from "./naming";
 
 /**
  * Where the manager should connect to reach a game container's admin port (RCON,
@@ -43,6 +43,10 @@ export interface ManagerNetworkFacts {
   /** The manager's own container name, so a suggested fix is copy-pasteable rather
    *  than a `<placeholder>` the user has to go look up. */
   name?: string | null;
+  /** The bridge new game containers are created on (SHARED_NETWORK, or the default).
+   *  Carried with the manager's own networks so resolution and every user-facing fix
+   *  message name the same network without reaching back into config. */
+  sharedNetwork: string;
 }
 
 export interface ResolvedEndpoint {
@@ -67,16 +71,35 @@ function usesHostNetwork(c: ContainerNetworkFacts): boolean {
 }
 
 /**
- * The first network both ends share, preferring ark-net. Connecting to the
- * container's IP on a shared network skips Docker's embedded DNS entirely — which
- * is the specific thing that was failing — and works even if the container was
- * renamed out from under us.
+ * The first network both ends share, preferring the current shared bridge and then
+ * the legacy one. Connecting to the container's IP on a shared network skips
+ * Docker's embedded DNS entirely — which is the specific thing that was failing —
+ * and works even if the container was renamed out from under us.
+ *
+ * The preference order only decides which of several shared networks to use, so a
+ * half-migrated install (some servers still on the legacy bridge) resolves either
+ * way round.
  */
 function sharedNetworkIp(c: ContainerNetworkFacts, manager: ManagerNetworkFacts): string | null {
   const shared = Object.keys(c.networks).filter((n) => manager.networks.includes(n));
-  const preferred = shared.includes(ARK_NETWORK) ? ARK_NETWORK : shared[0];
+  const preferred =
+    [manager.sharedNetwork, LEGACY_NETWORK].find((n) => shared.includes(n)) ?? shared[0];
   const ip = preferred ? c.networks[preferred] : null;
   return ip || null;
+}
+
+/**
+ * The bridge a game container sits on, as a name to quote back to the user. Prefers
+ * the networks we know about so the advice matches whichever era the container was
+ * created in; null for host-network containers and for anything we can't see.
+ */
+export function gameBridgeNetwork(
+  c: ContainerNetworkFacts | null,
+  manager: ManagerNetworkFacts,
+): string | null {
+  if (!c || usesHostNetwork(c)) return null;
+  const names = Object.keys(c.networks);
+  return [manager.sharedNetwork, LEGACY_NETWORK].find((n) => names.includes(n)) ?? names[0] ?? null;
 }
 
 /** The host port `containerPort` is published on, if any. */
@@ -136,15 +159,20 @@ export function explainEndpointFailure(input: {
   error: Error;
   endpoint: ResolvedEndpoint;
   manager: ManagerNetworkFacts;
-  gameOnArkNet: boolean;
+  /** The bridge the game container is on (gameBridgeNetwork), or null when it uses
+   *  host networking or we couldn't inspect it. */
+  gameNetwork: string | null;
 }): string | null {
-  const { endpoint, manager, gameOnArkNet } = input;
+  const { endpoint, manager, gameNetwork } = input;
+  // Name the network the game is actually on: during the migration off "ark-net"
+  // that may not be the one new containers get.
+  const net = gameNetwork ?? manager.sharedNetwork;
   const code = (input.error as NodeJS.ErrnoException).code;
   const dnsFailure = code === "ENOTFOUND" || code === "EAI_AGAIN";
 
   if (dnsFailure && endpoint.via === "container-name") {
-    if (gameOnArkNet && manager.inContainer && !manager.networks.includes(ARK_NETWORK)) {
-      return `the manager container is not attached to the "${ARK_NETWORK}" network, so it cannot resolve game containers by name, and this server's RCON port is not published to the host either — run: docker network connect ${ARK_NETWORK} ${manager.name || "<manager container>"} (on Unraid: edit the Palisade container and set Network Type to ${ARK_NETWORK}), then restart this server`;
+    if (gameNetwork && manager.inContainer && !manager.networks.includes(gameNetwork)) {
+      return `the manager container is not attached to the "${net}" network, so it cannot resolve game containers by name, and this server's RCON port is not published to the host either — run: docker network connect ${net} ${manager.name || "<manager container>"} (on Unraid: edit the Palisade container and set Network Type to ${net}), then restart this server`;
     }
     return `the name "${endpoint.host}" did not resolve — the game container is not on a network this manager shares, and its port is not published to the host`;
   }
@@ -158,10 +186,10 @@ export function explainEndpointFailure(input: {
   // both the Docker host and Docker's bridges, so neither the host gateway nor a
   // container IP is reachable, whichever way GAME_HOST_NETWORK is set (GH #31).
   if (code === "EHOSTUNREACH" || code === "ENETUNREACH") {
-    const attach = `docker network connect ${ARK_NETWORK} ${manager.name || "<manager container>"}`;
+    const attach = `docker network connect ${net} ${manager.name || "<manager container>"}`;
     return endpoint.via === "host-network" || endpoint.via === "published-port"
-      ? `no route from the manager to ${endpoint.host} — it is on a network with no path to the Docker host. If the manager runs on an Unraid custom/macvlan network, it cannot reach the host gateway: attach it to "${ARK_NETWORK}" as an additional network (${attach}) and set GAME_HOST_NETWORK=false so game servers share that bridge`
-      : `no route from the manager to ${endpoint.host} — the manager and this server are on networks that cannot reach each other. Attach the manager to "${ARK_NETWORK}" (${attach}), then restart this server`;
+      ? `no route from the manager to ${endpoint.host} — it is on a network with no path to the Docker host. If the manager runs on an Unraid custom/macvlan network, it cannot reach the host gateway: attach it to "${net}" as an additional network (${attach}) and set GAME_HOST_NETWORK=false so game servers share that bridge`
+      : `no route from the manager to ${endpoint.host} — the manager and this server are on networks that cannot reach each other. Attach the manager to "${net}" (${attach}), then restart this server`;
   }
 
   if (code === "ECONNREFUSED") {

--- a/apps/api/src/common/naming.ts
+++ b/apps/api/src/common/naming.ts
@@ -1,7 +1,22 @@
 import { Game } from "@ark/shared";
 
-/** Shared Docker network the manager and all game containers join (for RCON). */
-export const ARK_NETWORK = "ark-net";
+/**
+ * Shared Docker network the manager and all game containers join (for RCON).
+ *
+ * The name is load-bearing on Unraid, which is why it is not "ark-net" any more.
+ * For a manager container on a custom (macvlan/ipvlan) network, Unraid derives the
+ * WebUI button's address from `reset($ct['Networks'])` — the FIRST entry of the
+ * container's network map — and the Docker API returns that map sorted by name. So
+ * "ark-net" sorted ahead of "br0"/"bond0"/"eth0" and the WebUI button pointed at the
+ * bridge IP instead of the LAN one the moment Palisade attached itself (GH #31).
+ * Anything sorting after those interface names, like this, picks the right IP by
+ * itself. SHARED_NETWORK overrides it if a host manages to sort even later.
+ */
+export const DEFAULT_SHARED_NETWORK = "palisade-net";
+
+/** The pre-1.11 network name. Still honoured for installs that have servers on it —
+ *  see common/shared-network.ts for how the two coexist during the migration. */
+export const LEGACY_NETWORK = "ark-net";
 
 /** Container-name prefix per game, so e.g. Conan containers aren't named "ark-…".
  *  Cosmetic only — containers are matched by the `ark.serverId` label. */

--- a/apps/api/src/common/shared-network.test.ts
+++ b/apps/api/src/common/shared-network.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  NetworkPlanInput,
+  dockerViaProxy,
+  legacyMigrationNote,
+  legacyStillNeeded,
+  shouldLeaveLegacy,
+  targetNetwork,
+} from "./shared-network";
+
+// GH #31 follow-up. Unraid builds a container's WebUI link from the FIRST of its
+// networks (`reset($ct['Networks'])`, sorted by name), so once Palisade attached
+// itself to "ark-net" the button on a custom/macvlan install pointed at the bridge
+// IP instead of the LAN one. The network is named "palisade-net" so it sorts after
+// br0/bond0/eth0 — but only once the manager has actually let go of the old one,
+// which is what these rules decide.
+
+/** Migration finished: manager on both networks, nothing left behind. */
+const done: NetworkPlanInput = {
+  managerNetworks: ["br0", "palisade-net", "ark-net"],
+  legacyServers: 0,
+  otherOnLegacy: false,
+  dockerViaProxy: false,
+};
+
+describe("targetNetwork", () => {
+  it("defaults to the name chosen to sort after Unraid's interface networks", () => {
+    expect(targetNetwork()).toBe("palisade-net");
+    // The whole point of the rename: it must lose an alphabetical sort to br0 etc.
+    expect(["bond0", "br0", "br0.10", "eth0"].every((n) => n < targetNetwork())).toBe(true);
+  });
+
+  it("honours an explicit SHARED_NETWORK", () => {
+    expect(targetNetwork("my-net")).toBe("my-net");
+  });
+
+  it("treats a blank override as unset", () => {
+    // Unraid passes empty template fields as empty strings, not absent vars (GH #6).
+    expect(targetNetwork("")).toBe("palisade-net");
+    expect(targetNetwork("   ")).toBe("palisade-net");
+    expect(targetNetwork(null)).toBe("palisade-net");
+  });
+});
+
+describe("dockerViaProxy", () => {
+  it("recognises the mounted socket", () => {
+    expect(dockerViaProxy("unix:///var/run/docker.sock")).toBe(false);
+    expect(dockerViaProxy("UNIX:///var/run/docker.sock")).toBe(false);
+  });
+
+  it("treats anything else as a proxy we might be talking to over the old network", () => {
+    expect(dockerViaProxy("tcp://socket-proxy:2375")).toBe(true);
+  });
+});
+
+describe("shouldLeaveLegacy", () => {
+  it("drops the old endpoint once every server has moved", () => {
+    expect(shouldLeaveLegacy(done)).toBe(true);
+  });
+
+  it("keeps it while any server is still on the old network", () => {
+    expect(shouldLeaveLegacy({ ...done, legacyServers: 1 })).toBe(false);
+  });
+
+  it("keeps it when a container that isn't ours is using it", () => {
+    // The socket-proxy setup the README used to describe puts one there.
+    expect(shouldLeaveLegacy({ ...done, otherOnLegacy: true })).toBe(false);
+  });
+
+  it("keeps it whenever Docker itself is reached over TCP", () => {
+    // Disconnecting could be the last thing this manager ever does: if the proxy
+    // answers on that network, it takes Docker access with it.
+    expect(shouldLeaveLegacy({ ...done, dockerViaProxy: true })).toBe(false);
+  });
+
+  it("never strands the manager by leaving before it has joined the new network", () => {
+    expect(shouldLeaveLegacy({ ...done, managerNetworks: ["br0", "ark-net"] })).toBe(false);
+  });
+
+  it("does nothing when the manager was never on the old network", () => {
+    expect(shouldLeaveLegacy({ ...done, managerNetworks: ["br0", "palisade-net"] })).toBe(false);
+  });
+
+  it("stands down when the user pinned SHARED_NETWORK to the old name", () => {
+    expect(shouldLeaveLegacy({ ...done, override: "ark-net" })).toBe(false);
+  });
+});
+
+describe("legacyStillNeeded", () => {
+  it("is true if there is any reason at all to keep the old network", () => {
+    expect(legacyStillNeeded(done)).toBe(false);
+    expect(legacyStillNeeded({ ...done, legacyServers: 2 })).toBe(true);
+    expect(legacyStillNeeded({ ...done, otherOnLegacy: true })).toBe(true);
+    expect(legacyStillNeeded({ ...done, dockerViaProxy: true })).toBe(true);
+  });
+});
+
+describe("legacyMigrationNote", () => {
+  it("tells the admin the one thing that finishes the move", () => {
+    const note = legacyMigrationNote({ ...done, legacyServers: 3 });
+    expect(note).toContain("3 servers");
+    expect(note).toContain("Restarting");
+    expect(note).toContain("palisade-net");
+  });
+
+  it("reads correctly for a single server", () => {
+    const note = legacyMigrationNote({ ...done, legacyServers: 1 });
+    expect(note).toContain("1 server still runs");
+    expect(note).not.toContain("servers still");
+  });
+
+  it("names the blocker when the servers have moved but something else has not", () => {
+    const note = legacyMigrationNote({ ...done, otherOnLegacy: true });
+    expect(note).toContain("socket-proxy");
+    expect(note).toContain("docker network disconnect ark-net");
+  });
+
+  it("says nothing once the manager is off the old network", () => {
+    expect(legacyMigrationNote({ ...done, managerNetworks: ["br0", "palisade-net"] })).toBeNull();
+  });
+
+  it("says nothing when the old name is the configured one", () => {
+    expect(legacyMigrationNote({ ...done, legacyServers: 2, override: "ark-net" })).toBeNull();
+  });
+
+  it("says nothing when there is nothing left to do", () => {
+    // Manager still on both, but no servers and no blockers: shouldLeaveLegacy is
+    // about to clear it, so don't put a chore in front of the user first.
+    expect(legacyMigrationNote(done)).toBeNull();
+  });
+});

--- a/apps/api/src/common/shared-network.ts
+++ b/apps/api/src/common/shared-network.ts
@@ -1,0 +1,90 @@
+import { DEFAULT_SHARED_NETWORK, LEGACY_NETWORK } from "./naming";
+
+/**
+ * Which Docker network the manager and its game containers meet on, while the
+ * pre-1.11 "ark-net" installs migrate off it.
+ *
+ * The rules are deliberately one-way and boring: every NEW container goes on the
+ * target network, the manager holds an endpoint on both for as long as anything
+ * still needs the old one, and the old endpoint is dropped only when nothing can
+ * possibly be depending on it. A half-migrated install keeps working the whole
+ * time, because endpoint resolution reads each container's real networking rather
+ * than assuming a name (common/game-endpoint.ts).
+ */
+export interface NetworkPlanInput {
+  /** SHARED_NETWORK override. Blank/absent means the default. */
+  override?: string | null;
+  /** Networks the manager container is currently attached to. */
+  managerNetworks: string[];
+  /** Managed game containers (any state) still attached to the legacy network. */
+  legacyServers: number;
+  /** A container that isn't one of ours sits on the legacy network — most likely a
+   *  socket-proxy, which the docs used to tell people to put there. */
+  otherOnLegacy: boolean;
+  /** Docker is reached over TCP (a socket-proxy) rather than the mounted socket. */
+  dockerViaProxy: boolean;
+}
+
+/** Where new game containers are attached. Fixed per install, so a start never has
+ *  to guess and two servers created minutes apart always land together. */
+export function targetNetwork(override?: string | null): string {
+  return (override ?? "").trim() || DEFAULT_SHARED_NETWORK;
+}
+
+/** True when Docker is fronted by a proxy rather than the mounted unix socket. */
+export function dockerViaProxy(dockerHost: string): boolean {
+  return !/^unix:\/\//i.test(dockerHost.trim());
+}
+
+/**
+ * Whether anything could still depend on the legacy network. Any doubt counts as
+ * yes: leaving a spare endpoint attached costs nothing, while dropping one that a
+ * socket-proxy was answering on would cut the manager off from Docker entirely.
+ */
+export function legacyStillNeeded(i: NetworkPlanInput): boolean {
+  return i.legacyServers > 0 || i.otherOnLegacy || i.dockerViaProxy;
+}
+
+/**
+ * Whether the manager can now drop its legacy endpoint — the step that actually
+ * fixes Unraid's WebUI link, since it leaves the LAN network sorting first again
+ * (see DEFAULT_SHARED_NETWORK). Never strands the manager: it only lets go of the
+ * old network once it is holding the new one.
+ */
+export function shouldLeaveLegacy(i: NetworkPlanInput): boolean {
+  if (targetNetwork(i.override) === LEGACY_NETWORK) return false;
+  if (!i.managerNetworks.includes(LEGACY_NETWORK)) return false;
+  if (!i.managerNetworks.includes(targetNetwork(i.override))) return false;
+  return !legacyStillNeeded(i);
+}
+
+/**
+ * Admin-facing progress note while both networks are in play, or null when there is
+ * nothing to say. Every case here resolves itself through normal use, so the note
+ * says what to do rather than what went wrong.
+ */
+export function legacyMigrationNote(i: NetworkPlanInput): string | null {
+  const target = targetNetwork(i.override);
+  if (target === LEGACY_NETWORK) return null;
+  if (!i.managerNetworks.includes(LEGACY_NETWORK)) return null;
+
+  if (i.legacyServers > 0) {
+    const n = i.legacyServers;
+    return (
+      `${n} server${n === 1 ? "" : "s"} still run${n === 1 ? "s" : ""} on the old "${LEGACY_NETWORK}" ` +
+      `Docker network. Restarting ${n === 1 ? "it" : "each of them"} moves ${n === 1 ? "it" : "them"} to ` +
+      `"${target}"; nothing else is needed, and Palisade stays attached to both networks until ` +
+      `${n === 1 ? "it has" : "they all have"}. On Unraid, finishing this also restores the Palisade ` +
+      `container's WebUI link if you run it on a custom (br0/macvlan) network.`
+    );
+  }
+  if (i.otherOnLegacy || i.dockerViaProxy) {
+    return (
+      `Every server has moved to the "${target}" Docker network, but Palisade is still attached to ` +
+      `the old "${LEGACY_NETWORK}" one because another container is using it — usually a ` +
+      `socket-proxy. Move that container to "${target}", then run: ` +
+      `docker network disconnect ${LEGACY_NETWORK} <manager container>`
+    );
+  }
+  return null;
+}

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -67,6 +67,13 @@ const schema = z.object({
     .default("true")
     .transform((v) => v !== "false" && v !== "0"),
 
+  // Name of the Docker bridge the manager and its game containers meet on. Leave
+  // unset — the default is chosen so that Unraid picks the right IP for the manager
+  // container's WebUI link (see DEFAULT_SHARED_NETWORK). Set this only to keep a
+  // hand-managed network, or if the host has a custom network whose name sorts after
+  // the default and takes the WebUI link with it.
+  SHARED_NETWORK: z.string().optional(),
+
   // Browsers reach the API same-origin through the Next rewrite proxy, so
   // cross-origin requests are denied by default. If you serve the web UI from a
   // different origin than the API, list the allowed origins here

--- a/apps/api/src/docker/docker.service.ts
+++ b/apps/api/src/docker/docker.service.ts
@@ -327,6 +327,46 @@ export class DockerService {
     return true;
   }
 
+  /**
+   * Detach a container from a network. Used only to drop the legacy "ark-net"
+   * endpoint once nothing needs it (common/shared-network.ts) — dropping a network
+   * a socket-proxy answers on would cut the manager off from Docker, so the caller
+   * decides, not this method. Returns whether the container ended up detached.
+   */
+  async disconnectFromNetwork(networkName: string, containerId: string): Promise<boolean> {
+    try {
+      await this.docker.getNetwork(networkName).disconnect({ Container: containerId });
+      return true;
+    } catch (err) {
+      // Same reasoning as connectToNetwork: "already gone" and "not allowed" both
+      // come back as an error, and only the container's state tells them apart.
+      const attached = await this.containerOnNetwork(networkName, containerId);
+      if (attached) {
+        this.logger.warn(
+          `Could not detach ${containerId.slice(0, 12)} from ${networkName}: ${(err as Error).message}`,
+        );
+      }
+      return !attached;
+    }
+  }
+
+  /**
+   * Ids of every container attached to a network, or null when we couldn't ask (a
+   * socket-proxy with NETWORKS=0). Null is not "empty": acting on it would let the
+   * manager walk away from a network that is still in use.
+   */
+  async networkContainerIds(networkName: string): Promise<string[] | null> {
+    try {
+      const info = (await this.docker.getNetwork(networkName).inspect()) as {
+        Containers?: Record<string, unknown>;
+      };
+      return Object.keys(info.Containers ?? {});
+    } catch (err) {
+      this.logger.debug(`could not inspect network ${networkName} (${(err as Error).message})`);
+      return null;
+    }
+  }
+
   /** Whether a container currently has an endpoint on the named network. */
   async containerOnNetwork(networkName: string, containerId: string): Promise<boolean> {
     try {

--- a/apps/api/src/docker/game-endpoint.service.test.ts
+++ b/apps/api/src/docker/game-endpoint.service.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { resetEnvCache } from "../config/env";
+import { GameEndpointService } from "./game-endpoint.service";
+
+// The only module seam that can't run here: finding our own container id reads
+// /proc, and the tests are not in a container. Everything else is the real service.
+vi.mock("../config/ensure-host-data-dir", async (orig) => ({
+  ...(await orig<typeof import("../config/ensure-host-data-dir")>()),
+  findSelfContainerId: async () => selfId,
+}));
+
+let selfId: string | null = "manager-id";
+
+/**
+ * GH #31 follow-up: the manager attaches itself to the shared bridge, and lets go of
+ * the pre-1.11 "ark-net" one once nothing needs it — which is what restores the WebUI
+ * link on an Unraid custom network. Detaching is the step that can do real damage
+ * (drop the network a socket-proxy answers on and Docker access goes with it), so
+ * every reason to stand down gets its own case here.
+ */
+class FakeDocker {
+  networks: string[] = ["br0"];
+  exists: boolean | null = true;
+  legacyMembers: string[] | null = ["manager-id"];
+  managedServers: string[] = [];
+  connected: string[] = [];
+  disconnected: string[] = [];
+  client = {} as never;
+
+  async inspect() {
+    return {
+      Name: "/Palisade",
+      HostConfig: { NetworkMode: this.networks[0] },
+      NetworkSettings: {
+        Networks: Object.fromEntries(this.networks.map((n) => [n, { IPAddress: "172.20.0.2" }])),
+      },
+    } as never;
+  }
+  async networkExists(name: string) {
+    return this.exists === true ? true : this.exists;
+  }
+  async connectToNetwork(name: string, id: string) {
+    this.connected.push(name);
+    this.networks.push(name);
+    return true;
+  }
+  async disconnectFromNetwork(name: string, id: string) {
+    this.disconnected.push(name);
+    this.networks = this.networks.filter((n) => n !== name);
+    return true;
+  }
+  async networkContainerIds() {
+    return this.legacyMembers;
+  }
+  async listManagedServers() {
+    return this.managedServers.map((id) => ({ id, serverId: id, running: true, status: "Up" }));
+  }
+}
+
+const make = (docker: FakeDocker) => new GameEndpointService(docker as never);
+
+beforeEach(() => {
+  selfId = "manager-id";
+  process.env.SECRETS_KEY = "a".repeat(64);
+  process.env.JWT_SECRET = "b".repeat(32);
+  process.env.DOCKER_HOST = "unix:///var/run/docker.sock";
+  process.env.AUTO_CREATE_NETWORK = "true";
+  delete process.env.SHARED_NETWORK;
+  resetEnvCache();
+});
+
+describe("ensureManagerNetworks", () => {
+  it("attaches the manager to the shared bridge, keeping its existing networks", async () => {
+    const docker = new FakeDocker();
+    expect(await make(docker).ensureManagerNetworks()).toBe(true);
+    expect(docker.connected).toEqual(["palisade-net"]);
+    // The macvlan case this exists for: br0 (and its static LAN IP) is untouched.
+    expect(docker.networks).toContain("br0");
+  });
+
+  it("does nothing when the network doesn't exist yet", async () => {
+    // A first server start creates it and calls back in; nothing to join before that.
+    const docker = new FakeDocker();
+    docker.exists = false;
+    expect(await make(docker).ensureManagerNetworks()).toBe(false);
+    expect(docker.connected).toEqual([]);
+  });
+
+  it("stands down entirely when AUTO_CREATE_NETWORK is off", async () => {
+    process.env.AUTO_CREATE_NETWORK = "false";
+    resetEnvCache();
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "ark-net"];
+    await make(docker).ensureManagerNetworks();
+    expect(docker.connected).toEqual([]);
+    expect(docker.disconnected).toEqual([]);
+  });
+
+  it("leaves a host-networked manager alone", async () => {
+    const docker = new FakeDocker();
+    docker.networks = ["host"];
+    expect(await make(docker).ensureManagerNetworks()).toBe(false);
+    expect(docker.connected).toEqual([]);
+  });
+
+  it("honours SHARED_NETWORK", async () => {
+    process.env.SHARED_NETWORK = "my-net";
+    resetEnvCache();
+    const docker = new FakeDocker();
+    await make(docker).ensureManagerNetworks();
+    expect(docker.connected).toEqual(["my-net"]);
+  });
+});
+
+describe("retiring the legacy network", () => {
+  /** A mid-migration manager: on its LAN network and both bridges. */
+  const migrating = () => {
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "ark-net", "palisade-net"];
+    return docker;
+  };
+
+  it("drops ark-net once no server is left on it", async () => {
+    const docker = migrating();
+    docker.legacyMembers = ["manager-id"];
+    await make(docker).ensureManagerNetworks();
+    expect(docker.disconnected).toEqual(["ark-net"]);
+    expect(docker.networks).toEqual(["br0", "palisade-net"]);
+  });
+
+  it("keeps ark-net while a server still runs on it", async () => {
+    const docker = migrating();
+    docker.legacyMembers = ["manager-id", "server-1"];
+    docker.managedServers = ["server-1"];
+    await make(docker).ensureManagerNetworks();
+    expect(docker.disconnected).toEqual([]);
+  });
+
+  it("keeps ark-net when a container that isn't ours is on it", async () => {
+    // The documented socket-proxy setup put one there.
+    const docker = migrating();
+    docker.legacyMembers = ["manager-id", "some-other-container"];
+    await make(docker).ensureManagerNetworks();
+    expect(docker.disconnected).toEqual([]);
+  });
+
+  it("keeps ark-net whenever Docker is reached through a proxy", async () => {
+    // Disconnecting could be the last thing this manager ever does.
+    process.env.DOCKER_HOST = "tcp://socket-proxy:2375";
+    resetEnvCache();
+    const docker = migrating();
+    await make(docker).ensureManagerNetworks();
+    expect(docker.disconnected).toEqual([]);
+  });
+
+  it("keeps ark-net when Docker won't say who else is on it", async () => {
+    const docker = migrating();
+    docker.legacyMembers = null; // locked-down socket-proxy, or the network is gone
+    await make(docker).ensureManagerNetworks();
+    expect(docker.disconnected).toEqual([]);
+  });
+
+  it("joins the new network before leaving the old one, never both at once", async () => {
+    // Starting state is the one every pre-1.11 install boots into.
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "ark-net"];
+    await make(docker).ensureManagerNetworks();
+    expect(docker.connected).toEqual(["palisade-net"]);
+    expect(docker.disconnected).toEqual(["ark-net"]);
+    expect(docker.networks).toEqual(["br0", "palisade-net"]);
+  });
+
+  it("does not strand itself when the new network can't be joined", async () => {
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "ark-net"];
+    docker.exists = false; // palisade-net not created yet
+    await make(docker).ensureManagerNetworks();
+    expect(docker.disconnected).toEqual([]);
+    expect(docker.networks).toContain("ark-net");
+  });
+
+  it("does nothing at all when it cannot identify its own container", async () => {
+    selfId = null;
+    const docker = migrating();
+    await make(docker).ensureManagerNetworks();
+    expect(docker.disconnected).toEqual([]);
+  });
+});
+
+describe("migrationNote", () => {
+  it("reports servers still to move", async () => {
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "ark-net", "palisade-net"];
+    docker.legacyMembers = ["manager-id", "server-1", "server-2"];
+    docker.managedServers = ["server-1", "server-2"];
+    expect(await make(docker).migrationNote()).toContain("2 servers");
+  });
+
+  it("says nothing on an install that was never on the legacy network", async () => {
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "palisade-net"];
+    docker.legacyMembers = null;
+    expect(await make(docker).migrationNote()).toBeNull();
+  });
+});

--- a/apps/api/src/docker/game-endpoint.service.ts
+++ b/apps/api/src/docker/game-endpoint.service.ts
@@ -2,13 +2,21 @@ import { Injectable, Logger } from "@nestjs/common";
 import type Docker from "dockerode";
 import { DockerService } from "./docker.service";
 import { findSelfContainerId } from "../config/ensure-host-data-dir";
-import { ARK_NETWORK } from "../common/naming";
+import { LEGACY_NETWORK } from "../common/naming";
 import { loadEnv } from "../config/env";
+import {
+  NetworkPlanInput,
+  dockerViaProxy,
+  legacyMigrationNote,
+  shouldLeaveLegacy,
+  targetNetwork,
+} from "../common/shared-network";
 import {
   ContainerNetworkFacts,
   ManagerNetworkFacts,
   ResolvedEndpoint,
   explainEndpointFailure,
+  gameBridgeNetwork,
   resolveGameEndpoint,
 } from "../common/game-endpoint";
 
@@ -30,8 +38,10 @@ export class GameEndpointService {
   private readonly lastVia = new Map<string, ResolvedEndpoint["via"]>();
   /** Cached from the manager facts so `addressingNote` can stay synchronous.
    *  Null until the first resolve has loaded them. */
-  private missingArkNet: boolean | null = null;
+  private missingShared: boolean | null = null;
   private managerName: string | null = null;
+  /** Our own container id — resolved once, then reused by every network call. */
+  private selfContainerId: Promise<string | null> | null = null;
 
   constructor(private readonly docker: DockerService) {}
 
@@ -77,73 +87,147 @@ export class GameEndpointService {
       error,
       endpoint,
       manager,
-      gameOnArkNet: facts ? ARK_NETWORK in facts.networks : false,
+      gameNetwork: gameBridgeNetwork(facts, manager),
     });
   }
 
   /**
-   * Attach the manager itself to ark-net when it isn't already, so game containers
-   * on that bridge become reachable (GH #31 — the reporter's fix was to run
-   * `docker network connect ark-net Palisade` by hand, which is not a reasonable
-   * thing to expect after an install).
+   * Put the manager on the network its game containers use, and take it off the one
+   * they no longer use (GH #31). Both halves are safe to run on every boot.
    *
-   * Docker adds the interface live: no restart, and existing networks are kept, so
-   * a manager on an Unraid custom/macvlan network keeps its static LAN IP and just
-   * gains a route to the bridge. Returns true when the manager ends up attached.
+   * Docker attaches a running container to an extra network live: no restart, and
+   * existing networks are kept, so a manager on an Unraid custom/macvlan network
+   * keeps its static LAN IP and just gains a route to the game servers.
    *
-   * Deliberately conservative — it does nothing when:
-   *  - the flag is off (someone managing their own networking),
-   *  - the manager isn't containerised, or runs on the host network (already fine),
-   *  - we can't read our own networking (a locked-down socket-proxy), or
-   *  - ark-net doesn't exist yet — nothing to join until a server needs it.
+   * Deliberately conservative — it does nothing when the flag is off, the manager
+   * isn't containerised or runs on the host network, we can't read our own
+   * networking (a locked-down socket-proxy), or the target network doesn't exist
+   * yet. Returns whether the manager ended up on the target network.
    */
-  async ensureManagerOnArkNet(): Promise<boolean> {
+  async ensureManagerNetworks(): Promise<boolean> {
     if (!loadEnv().AUTO_CREATE_NETWORK) return false;
     const manager = await this.manager();
     if (!manager.inContainer || manager.hostNetwork) return false;
     if (!manager.networks.length) return false; // couldn't inspect ourselves
-    if (manager.networks.includes(ARK_NETWORK)) return true;
-    if ((await this.docker.networkExists(ARK_NETWORK)) !== true) return false;
 
-    const id = await findSelfContainerId(this.docker.client).catch(() => null);
-    if (!id) return false;
-    const ok = await this.docker.connectToNetwork(ARK_NETWORK, id);
-    if (ok) {
-      this.logger.log(
-        `Attached the manager to "${ARK_NETWORK}" so game servers on that bridge are reachable`,
-      );
-      // Our cached view of our own networking is now stale — the next resolve (and
-      // the health check) must see the new interface.
-      this.managerFacts = null;
-      this.missingArkNet = false;
+    const target = manager.sharedNetwork;
+    let joined = manager.networks.includes(target);
+    if (!joined && (await this.docker.networkExists(target)) === true) {
+      const id = await this.selfId();
+      joined = id ? await this.docker.connectToNetwork(target, id) : false;
+      if (joined) {
+        this.logger.log(
+          `Attached the manager to "${target}" so game servers on that bridge are reachable`,
+        );
+        this.forgetManagerFacts();
+      }
     }
-    return ok;
-  }
-
-  /** True when the manager runs in a container that ISN'T on ark-net — the setup
-   *  that silently breaks name-based RCON. Null when we can't tell. */
-  async managerMissingArkNet(): Promise<boolean | null> {
-    const manager = await this.manager();
-    if (!manager.inContainer || manager.hostNetwork) return false;
-    if (!manager.networks.length) return null; // inspect denied — don't cry wolf
-    return !manager.networks.includes(ARK_NETWORK);
+    await this.retireLegacyNetwork().catch(() => undefined);
+    return joined;
   }
 
   /**
-   * Sync note for a server Palisade genuinely cannot reach — the manager is off
-   * ark-net AND this server's last resolve had to fall back to the container name
-   * (no shared network, no published port), so RCON/player counts will fail.
+   * Drop the manager's endpoint on the pre-1.11 "ark-net" network once nothing can
+   * still be depending on it. This is the step that repairs Unraid's WebUI link for
+   * a manager on a custom network — Unraid reads the FIRST of the container's
+   * networks and "ark-net" sorted ahead of "br0" (see DEFAULT_SHARED_NETWORK).
    *
-   * Deliberately narrow: being off ark-net is harmless when ports are published, so
-   * this only speaks up for servers that actually failed. Surfaces in the UI's
+   * Never runs on a guess: if Docker won't tell us who else is on that network, the
+   * endpoint stays. Leaving a spare endpoint attached costs nothing; removing one a
+   * socket-proxy was answering on would cut the manager off from Docker entirely.
+   */
+  private async retireLegacyNetwork(): Promise<void> {
+    const plan = await this.legacyPlan();
+    if (!plan || !shouldLeaveLegacy(plan)) return;
+    const id = await this.selfId();
+    if (!id) return;
+    if (await this.docker.disconnectFromNetwork(LEGACY_NETWORK, id)) {
+      this.logger.log(
+        `Detached the manager from the legacy "${LEGACY_NETWORK}" network — every server now runs on "${targetNetwork(plan.override)}"`,
+      );
+      this.forgetManagerFacts();
+    }
+  }
+
+  /**
+   * How far along the move off "ark-net" this install is, or null when the network
+   * is gone or Docker won't say. Everything the plan decides is derived here once so
+   * the rules themselves stay pure and testable (common/shared-network.ts).
+   */
+  private async legacyPlan(): Promise<NetworkPlanInput | null> {
+    const manager = await this.manager();
+    if (!manager.inContainer) return null;
+    // Docker lists only containers with a LIVE endpoint here, so a stopped server on
+    // the legacy network doesn't count — correctly: every start recreates the
+    // container, so it comes back on the new network regardless.
+    const ids = await this.docker.networkContainerIds(LEGACY_NETWORK);
+    if (ids === null) return null; // network absent, or the API is denied to us
+    const selfId = await this.selfId();
+    const managed = new Set((await this.docker.listManagedServers()).map((s) => s.id));
+    return {
+      override: loadEnv().SHARED_NETWORK,
+      managerNetworks: manager.networks,
+      legacyServers: ids.filter((id) => managed.has(id)).length,
+      otherOnLegacy: ids.some((id) => id !== selfId && !managed.has(id)),
+      dockerViaProxy: dockerViaProxy(loadEnv().DOCKER_HOST),
+    };
+  }
+
+  /** Progress note for the admin while both networks are in play, else null. */
+  async migrationNote(): Promise<string | null> {
+    const plan = await this.legacyPlan().catch(() => null);
+    return plan ? legacyMigrationNote(plan) : null;
+  }
+
+  /** True when the manager runs in a container attached to NEITHER the shared network
+   *  nor the legacy one — the setup that silently breaks name-based RCON. Null when
+   *  we can't tell. */
+  async managerMissingSharedNetwork(): Promise<boolean | null> {
+    const manager = await this.manager();
+    if (!manager.inContainer || manager.hostNetwork) return false;
+    if (!manager.networks.length) return null; // inspect denied — don't cry wolf
+    return !manager.networks.some((n) => n === manager.sharedNetwork || n === LEGACY_NETWORK);
+  }
+
+  /**
+   * Sync note for a server Palisade genuinely cannot reach — the manager is off the
+   * shared network AND this server's last resolve had to fall back to the container
+   * name (no shared network, no published port), so RCON/player counts will fail.
+   *
+   * Deliberately narrow: being off the bridge is harmless when ports are published,
+   * so this only speaks up for servers that actually failed. Surfaces in the UI's
    * health banner because "check /api/health" is not something a panel user should
    * have to know how to do (GH #21).
    */
   addressingNote(serverId: string): string | null {
-    if (this.missingArkNet !== true) return null;
+    if (this.missingShared !== true) return null;
     if (this.lastVia.get(serverId) !== "container-name") return null;
     const target = this.managerName || "<manager container>";
-    return `Palisade can't reach this server's RCON/query port — the manager container isn't attached to the "${ARK_NETWORK}" network and this server's ports aren't published to the host, so player counts and the console won't work. Fix: run \`docker network connect ${ARK_NETWORK} ${target}\` (on Unraid: edit the Palisade container and set Network Type to ${ARK_NETWORK}), then restart this server.`;
+    const net = this.sharedNetworkName();
+    return `Palisade can't reach this server's RCON/query port — the manager container isn't attached to the "${net}" network and this server's ports aren't published to the host, so player counts and the console won't work. Fix: run \`docker network connect ${net} ${target}\` (on Unraid: edit the Palisade container and set Network Type to ${net}), then restart this server.`;
+  }
+
+  /** The bridge new game containers are created on. */
+  sharedNetworkName(): string {
+    return targetNetwork(loadEnv().SHARED_NETWORK);
+  }
+
+  /** Our own container id, memoized — every network call needs it. Only a SUCCESSFUL
+   *  lookup is kept: caching a transient boot-time failure would pin the manager to
+   *  "can't see myself" for the life of the process and quietly skip every attach. */
+  private async selfId(): Promise<string | null> {
+    const id = await (this.selfContainerId ??= findSelfContainerId(this.docker.client).catch(
+      () => null,
+    ));
+    if (!id) this.selfContainerId = null;
+    return id;
+  }
+
+  /** Our cached view of our own networking is stale after we change it — the next
+   *  resolve (and the health check) must see the new interface list. */
+  private forgetManagerFacts(): void {
+    this.managerFacts = null;
+    this.missingShared = null;
   }
 
   /** The game container's networking, or null if we can't see it. */
@@ -164,9 +248,15 @@ export class GameEndpointService {
   }
 
   private async loadManagerFacts(): Promise<ManagerNetworkFacts> {
-    const unknown: ManagerNetworkFacts = { inContainer: false, hostNetwork: false, networks: [] };
+    const sharedNetwork = this.sharedNetworkName();
+    const unknown: ManagerNetworkFacts = {
+      inContainer: false,
+      hostNetwork: false,
+      networks: [],
+      sharedNetwork,
+    };
     try {
-      const id = await findSelfContainerId(this.docker.client);
+      const id = await this.selfId();
       if (!id) return unknown; // not in a container (dev on the host)
       const info = await this.docker.inspect(id);
       const networks = Object.keys(info.NetworkSettings?.Networks ?? {});
@@ -175,9 +265,13 @@ export class GameEndpointService {
         hostNetwork: info.HostConfig?.NetworkMode === "host" || networks.includes("host"),
         networks,
         name: info.Name?.replace(/^\//, "") || null,
+        sharedNetwork,
       };
       this.managerName = facts.name ?? null;
-      this.missingArkNet = facts.hostNetwork ? false : !networks.includes(ARK_NETWORK);
+      // Either bridge counts: mid-migration the servers may still be on the old one.
+      this.missingShared = facts.hostNetwork
+        ? false
+        : !networks.some((n) => n === sharedNetwork || n === LEGACY_NETWORK);
       this.logger.log(
         `manager networking: ${facts.hostNetwork ? "host" : networks.join(", ") || "none detected"}`,
       );

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -2,7 +2,6 @@ import { Controller, Get } from "@nestjs/common";
 import { Public } from "../auth/public.decorator";
 import { DockerService } from "../docker/docker.service";
 import { GameEndpointService } from "../docker/game-endpoint.service";
-import { ARK_NETWORK } from "../common/naming";
 import { hostDataDirMismatch, mismatchMessage } from "../config/ensure-host-data-dir";
 
 @Controller("health")
@@ -18,14 +17,20 @@ export class HealthController {
     // A manager that isn't on ark-net can still run every container, but can't
     // resolve them by name — which used to surface only as an opaque RCON DNS
     // error (GH #21). Say so up front. Null = we couldn't tell; stay quiet.
-    const missingArkNet = await this.endpoints.managerMissingArkNet().catch(() => null);
+    const missingShared = await this.endpoints.managerMissingSharedNetwork().catch(() => null);
+    const network = this.endpoints.sharedNetworkName();
+    // Progress note while an install moves off the pre-1.11 "ark-net" network. Not a
+    // fault — it clears itself as servers are restarted — but it needs saying, since
+    // finishing it is what restores the WebUI link on Unraid custom networks (GH #31).
+    const migration = await this.endpoints.migrationNote().catch(() => null);
     const dataDir = hostDataDirMismatch();
     const warnings = [
-      ...(missingArkNet
+      ...(missingShared
         ? [
-            `The manager container is not attached to the "${ARK_NETWORK}" network. Game servers on the bridge are reached by IP where possible, but RCON/player counts may fail for containers with unpublished ports. Fix: docker network connect ${ARK_NETWORK} <manager container>`,
+            `The manager container is not attached to the "${network}" network. Game servers on the bridge are reached by IP where possible, but RCON/player counts may fail for containers with unpublished ports. Fix: docker network connect ${network} <manager container>`,
           ]
         : []),
+      ...(migration ? [migration] : []),
       // A HOST_DATA_DIR that disagrees with the real /data mount puts every game
       // server somewhere the user never configured (GH #29).
       ...(dataDir ? [mismatchMessage(dataDir.configured, dataDir.detected)] : []),

--- a/apps/api/src/servers/lifecycle-harness.ts
+++ b/apps/api/src/servers/lifecycle-harness.ts
@@ -250,7 +250,11 @@ export async function makeService(row: ServerRow, docker: FakeDocker) {
     logCapture as never,
     { create: noop } as never,
     { count: async () => ({ online: 0 }) } as never,
-    { addressingNote: () => null, ensureManagerOnArkNet: async () => false } as never, // endpoints
+    {
+      addressingNote: () => null,
+      ensureManagerNetworks: async () => false,
+      sharedNetworkName: () => "palisade-net",
+    } as never, // endpoints
     configWriter,
     { getAll: async () => ({}) } as never, // artwork
   );

--- a/apps/api/src/servers/runtime-spec.ts
+++ b/apps/api/src/servers/runtime-spec.ts
@@ -55,7 +55,8 @@ import { SOTF_GAME_SETTINGS_KEYS } from "../catalog/sotf.catalog";
 import { LIF_SKILLCAP_GROUPS } from "../catalog/lif.catalog";
 import { TERRARIA_CLI_KEYS } from "../catalog/terraria.catalog";
 import { FACTORIO_ENV_KEYS } from "../catalog/factorio.catalog";
-import { ARK_NETWORK, containerName } from "../common/naming";
+import { containerName } from "../common/naming";
+import { targetNetwork } from "../common/shared-network";
 import { loadEnv } from "../config/env";
 
 export interface RuntimeSpecInput {
@@ -244,6 +245,19 @@ function gameSpecFor(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
   return buildAseSpec(input);
 }
 
+/**
+ * The bridge every non-host-network game container joins, so the manager can reach
+ * its admin ports. Host-network specs get nothing — they share the host's stack.
+ * One helper rather than the same literal in all 26 game specs, so the network name
+ * has exactly one source of truth while installs migrate off "ark-net".
+ */
+function bridgeNetworking(
+  hostNet: boolean,
+): Partial<Pick<Docker.ContainerCreateOptions, "NetworkingConfig">> {
+  if (hostNet) return {};
+  return { NetworkingConfig: { EndpointsConfig: { [targetNetwork(loadEnv().SHARED_NETWORK)]: {} } } };
+}
+
 const portKey = (p: number, proto: "udp" | "tcp") => `${p}/${proto}`;
 
 /**
@@ -371,7 +385,7 @@ function buildPokSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
       // ASA wants a high fd limit; POK warns it can't raise it itself.
       Ulimits: [{ Name: "nofile", Soft: 100000, Hard: 100000 }],
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -448,7 +462,7 @@ function buildAseSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
       Ulimits: [{ Name: "nofile", Soft: 100000, Hard: 100000 }],
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -560,7 +574,7 @@ function buildConanSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions 
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -637,7 +651,7 @@ function buildPalworldSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptio
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -744,7 +758,7 @@ function buildPalworldWineSpec(input: RuntimeSpecInput): Docker.ContainerCreateO
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -834,7 +848,7 @@ function buildMinecraftSpec(input: RuntimeSpecInput): Docker.ContainerCreateOpti
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -912,7 +926,7 @@ function buildIcarusSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -985,7 +999,7 @@ function buildBedrockSpec(input: RuntimeSpecInput): Docker.ContainerCreateOption
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1066,7 +1080,7 @@ function buildValheimSpec(input: RuntimeSpecInput): Docker.ContainerCreateOption
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1174,7 +1188,7 @@ function buildSevenDaysSpec(input: RuntimeSpecInput): Docker.ContainerCreateOpti
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1241,7 +1255,7 @@ function buildEnshroudedSpec(input: RuntimeSpecInput): Docker.ContainerCreateOpt
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1364,7 +1378,7 @@ function buildZomboidSpec(input: RuntimeSpecInput): Docker.ContainerCreateOption
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1552,7 +1566,7 @@ function buildVRisingSpec(input: RuntimeSpecInput): Docker.ContainerCreateOption
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1616,7 +1630,7 @@ function buildSotfSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1721,7 +1735,7 @@ function buildSatisfactorySpec(input: RuntimeSpecInput): Docker.ContainerCreateO
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1802,7 +1816,7 @@ function buildLifSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1869,7 +1883,7 @@ function buildFactorioSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptio
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -1989,7 +2003,7 @@ function buildRustSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -2055,7 +2069,7 @@ function buildBeammpSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -2129,7 +2143,7 @@ function buildTerrariaSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptio
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -2228,7 +2242,7 @@ function buildCoreKeeperSpec(input: RuntimeSpecInput): Docker.ContainerCreateOpt
     },
     // Relay mode needs no inbound ports; on the bridge the container still joins
     // ark-net for consistency (harmless — nothing connects to it).
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -2299,7 +2313,7 @@ function buildAtsSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -2365,7 +2379,7 @@ function buildCs2Spec(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -2425,7 +2439,7 @@ function buildDstSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions {
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 
@@ -2571,7 +2585,7 @@ function buildOpenttdSpec(input: RuntimeSpecInput): Docker.ContainerCreateOption
       Memory: input.ramLimitMb ? input.ramLimitMb * 1024 * 1024 : undefined,
       NanoCpus: input.cpuLimit ? Math.round(input.cpuLimit * 1e9) : undefined,
     },
-    ...(hostNet ? {} : { NetworkingConfig: { EndpointsConfig: { [ARK_NETWORK]: {} } } }),
+    ...bridgeNetworking(hostNet),
   };
 }
 

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -54,7 +54,7 @@ import { detectPalWineProxyDlls } from "../palmods/palmods.service";
 import { GameEndpointService } from "../docker/game-endpoint.service";
 import { portsFor, serverPortSet } from "../catalog/ports";
 import { LocalPaths } from "../common/paths";
-import { containerName, ARK_NETWORK } from "../common/naming";
+import { containerName } from "../common/naming";
 import { hostStats } from "../common/host-stats";
 import { IMAGES, SERVER_UID, SERVER_GID } from "../common/images";
 import { loadEnv } from "../config/env";
@@ -301,12 +301,13 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
   // ── Startup reconciliation ──────────────────────────────────────────────────
   /** On boot, re-sync DB state + monitors with the Docker reality (see reconcile). */
   async onApplicationBootstrap(): Promise<void> {
-    // Join ark-net ourselves if we aren't on it, so RCON and player counts work
-    // without anyone running `docker network connect` by hand (GH #31). No-op when
-    // the network doesn't exist yet — a first server start creates it and joins then.
+    // Join the shared bridge ourselves if we aren't on it, so RCON and player counts
+    // work without anyone running `docker network connect` by hand, and let go of the
+    // legacy one once nothing needs it (GH #31). No-op when the network doesn't exist
+    // yet — a first server start creates it and joins then.
     await Promise.resolve()
-      .then(() => this.endpoints.ensureManagerOnArkNet())
-      .catch((e) => this.logger.debug(`ark-net self-attach skipped: ${(e as Error).message}`));
+      .then(() => this.endpoints.ensureManagerNetworks())
+      .catch((e) => this.logger.debug(`network self-attach skipped: ${(e as Error).message}`));
     await this.reconcile().catch((e) =>
       this.logger.error(`Startup reconcile failed: ${(e as Error).message}`),
     );
@@ -1898,7 +1899,7 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
 
   /**
    * Make sure the bridge network this spec attaches to actually exists. Docker's own
-   * failure here is "(HTTP code 404) no such container - network ark-net not found",
+   * failure here is "(HTTP code 404) no such container - network palisade-net not found",
    * which reads like a container problem and sent a user hunting (GH #31). Host-network
    * specs have no EndpointsConfig, so this is a no-op for them.
    */
@@ -1913,11 +1914,11 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       if (exists !== false) continue;
       const created =
         loadEnv().AUTO_CREATE_NETWORK && (await this.docker.createBridgeNetwork(name).catch(() => false));
-      if (created && name === ARK_NETWORK) {
+      if (created && name === this.endpoints.sharedNetworkName()) {
         // We just made the bridge this server will sit on — join it ourselves too,
         // or the manager still couldn't reach the server it is about to start.
         await Promise.resolve()
-          .then(() => this.endpoints.ensureManagerOnArkNet())
+          .then(() => this.endpoints.ensureManagerNetworks())
           .catch(() => undefined);
       }
       if (!created) {

--- a/apps/api/src/servers/shared-network-preflight.test.ts
+++ b/apps/api/src/servers/shared-network-preflight.test.ts
@@ -3,17 +3,17 @@ import { FakeDocker, makeRow, makeService, setupE2eEnv, startServer } from "./li
 import { resetEnvCache } from "../config/env";
 
 /**
- * GH #31: with GAME_HOST_NETWORK=false and no ark-net, a start died on Docker's raw
- * "(HTTP code 404) no such container - network ark-net not found" — which reads like a
- * container fault, not a missing prerequisite. Palisade now creates it, and when it
- * can't, says so in words the user can act on.
+ * GH #31: with GAME_HOST_NETWORK=false and no shared bridge, a start died on Docker's
+ * raw "(HTTP code 404) no such container - network palisade-net not found" — which
+ * reads like a container fault, not a missing prerequisite. Palisade now creates it,
+ * and when it can't, says so in words the user can act on.
  */
 beforeAll(async () => {
   await setupE2eEnv();
-  process.env.GAME_HOST_NETWORK = "false"; // specs then carry an ark-net EndpointsConfig
+  process.env.GAME_HOST_NETWORK = "false"; // specs then carry a bridge EndpointsConfig
 });
 
-describe("ark-net preflight", () => {
+describe("shared-network preflight", () => {
   let docker: FakeDocker;
   beforeEach(() => {
     docker = new FakeDocker();
@@ -21,16 +21,16 @@ describe("ark-net preflight", () => {
     resetEnvCache(); // loadEnv memoizes; the flag is read at start time
   });
 
-  it("creates ark-net when it is confirmed missing, and the start proceeds", async () => {
+  it("creates the shared network when it is confirmed missing, and the start proceeds", async () => {
     docker.networkPresent = false;
     const row = makeRow();
     const { service } = await makeService(row, docker);
     await startServer(service, row.id);
-    expect(docker.createdNetworks).toEqual(["ark-net"]);
+    expect(docker.createdNetworks).toEqual(["palisade-net"]);
     expect(docker.createdSpecs.length).toBe(1);
   });
 
-  it("does not touch Docker's networks when ark-net already exists", async () => {
+  it("does not touch Docker's networks when the shared network already exists", async () => {
     docker.networkPresent = true;
     const row = makeRow();
     const { service } = await makeService(row, docker);
@@ -56,7 +56,7 @@ describe("ark-net preflight", () => {
     docker.networkCreateFails = true;
     const row = makeRow();
     const { service } = await makeService(row, docker);
-    await expect(startServer(service, row.id)).rejects.toThrow(/docker network create ark-net/);
+    await expect(startServer(service, row.id)).rejects.toThrow(/docker network create palisade-net/);
     // Nothing was created — the start stopped at the preflight, not mid-launch.
     expect(docker.createdSpecs.length).toBe(0);
   });

--- a/apps/web/components/setup-warnings.tsx
+++ b/apps/web/components/setup-warnings.tsx
@@ -11,7 +11,8 @@ interface Health {
 
 /**
  * Host-setup problems Palisade can detect but not fix for you — the manager sitting
- * off ark-net, or a HOST_DATA_DIR that disagrees with the real /data mount.
+ * off the shared Docker network, a migration off the old "ark-net" one that still
+ * has servers to move, or a HOST_DATA_DIR that disagrees with the real /data mount.
  *
  * These were already reported by GET /api/health, which is not somewhere a panel
  * user would ever think to look: the #31 reporter had to be told the fix in the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       TZ: ${TZ:-UTC}
       # Run game containers on the host network (removes Docker NAT → more reliable
       # ASA/EOS public listing). When on, the manager reaches RCON via
-      # host.docker.internal (see extra_hosts below). Default off = ark-net bridge.
+      # host.docker.internal (see extra_hosts below). Default off = palisade-net bridge.
       GAME_HOST_NETWORK: ${GAME_HOST_NETWORK:-false}
     volumes:
       - ${HOST_DATA_DIR:-./data}:/data
@@ -51,7 +51,7 @@ services:
     ports:
       - "3000:3000" # web UI
       - "8787:8787" # API (optional to expose; web can proxy)
-    networks: [ark-net]
+    networks: [palisade-net]
     restart: unless-stopped
 
   # Least-privilege Docker API gateway (opt in — see header comment).
@@ -74,7 +74,9 @@ services:
   #   restart: unless-stopped
 
 networks:
-  ark-net:
-    name: ark-net
+  # Named, not compose-prefixed: the manager creates game containers on this exact
+  # name. It sorts after br0/bond0/eth0 on purpose — see DEFAULT_SHARED_NETWORK.
+  palisade-net:
+    name: palisade-net
   # docker-proxy-net:
   #   internal: true   # no outbound access; only the manager talks to the proxy

--- a/unraid/palisade.xml
+++ b/unraid/palisade.xml
@@ -2,7 +2,7 @@
 <!-- Unraid template for Palisade (formerly ARK Server Manager).
      Controls Docker via the host socket mounted at /var/run/docker.sock. For
      least-privilege access instead, front Docker with a tecnativa/docker-socket-proxy
-     on 'ark-net', set DOCKER_HOST to tcp://socket-proxy:2375, and drop the socket mount.
+     on 'palisade-net', set DOCKER_HOST to tcp://socket-proxy:2375, and drop the socket mount.
 
      IMPORTANT: use a path on the cache disk itself (/mnt/cache/appdata/...), NOT
      the /mnt/user FUSE mount — the manager reflink-clones the ~13 GB game files
@@ -15,7 +15,7 @@
   <Name>Palisade</Name>
   <Repository>ghcr.io/shakes63/palisade:latest</Repository>
   <Registry>https://github.com/Shakes63/palisade/pkgs/container/palisade</Registry>
-  <Network>ark-net</Network>
+  <Network>palisade-net</Network>
   <Privileged>false</Privileged>
   <Support>https://github.com/Shakes63/palisade/issues</Support>
   <Project>https://github.com/Shakes63/palisade</Project>
@@ -40,10 +40,11 @@
   <Config Name="PUBLIC_BASE_URL" Target="PUBLIC_BASE_URL" Default="" Type="Variable" Display="always" Required="false" Description="The address you actually reach the manager at, e.g. http://10.10.10.10:8970. Used for links and for each game server's WebUI button on the Unraid Docker page."/>
   <Config Name="SECRETS_KEY" Target="SECRETS_KEY" Default="" Type="Variable" Display="advanced" Required="false" Mask="true" Description="Optional. LEAVE BLANK and the manager generates a strong key on first start and saves it in App data, so it stays stable across restarts - nothing to do. Only set one yourself (openssl rand -hex 32, 64 hex chars) if you want to control it or reuse an App-data folder from another install. It encrypts saved passwords, so if it ever changes, previously saved passwords can't be decrypted."/>
   <Config Name="JWT_SECRET" Target="JWT_SECRET" Default="" Type="Variable" Display="advanced" Required="false" Mask="true" Description="Optional. LEAVE BLANK - the manager generates and persists one on first start. It signs your login session tokens; changing it just logs everyone out (no data loss). Only set one (openssl rand -hex 24) if you specifically want to."/>
-  <Config Name="GAME_HOST_NETWORK" Target="GAME_HOST_NETWORK" Default="true" Type="Variable" Display="always" Required="false" Description="Run game servers directly on the host network instead of a Docker bridge. true (recommended) gives more reliable ASA/EOS public server listing; false puts them on the ark-net bridge.">true</Config>
+  <Config Name="GAME_HOST_NETWORK" Target="GAME_HOST_NETWORK" Default="true" Type="Variable" Display="always" Required="false" Description="Run game servers directly on the host network instead of a Docker bridge. true (recommended) gives more reliable ASA/EOS public server listing; false puts them on the palisade-net bridge.">true</Config>
 
   <Config Name="DOCKER_HOST" Target="DOCKER_HOST" Default="unix:///var/run/docker.sock" Type="Variable" Display="advanced" Required="false" Description="How the manager connects to Docker. unix:///var/run/docker.sock uses the socket mounted above. Only change this if you front Docker with a least-privilege socket-proxy, in which case use tcp://socket-proxy:2375.">unix:///var/run/docker.sock</Config>
-  <Config Name="AUTO_CREATE_NETWORK" Target="AUTO_CREATE_NETWORK" Default="true" Type="Variable" Display="advanced" Required="false" Description="Let Palisade manage the 'ark-net' Docker network by itself: create it when a game server needs it, and attach this container to it when it isn't already. true (recommended) means there is nothing to set up by hand - including on a custom network, where Palisade keeps its own IP and just adds a route to the game servers. Set false to manage networks yourself.">true</Config>
+  <Config Name="AUTO_CREATE_NETWORK" Target="AUTO_CREATE_NETWORK" Default="true" Type="Variable" Display="advanced" Required="false" Description="Let Palisade manage its Docker network by itself: create it when a game server needs it, attach this container to it when it isn't already, and let go of the old 'ark-net' network once no server uses it. true (recommended) means there is nothing to set up by hand - including on a custom network, where Palisade keeps its own IP and just adds a route to the game servers. Set false to manage networks yourself.">true</Config>
+  <Config Name="SHARED_NETWORK" Target="SHARED_NETWORK" Default="" Type="Variable" Display="advanced" Required="false" Description="Optional. LEAVE BLANK. Name of the Docker network the manager and its game servers share; blank means 'palisade-net'. That name matters on Unraid: a container's WebUI link is built from the first of its networks sorted by name, so a network sorting before br0 would take the link with it. Installs made before v1.11 used 'ark-net' and move across on their own as each server is restarted."/>
   <Config Name="HOST_DATA_DIR" Target="HOST_DATA_DIR" Default="" Type="Variable" Display="advanced" Required="false" Description="Optional. LEAVE BLANK - the manager auto-detects the host-side path of App data from its own /data mount on start. It only needs this to bind-mount data into the game-server containers it spawns. Set it manually only if auto-detection fails (check the log), in which case use the exact App data path above."/>
   <Config Name="PUID" Target="PUID" Default="99" Type="Variable" Display="advanced" Required="false" Description="User ID the manager owns its files as. Unraid's default is 99 (the nobody user). Leave as-is unless you specifically need another.">99</Config>
   <Config Name="PGID" Target="PGID" Default="100" Type="Variable" Display="advanced" Required="false" Description="Group ID for file ownership. Unraid's default is 100 (the users group). Leave as-is.">100</Config>


### PR DESCRIPTION
Closes the last thread on #31: after v1.10.1 taught the manager to attach itself to the shared bridge, the reporter found their Unraid WebUI button pointing at `172.19.0.2` instead of their LAN address, and had to hardcode the WebUI field to get it back.

## Why the name was the bug

Unraid builds a container's WebUI link from the **first** of its networks. For a manager on a custom (macvlan/ipvlan) network, `DockerClient.php:333` takes:

```php
$ip = reset($ct['Networks'])['IPAddress'];
```

`$ct['Networks']` is built by iterating `NetworkSettings.Networks` in JSON order, and the Docker API returns that map sorted by name regardless of attach order. I confirmed both directions against a live daemon:

| Primary network | Attached later | First key |
|---|---|---|
| `zz-primary` | `aa-second` | `aa-second` |
| `aa-primary` | `zz-second` | `aa-primary` |

So `ark-net` beat `br0` and took the WebUI link with it. `palisade-net` sorts after `br0`, `bond0` and `eth0`, so Unraid picks the right IP by itself — no fixed-IP field, nothing for the user to do. Line 1016 reassigns the `NetworkMode` key right after building the map, but PHP keeps an existing key in place, so it doesn't help; this is really an Unraid bug, and if they ever fix it the name simply stops mattering.

The rename also retires a name that stopped making sense 25 games ago.

## Migration

Automatic, one-way, and a half-migrated install works the whole way through:

- New containers are created on the target network. Existing servers move the next time they start — every start already recreates the container.
- The manager holds **both** networks until nothing needs the old one, then drops it. Endpoint resolution reads each container's real networking, so servers on either bridge stay reachable meanwhile.
- It never lets go on a guess. Any managed server still on `ark-net`, any container that isn't ours on it (the socket-proxy setup the README used to describe), `DOCKER_HOST` pointing at a TCP proxy, or Docker declining to say who else is attached — the endpoint stays. Dropping the network a socket-proxy answers on would take Docker access with it.
- Until it finishes, `/health` and the Servers banner report the one step left: restart the remaining servers.

`SHARED_NETWORK` overrides the name, and is the escape hatch if a host has its own network sorting after the default.

## Also in here

- The identical `NetworkingConfig` literal in all 25 game specs collapses into one helper, so the network name has a single source of truth.
- A failed self-container-id lookup is no longer cached — a transient failure at boot could otherwise skip every attach for the life of the process.

## Verification

- 476 tests pass (up from 461): 19 for the migration rules, 15 driving the service against a fake Docker (every stand-down reason has a case, since detaching is the step that can do real damage), and mid-migration coverage for resolution.
- `pnpm typecheck`, full `pnpm build`, and `pnpm audit --prod --audit-level high` clean.
- Unraid behaviour read off a real 7.2.2 install rather than inferred.

## Risk

The detach is the only destructive step, and it's guarded four ways plus `AUTO_CREATE_NETWORK=false`. Worst realistic case is a manager that stays on both networks — which is exactly today's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)