### PR TITLE
Return from a start once the server is committed, not once it has launched

### DIFF
--- a/apps/api/src/servers/servers.controller.ts
+++ b/apps/api/src/servers/servers.controller.ts
@@ -187,7 +187,9 @@ export class ServersController {
 
   @Post(":id/start")
   start(@Param("id") id: string, @Body() body: StartBody) {
-    return this.servers.start(id, { force: body?.force, stopFirst: body?.stopFirst });
+    // Detached: returns once the server is Starting, so a long image pull can't
+    // outlive the request timeout and surface as an error for a start that worked.
+    return this.servers.startDetached(id, { force: body?.force, stopFirst: body?.stopFirst });
   }
 
   @Post(":id/stop")

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -966,7 +966,10 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
     return { jobId };
   }
 
-  async start(id: string, opts: { force?: boolean; stopFirst?: string } = {}): Promise<void> {
+  async start(
+    id: string,
+    opts: { force?: boolean; stopFirst?: string; onAdmitted?: () => void } = {},
+  ): Promise<void> {
     if (opts.stopFirst && opts.stopFirst !== id) {
       // Swap: back up the outgoing server, then stop it (freeing RAM), then start
       // this one. The backup is best-effort — the graceful stop also saves the world
@@ -985,7 +988,39 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
     // but not a restart-in-place, which re-uses files already on disk. A near-full
     // volume corrupts a fresh install and starves a running server's saves.
     if (!opts.force) await this.assertDiskAvailable(id);
-    return this.withLock(id, () => this.doStart(id));
+    return this.withLock(id, () => this.doStart(id, opts.onAdmitted));
+  }
+
+  /**
+   * Start for the HTTP layer: resolves once the server is committed to Starting,
+   * while the launch itself finishes in the background under the same lock.
+   *
+   * A first start pulls a game image — 3.3 GB for Palworld's Wine variant — which
+   * routinely outlives Node's 5-minute default requestTimeout. The socket was then
+   * torn down mid-pull, the web app's proxy logged ECONNRESET, and the UI reported
+   * "Internal Server Error" for a start that was working fine and did reach Running.
+   *
+   * Validation still answers synchronously, so a bad request is still a 400. Only
+   * the slow half is detached, and its failures are already recorded on the server
+   * (Crashed + crashReason) where the UI reads them. Internal callers keep using
+   * start(): the cluster launcher relies on it awaiting completion so members come
+   * up one at a time rather than all at once.
+   */
+  async startDetached(id: string, opts: { force?: boolean; stopFirst?: string } = {}): Promise<void> {
+    let admit!: () => void;
+    let reject!: (e: unknown) => void;
+    const admitted = new Promise<void>((res, rej) => {
+      admit = res;
+      reject = rej;
+    });
+    // Anything thrown before admission is the caller's answer; anything after it has
+    // already been turned into a crashReason, so it must not become an unhandled
+    // rejection here.
+    // then(admit) as well as the callback: a start that finishes outright still has to
+    // settle this promise, or the request would hang waiting for an admission that
+    // already went by.
+    void this.start(id, { ...opts, onAdmitted: admit }).then(admit, reject);
+    return admitted;
   }
 
   /** Throw a 409 (with the running servers + RAM) if starting `id` would exceed the
@@ -1221,7 +1256,7 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
     });
   }
 
-  private async doStart(id: string): Promise<void> {
+  private async doStart(id: string, onAdmitted?: () => void): Promise<void> {
     const server = (await this.prisma.server.findUnique({
       where: { id },
       include: { cluster: true },
@@ -1241,6 +1276,9 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
     await this.sm.transition(id, ServerState.Starting);
     // Fresh attempt → drop any stale crash reason from a previous failed boot.
     await this.prisma.server.update({ where: { id }, data: { crashReason: null } }).catch(() => undefined);
+    // Committed: every check that can answer the caller has passed, so an HTTP start
+    // can return here rather than hold the request open through the image pull.
+    onAdmitted?.();
     try {
       const game = server.game as Game;
       // Clone game files from the warmed cache if available, so POK boots

--- a/apps/api/src/servers/start-detached.test.ts
+++ b/apps/api/src/servers/start-detached.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { FakeDocker, makeRow, makeService, neuterGuards, setupE2eEnv } from "./lifecycle-harness";
+import { ServerState } from "@ark/shared";
+
+/**
+ * A first start pulls the game image — 3.3 GB for Palworld's Wine variant — which
+ * outlives Node's 5-minute default requestTimeout. The socket was torn down mid-pull,
+ * the web app's proxy logged ECONNRESET, and the UI reported "Internal Server Error"
+ * for a start that was working and did reach Running. Observed on a real box.
+ *
+ * So the HTTP start now returns once the server is committed to Starting. The point
+ * of these is that detaching didn't cost us the thing the request was for: bad input
+ * still answers the caller, and a failed launch still lands somewhere the UI reads.
+ */
+beforeAll(async () => {
+  await setupE2eEnv();
+});
+
+describe("startDetached", () => {
+  let docker: FakeDocker;
+  beforeEach(() => {
+    docker = new FakeDocker();
+  });
+
+  it("returns while the image is still pulling", async () => {
+    const row = makeRow();
+    const { service } = await makeService(row, docker);
+    neuterGuards(service);
+
+    // Hold the pull open, the way a multi-GB first pull does.
+    let releasePull!: () => void;
+    const pulling = new Promise<void>((res) => (releasePull = res));
+    docker.pullImage = async () => {
+      await pulling;
+    };
+
+    let returned = false;
+    const call = service.startDetached(row.id).then(() => (returned = true));
+    await call;
+    expect(returned).toBe(true);
+    // Still mid-pull: the launch has not created anything yet.
+    expect(docker.createdSpecs.length).toBe(0);
+
+    releasePull();
+  });
+
+  it("commits the server to Starting before it returns", async () => {
+    // Otherwise the UI would briefly show Stopped and look like nothing happened.
+    const row = makeRow();
+    const { service, prisma } = await makeService(row, docker);
+    neuterGuards(service);
+    let releasePull!: () => void;
+    const pulling = new Promise<void>((res) => (releasePull = res));
+    docker.pullImage = async () => {
+      await pulling;
+    };
+
+    await service.startDetached(row.id);
+    const after = await prisma.server.findUnique();
+    expect(after?.state).toBe(ServerState.Starting);
+
+    releasePull();
+  });
+
+  it("still rejects a request that was never valid", async () => {
+    // Validation runs before admission, so a bad state is still the caller's answer
+    // rather than a silent no-op the UI can't explain.
+    const row = makeRow({ state: ServerState.Running });
+    const { service } = await makeService(row, docker);
+    neuterGuards(service);
+    await expect(service.startDetached(row.id)).rejects.toThrow(/Cannot start from state/);
+  });
+
+  it("records a launch failure on the server rather than losing it", async () => {
+    // The request has already returned by then, so crashReason is the only place
+    // left for the reason to surface.
+    const row = makeRow();
+    const { service, prisma } = await makeService(row, docker);
+    neuterGuards(service);
+    docker.missingImage = true;
+
+    await service.startDetached(row.id);
+    await new Promise((r) => setTimeout(r, 50)); // let the detached launch settle
+
+    const after = await prisma.server.findUnique();
+    expect(after?.state).toBe(ServerState.Crashed);
+    expect(after?.crashReason).toMatch(/isn't available/);
+  });
+});


### PR DESCRIPTION
Found while testing #39 on a real Unraid box: starting a Palworld (Wine) server for the first time showed **"Internal Server Error"** in the UI, while the server pulled its image, launched and reached Running perfectly well.

## Cause

Node's default `requestTimeout` is 5 minutes. A first start pulls the game image — 3.3 GB for the Wine variant — so the request outlived it:

```
Failed to proxy http://localhost:8787/api/servers/…/start [Error: socket hang up] { code: 'ECONNRESET' }
```

The socket was torn down mid-pull and the web app's rewrite proxy turned that into a 500. Nothing was actually wrong, which is the worst version of this failure: the user is told their start failed while it's busy succeeding, and the only way to find out otherwise is to watch the state change on its own.

## Fix

The HTTP route now uses `startDetached`, which resolves as soon as the server is committed to `Starting` and lets the launch finish in the background under the same lock.

The split falls where the code already divided it. Everything that can answer the caller — the state check, the new Palworld port guard, the RAM/disk guards, `assertPortsFree` — runs *before* the transition to `Starting`, so **a bad request is still a 400**. A failure after that point already lands on the server as `Crashed` + `crashReason`, which is where the UI reads it.

## What deliberately did not change

`start()` keeps its contract. `clusters.service.ts:114` starts members with a sequential `await` so they come up one at a time rather than all at once, and the scheduler relies on the same completion semantics. Only the HTTP entry point detaches.

## Verification

513 tests (up from 509). The four new ones cover what detaching could plausibly have cost us: it returns mid-pull, it has already committed the server to `Starting` when it returns (so the UI doesn't flash `Stopped`), an invalid request still rejects, and a launch failure still reaches `crashReason` rather than vanishing with the request.

`pnpm typecheck`, `pnpm lint`, `pnpm build` clean.

## Related, not fixed here

Other genuinely long endpoints (install, backup restore) can still hit the same 5-minute ceiling. They didn't come up in testing and each needs its own think about what "done" means, so I've left them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)