### PR TITLE
Match container ids by prefix, so the manager recognises itself on ark-net

### DIFF
--- a/apps/api/src/common/shared-network.test.ts
+++ b/apps/api/src/common/shared-network.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   NetworkPlanInput,
   dockerViaProxy,
+  sameContainerId,
   legacyMigrationNote,
   legacyStillNeeded,
   shouldLeaveLegacy,
@@ -127,5 +128,35 @@ describe("legacyMigrationNote", () => {
     // Manager still on both, but no servers and no blockers: shouldLeaveLegacy is
     // about to clear it, so don't put a chore in front of the user first.
     expect(legacyMigrationNote(done)).toBeNull();
+  });
+});
+
+describe("sameContainerId", () => {
+  // Caught on a live Unraid box, not by any of these tests before it: `docker
+  // network inspect` returns the full 64-char id, but a container's hostname — how
+  // the manager identifies itself — is the 12-char short form. Comparing them with
+  // === made the manager count itself as a stranger on the legacy network, which
+  // blocked the migration from ever completing.
+  const full = "eddb0b7d25489b00b7ad4d3cf8487537cb99877648573a2a4ab40101671e7514";
+  const short = "eddb0b7d2548";
+
+  it("matches the short form against the full id", () => {
+    expect(sameContainerId(full, short)).toBe(true);
+    expect(sameContainerId(short, full)).toBe(true);
+  });
+
+  it("still matches two identical ids", () => {
+    expect(sameContainerId(full, full)).toBe(true);
+  });
+
+  it("does not match different containers", () => {
+    expect(sameContainerId(full, "ffffffffffff")).toBe(false);
+    expect(sameContainerId("ffffffffffff", full)).toBe(false);
+  });
+
+  it("treats a missing id as no match rather than as a wildcard", () => {
+    expect(sameContainerId(null, full)).toBe(false);
+    expect(sameContainerId(full, undefined)).toBe(false);
+    expect(sameContainerId("", full)).toBe(false);
   });
 });

--- a/apps/api/src/common/shared-network.ts
+++ b/apps/api/src/common/shared-network.ts
@@ -31,6 +31,21 @@ export function targetNetwork(override?: string | null): string {
   return (override ?? "").trim() || DEFAULT_SHARED_NETWORK;
 }
 
+/**
+ * Whether two Docker container ids refer to the same container.
+ *
+ * Docker hands back ids at different lengths depending on which API you ask:
+ * `network inspect` returns the full 64-char id, while a container's own hostname —
+ * which is how the manager identifies itself — is the 12-char short form. A plain
+ * `===` therefore made the manager count ITSELF as a stranger on the legacy network,
+ * which both raised a bogus warning and blocked the migration from ever finishing.
+ */
+export function sameContainerId(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (!a || !b) return false;
+  const n = Math.min(a.length, b.length);
+  return a.slice(0, n) === b.slice(0, n);
+}
+
 /** True when Docker is fronted by a proxy rather than the mounted unix socket. */
 export function dockerViaProxy(dockerHost: string): boolean {
   return !/^unix:\/\//i.test(dockerHost.trim());

--- a/apps/api/src/docker/game-endpoint.service.test.ts
+++ b/apps/api/src/docker/game-endpoint.service.test.ts
@@ -9,7 +9,12 @@ vi.mock("../config/ensure-host-data-dir", async (orig) => ({
   findSelfContainerId: async () => selfId,
 }));
 
-let selfId: string | null = "manager-id";
+/** Docker's full id for the manager, and the short form its hostname reports —
+ *  the mismatch that broke the migration on a real box. */
+const MANAGER_FULL = "eddb0b7d25489b00b7ad4d3cf8487537cb99877648573a2a4ab40101671e7514";
+const MANAGER_SHORT = MANAGER_FULL.slice(0, 12);
+
+let selfId: string | null = MANAGER_SHORT;
 
 /**
  * GH #31 follow-up: the manager attaches itself to the shared bridge, and lets go of
@@ -21,7 +26,7 @@ let selfId: string | null = "manager-id";
 class FakeDocker {
   networks: string[] = ["br0"];
   exists: boolean | null = true;
-  legacyMembers: string[] | null = ["manager-id"];
+  legacyMembers: string[] | null = [MANAGER_FULL];
   managedServers: string[] = [];
   connected: string[] = [];
   disconnected: string[] = [];
@@ -63,7 +68,7 @@ const noSettings = { getAutoCreateNetwork: async () => null } as never;
 const make = (docker: FakeDocker) => new GameEndpointService(docker as never, noSettings);
 
 beforeEach(() => {
-  selfId = "manager-id";
+  selfId = MANAGER_SHORT;
   process.env.SECRETS_KEY = "a".repeat(64);
   process.env.JWT_SECRET = "b".repeat(32);
   process.env.DOCKER_HOST = "unix:///var/run/docker.sock";
@@ -141,7 +146,7 @@ describe("retiring the legacy network", () => {
 
   it("drops ark-net once no server is left on it", async () => {
     const docker = migrating();
-    docker.legacyMembers = ["manager-id"];
+    docker.legacyMembers = [MANAGER_FULL];
     await make(docker).ensureManagerNetworks();
     expect(docker.disconnected).toEqual(["ark-net"]);
     expect(docker.networks).toEqual(["br0", "palisade-net"]);
@@ -149,7 +154,7 @@ describe("retiring the legacy network", () => {
 
   it("keeps ark-net while a server still runs on it", async () => {
     const docker = migrating();
-    docker.legacyMembers = ["manager-id", "server-1"];
+    docker.legacyMembers = [MANAGER_FULL, "server-1"];
     docker.managedServers = ["server-1"];
     await make(docker).ensureManagerNetworks();
     expect(docker.disconnected).toEqual([]);
@@ -158,7 +163,7 @@ describe("retiring the legacy network", () => {
   it("keeps ark-net when a container that isn't ours is on it", async () => {
     // The documented socket-proxy setup put one there.
     const docker = migrating();
-    docker.legacyMembers = ["manager-id", "some-other-container"];
+    docker.legacyMembers = [MANAGER_FULL, "some-other-container"];
     await make(docker).ensureManagerNetworks();
     expect(docker.disconnected).toEqual([]);
   });
@@ -210,7 +215,7 @@ describe("migrationNote", () => {
   it("reports servers still to move", async () => {
     const docker = new FakeDocker();
     docker.networks = ["br0", "ark-net", "palisade-net"];
-    docker.legacyMembers = ["manager-id", "server-1", "server-2"];
+    docker.legacyMembers = [MANAGER_FULL, "server-1", "server-2"];
     docker.managedServers = ["server-1", "server-2"];
     expect(await make(docker).migrationNote()).toContain("2 servers");
   });
@@ -220,5 +225,35 @@ describe("migrationNote", () => {
     docker.networks = ["br0", "palisade-net"];
     docker.legacyMembers = null;
     expect(await make(docker).migrationNote()).toBeNull();
+  });
+});
+
+describe("identifying itself on the legacy network", () => {
+  // The bug this guards: docker network inspect reports the manager by its FULL id,
+  // while the manager knows itself by the short one. Comparing them literally made
+  // it see a stranger, set otherOnLegacy, and refuse to ever leave ark-net.
+  it("recognises its own full id when it only knows the short one", async () => {
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "ark-net", "palisade-net"];
+    docker.legacyMembers = [MANAGER_FULL]; // only us
+    selfId = MANAGER_SHORT;
+    await make(docker).ensureManagerNetworks();
+    expect(docker.disconnected).toEqual(["ark-net"]);
+  });
+
+  it("says nothing about a socket-proxy when it is alone on the network", async () => {
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "ark-net", "palisade-net"];
+    docker.legacyMembers = [MANAGER_FULL];
+    expect(await make(docker).migrationNote()).toBeNull();
+  });
+
+  it("stands down when it cannot identify itself at all", async () => {
+    // Every id would look like a stranger, which would pin it to ark-net forever.
+    selfId = null;
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "ark-net", "palisade-net"];
+    expect(await make(docker).migrationNote()).toBeNull();
+    expect(docker.disconnected).toEqual([]);
   });
 });

--- a/apps/api/src/docker/game-endpoint.service.ts
+++ b/apps/api/src/docker/game-endpoint.service.ts
@@ -9,6 +9,7 @@ import {
   NetworkPlanInput,
   dockerViaProxy,
   legacyMigrationNote,
+  sameContainerId,
   shouldLeaveLegacy,
   targetNetwork,
 } from "../common/shared-network";
@@ -173,12 +174,16 @@ export class GameEndpointService {
     const ids = await this.docker.networkContainerIds(LEGACY_NETWORK);
     if (ids === null) return null; // network absent, or the API is denied to us
     const selfId = await this.selfId();
-    const managed = new Set((await this.docker.listManagedServers()).map((s) => s.id));
+    // Without knowing which container we are, every id on that network looks like a
+    // stranger — which would wrongly pin us to the legacy network forever.
+    if (!selfId) return null;
+    const managed = (await this.docker.listManagedServers()).map((s) => s.id);
+    const isManaged = (id: string) => managed.some((m) => sameContainerId(id, m));
     return {
       override: loadEnv().SHARED_NETWORK,
       managerNetworks: manager.networks,
-      legacyServers: ids.filter((id) => managed.has(id)).length,
-      otherOnLegacy: ids.some((id) => id !== selfId && !managed.has(id)),
+      legacyServers: ids.filter(isManaged).length,
+      otherOnLegacy: ids.some((id) => !sameContainerId(id, selfId) && !isManaged(id)),
       dockerViaProxy: dockerViaProxy(loadEnv().DOCKER_HOST),
     };
   }


### PR DESCRIPTION
Found by updating a real Unraid box to the nightly and watching what it did — not by any of the 492 tests.

## The bug

`docker network inspect` reports members by their **full 64-char id**:

```
eddb0b7d25489b00b7ad4d3cf8487537cb99877648573a2a4ab40101671e7514 = Palisade
```

but `findSelfContainerId` returns the container's hostname, which is the **12-char short form** (`eddb0b7d2548`). Comparing them with `!==` made the manager count *itself* as a foreign container on the legacy network.

Two consequences, one cosmetic and one not:

1. The Servers page warned about a socket-proxy on `ark-net` that wasn't there. Observed live:
   > Every server has moved to the "palisade-net" Docker network, but Palisade is still attached to the old "ark-net" one because another container is using it — usually a socket-proxy.
2. **The migration could never complete.** `otherOnLegacy: true` pins `legacyStillNeeded` on, which stops `shouldLeaveLegacy` from ever firing. The manager would sit on both networks indefinitely — precisely the state #40 exists to get out of, since Unraid builds the WebUI link from the first network and `ark-net` sorts ahead of `br0`.

So #40 shipped with its headline outcome broken on every install that has an `ark-net`.

## The fix

`sameContainerId` compares on the shorter of the two ids, applied to both the self check and the managed-server check. It also now stands down entirely when the manager can't identify its own container — otherwise every id looks like a stranger and pins it to the legacy network for the same wrong reason.

## Why the tests missed it

The fake used one made-up id string (`"manager-id"`) on both sides, so full-vs-short never arose. The fixtures now use a real full id and its short prefix. **Without the fix, four tests fail** — I verified by reverting the comparison and re-running, not by assuming.

## Verification

499 tests pass (up from 492). `pnpm typecheck`, `pnpm lint`, `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)