### PR TITLE
Run the Palworld (Wine) port guard before the start commits

### DIFF
--- a/apps/api/src/servers/lifecycle-harness.ts
+++ b/apps/api/src/servers/lifecycle-harness.ts
@@ -47,6 +47,8 @@ export interface ServerRow {
   configDirty: boolean;
   crashReason?: string | null;
   updateRequested?: boolean;
+  /** Per-server host-networking override; null = follow the manager setting. */
+  hostNetwork?: boolean | null;
 }
 
 export function makeRow(over: Partial<ServerRow> = {}): ServerRow {

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -1272,6 +1272,16 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
     // up front with a clear message instead. Not bypassed by force — that flag is
     // for the RAM guard; a port clash can never work.
     await this.assertPortsFree(server);
+    // The Wine image can't move its game port, so refuse rather than start a server
+    // reachable somewhere other than where the panel says it is (GH #39). Must run
+    // BEFORE the commit to Starting: past that point the HTTP caller has already been
+    // released, and this would surface as a crash instead of a rejected request.
+    const portIssue = palworldWinePortIssue(
+      server.game as Game,
+      this.portsOf(server),
+      server.hostNetwork ?? (await this.settings.getGameHostNetwork()) ?? loadEnv().GAME_HOST_NETWORK,
+    );
+    if (portIssue) throw new BadRequestException(portIssue);
 
     await this.sm.transition(id, ServerState.Starting);
     // Fresh attempt → drop any stale crash reason from a previous failed boot.
@@ -1325,15 +1335,6 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
         await chown(LocalPaths.instanceRoot(id), SERVER_UID[game], SERVER_GID[game]).catch(() => undefined);
         await chown(dataDir, SERVER_UID[game], SERVER_GID[game]).catch(() => undefined);
       }
-
-      // The Wine image can't move its game port, so refuse rather than start a server
-      // reachable somewhere other than where the panel says it is (GH #39).
-      const portIssue = palworldWinePortIssue(
-        server.game as Game,
-        this.portsOf(server),
-        server.hostNetwork ?? (await this.settings.getGameHostNetwork()) ?? loadEnv().GAME_HOST_NETWORK,
-      );
-      if (portIssue) throw new Error(portIssue);
 
       const spec = await this.assembleSpec(server);
 

--- a/apps/api/src/servers/start-detached.test.ts
+++ b/apps/api/src/servers/start-detached.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { FakeDocker, makeRow, makeService, neuterGuards, setupE2eEnv } from "./lifecycle-harness";
-import { ServerState } from "@ark/shared";
+import { Game, ServerState } from "@ark/shared";
 
 /**
  * A first start pulls the game image — 3.3 GB for Palworld's Wine variant — which
@@ -85,5 +85,21 @@ describe("startDetached", () => {
     const after = await prisma.server.findUnique();
     expect(after?.state).toBe(ServerState.Crashed);
     expect(after?.crashReason).toMatch(/isn't available/);
+  });
+
+  it("still rejects a guard that fires before the commit, rather than crashing", async () => {
+    // Regression guard for the interaction between #39 and this change: the Wine
+    // port check originally sat inside the launch, so detaching turned its 400 into
+    // a 201 followed by a Crashed server. Anything that can answer the caller has to
+    // run before admission.
+    const row = makeRow({ game: Game.PALWORLD_WINE, gamePort: 9000, hostNetwork: true });
+    const { service, prisma } = await makeService(row, docker);
+    neuterGuards(service);
+
+    await expect(service.startDetached(row.id)).rejects.toThrow(/always listens on 8211/);
+    // And it never committed the server, so there is no phantom crash to explain.
+    const after = await prisma.server.findUnique();
+    expect(after?.state).not.toBe(ServerState.Crashed);
+    expect(docker.createdSpecs.length).toBe(0);
   });
 });


### PR DESCRIPTION
Follow-up to #46, caught on a real box within minutes of deploying it.

## What broke

The Wine port guard from #39 sat *inside* the launch. That was fine while the HTTP request was held open for the whole start — the throw became a 400 with an explanation.

Detaching the start (#46) moved the caller's release earlier, so a Wine server with a custom port on host networking now answered **201** and then quietly went **Crashed**:

```
HTTP 201 in 1s
"state":"Crashed"
```

The reason still reached `crashReason`, but a rejected request had turned into a phantom crash the user has to go and read. That's a worse answer to a question the API could answer immediately.

## Fix

Moves the check up beside `assertPortsFree`, before the commit to `Starting`, and throws `BadRequestException` directly rather than depending on the launch's catch to wrap it.

The general rule this makes concrete: **anything that can answer the caller has to run before admission.** The regression test asserts both halves — that it rejects, and that the server was never committed, so there's no crash left behind to explain. Reverting the ordering fails it.

## Verification

514 tests. `pnpm typecheck`, `pnpm lint`, `pnpm build` clean. Also added `hostNetwork` to the test harness's row type, which had not been updated since #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)