### PR TITLE
Detach the relaunch half of restart too

### DIFF
--- a/apps/api/src/servers/servers.controller.ts
+++ b/apps/api/src/servers/servers.controller.ts
@@ -199,6 +199,8 @@ export class ServersController {
 
   @Post(":id/restart")
   restart(@Param("id") id: string) {
-    return this.servers.restart(id);
+    // Detached for the same reason as start: the relaunch pulls an image and would
+    // otherwise outlive the request timeout.
+    return this.servers.restartDetached(id);
   }
 }

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -1574,6 +1574,23 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
   }
 
   /**
+   * Restart for the HTTP layer — the sibling of startDetached, and affected by the
+   * same thing: a relaunch pulls the game image, so restart could outlive Node's
+   * 5-minute requestTimeout and report a failure for a restart that worked.
+   *
+   * Only the relaunch is detached. The stop is awaited because it is already
+   * bounded — a 30s wait for the world save, then Docker's 60s stop grace — so it
+   * cannot be what blows the budget, and awaiting it keeps the restart ordered.
+   *
+   * restart() itself is unchanged: the scheduler, the cluster restart and the
+   * crash-recovery path all rely on it awaiting completion.
+   */
+  async restartDetached(id: string): Promise<void> {
+    await this.stop(id).catch(() => undefined);
+    return this.startDetached(id, { force: true });
+  }
+
+  /**
    * The manager is going down (docker stop, deploy, array shutdown). Fire a
    * best-effort world-save at every RUNNING server so a host reboot costs at
    * most a few seconds of progress instead of everything since the last

--- a/apps/api/src/servers/start-detached.test.ts
+++ b/apps/api/src/servers/start-detached.test.ts
@@ -103,3 +103,61 @@ describe("startDetached", () => {
     expect(docker.createdSpecs.length).toBe(0);
   });
 });
+
+describe("restartDetached", () => {
+  let docker: FakeDocker;
+  beforeEach(() => {
+    docker = new FakeDocker();
+  });
+
+  /** Stop is stubbed the way the existing restart e2e does — the real one waits up
+   *  to 30s for a save marker the fake never emits. It records the call so ordering
+   *  is still asserted. */
+  const withRecordedStop = (service: unknown, row: { state: string }, calls: string[]) => {
+    (service as Record<string, unknown>).stop = async (id: string) => {
+      calls.push(`stop:${id}`);
+      row.state = ServerState.Stopped; // what a real stop leaves behind
+    };
+  };
+
+  it("returns while the relaunch is still pulling", async () => {
+    // The same bug start had, in its sibling: a restart pulls the image too.
+    const row = makeRow({ state: ServerState.Running, containerId: "c1" });
+    const { service } = await makeService(row, docker);
+    neuterGuards(service);
+    withRecordedStop(service, row, []);
+
+    let releasePull!: () => void;
+    const pulling = new Promise<void>((res) => (releasePull = res));
+    docker.pullImage = async () => {
+      await pulling;
+    };
+
+    await service.restartDetached(row.id);
+    // Still mid-pull, so the relaunch has not created anything yet.
+    expect(docker.createdSpecs.length).toBe(0);
+
+    releasePull();
+  });
+
+  it("stops first, then commits to Starting before returning", async () => {
+    const row = makeRow({ state: ServerState.Running, containerId: "c1" });
+    const { service, prisma } = await makeService(row, docker);
+    neuterGuards(service);
+    const calls: string[] = [];
+    withRecordedStop(service, row, calls);
+
+    let releasePull!: () => void;
+    const pulling = new Promise<void>((res) => (releasePull = res));
+    docker.pullImage = async () => {
+      await pulling;
+    };
+
+    await service.restartDetached(row.id);
+    expect(calls).toEqual([`stop:${row.id}`]);
+    const after = await prisma.server.findUnique();
+    expect(after?.state).toBe(ServerState.Starting);
+
+    releasePull();
+  });
+});


### PR DESCRIPTION
Follow-up to #46, from auditing where else that bug class lives.

`restart` is the direct sibling of the endpoint I fixed there and does the same work — stop, then a full launch including the image pull — but it was left holding the request open. So it could still outlive Node's 5-minute `requestTimeout` and report a failure for a restart that worked.

It's arguably the more commonly hit of the two, since restarting is how you apply a config change.

## Change

```ts
async restartDetached(id) {
  await this.stop(id).catch(() => undefined);   // bounded: 30s save wait + 60s stop grace
  return this.startDetached(id, { force: true });
}
```

Only the relaunch detaches. The stop stays awaited because it's already bounded, so it can't be what blows the budget, and awaiting it keeps the restart ordered.

`restart()` itself is unchanged, for the same reason `start()` was: the scheduler, the cluster restart and the crash-recovery path all rely on it awaiting completion.

## Audit results — what's still affected

I went through every mutating route rather than guessing. Not fixed here, and each needs the Job pattern the installer already uses rather than another bespoke detach:

- **`POST /clusters/:id/start`** — starts members sequentially by design, so the request holds for *N × launch time*. Worst case of the remaining set.
- **`POST /servers/:id/backups`** and **`…/restore`** — copies the instance dir; ARK instances run 14–17 GB.
- **`POST /replication/sync`** — SFTP upload, unbounded by size.
- Mod operations (`servers/:id/mods`, `modupdates/apply`, `minecraft/modpack/update`) — usually small, a large modpack could cross it.

**`POST /servers/:id/install` is already correct** — it returns `{ jobId }` and the installer runs detached with progress over realtime. That's the pattern the rest should adopt; it's currently used in exactly one place.

## Verification

516 tests (up from 514). The two new ones cover that it returns mid-pull, and that it still stops first and commits to `Starting` before returning.

`pnpm typecheck`, `pnpm lint`, `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)