### PR TITLE
Detach the whole restart, and correct the timeout it is working around

### DIFF
--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -995,10 +995,11 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
    * Start for the HTTP layer: resolves once the server is committed to Starting,
    * while the launch itself finishes in the background under the same lock.
    *
-   * A first start pulls a game image — 3.3 GB for Palworld's Wine variant — which
-   * routinely outlives Node's 5-minute default requestTimeout. The socket was then
-   * torn down mid-pull, the web app's proxy logged ECONNRESET, and the UI reported
-   * "Internal Server Error" for a start that was working fine and did reach Running.
+   * A first start pulls a game image — 3.3 GB for Palworld's Wine variant — far
+   * longer than the web app's rewrite proxy will hold a connection. It severs at
+   * ~30s (measured; Next 15 exposes no timeout to raise), the API sees ECONNRESET,
+   * and the UI reports "Internal Server Error" for a start that was working fine and
+   * did reach Running. Treat ~30s as the hard ceiling for anything the UI calls.
    *
    * Validation still answers synchronously, so a bad request is still a 400. Only
    * the slow half is detached, and its failures are already recorded on the server
@@ -1574,20 +1575,37 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
   }
 
   /**
-   * Restart for the HTTP layer — the sibling of startDetached, and affected by the
-   * same thing: a relaunch pulls the game image, so restart could outlive Node's
-   * 5-minute requestTimeout and report a failure for a restart that worked.
+   * Restart for the HTTP layer. Detaches the WHOLE restart, stop included.
    *
-   * Only the relaunch is detached. The stop is awaited because it is already
-   * bounded — a 30s wait for the world save, then Docker's 60s stop grace — so it
-   * cannot be what blows the budget, and awaiting it keeps the restart ordered.
+   * Measured rather than assumed: the API answers a restart correctly in ~43s, but
+   * the web app's rewrite proxy severs the connection at ~30s and the browser gets a
+   * 500 for a restart that worked. Next 15 exposes no timeout to raise, so anything
+   * held open past ~30s is unreportable through the UI — and a restart cannot fit,
+   * because the stop alone waits up to 30s for the world save before Docker's stop
+   * grace even starts.
+   *
+   * The cheap checks still answer the caller: a bad id is a 404, and a Wine server
+   * on an impossible port is a 400 (GH #39). Everything after that is reported the
+   * way the UI already follows a restart — Stopping, Starting, then Running or
+   * Crashed with a reason.
    *
    * restart() itself is unchanged: the scheduler, the cluster restart and the
    * crash-recovery path all rely on it awaiting completion.
    */
   async restartDetached(id: string): Promise<void> {
-    await this.stop(id).catch(() => undefined);
-    return this.startDetached(id, { force: true });
+    const server = await this.prisma.server.findUnique({ where: { id } });
+    if (!server) throw new NotFoundException("Server not found");
+    const portIssue = palworldWinePortIssue(
+      server.game as Game,
+      this.portsOf(server),
+      server.hostNetwork ?? (await this.settings.getGameHostNetwork()) ?? loadEnv().GAME_HOST_NETWORK,
+    );
+    if (portIssue) throw new BadRequestException(portIssue);
+
+    // Failures land on the server as Crashed + crashReason; nothing is waiting here.
+    void this.restart(id).catch((e) =>
+      this.logger.warn(`restart of ${id} failed: ${(e as Error).message}`),
+    );
   }
 
   /**

--- a/apps/api/src/servers/start-detached.test.ts
+++ b/apps/api/src/servers/start-detached.test.ts
@@ -110,54 +110,43 @@ describe("restartDetached", () => {
     docker = new FakeDocker();
   });
 
-  /** Stop is stubbed the way the existing restart e2e does — the real one waits up
-   *  to 30s for a save marker the fake never emits. It records the call so ordering
-   *  is still asserted. */
-  const withRecordedStop = (service: unknown, row: { state: string }, calls: string[]) => {
-    (service as Record<string, unknown>).stop = async (id: string) => {
-      calls.push(`stop:${id}`);
-      row.state = ServerState.Stopped; // what a real stop leaves behind
-    };
-  };
-
-  it("returns while the relaunch is still pulling", async () => {
-    // The same bug start had, in its sibling: a restart pulls the image too.
+  it("returns immediately, without waiting for the stop", async () => {
+    // The whole restart detaches: the API answered a real restart in ~43s, but the
+    // web app's proxy severs at ~30s, and the stop alone can spend 30s waiting for a
+    // world save. Nothing about a restart fits inside that budget.
     const row = makeRow({ state: ServerState.Running, containerId: "c1" });
     const { service } = await makeService(row, docker);
     neuterGuards(service);
-    withRecordedStop(service, row, []);
 
-    let releasePull!: () => void;
-    const pulling = new Promise<void>((res) => (releasePull = res));
-    docker.pullImage = async () => {
-      await pulling;
-    };
+    // A stop that never finishes: returning still has to be immediate.
+    (service as unknown as Record<string, unknown>).stop = () => new Promise<void>(() => {});
 
     await service.restartDetached(row.id);
-    // Still mid-pull, so the relaunch has not created anything yet.
     expect(docker.createdSpecs.length).toBe(0);
-
-    releasePull();
   });
 
-  it("stops first, then commits to Starting before returning", async () => {
-    const row = makeRow({ state: ServerState.Running, containerId: "c1" });
-    const { service, prisma } = await makeService(row, docker);
+  it("still answers a bad id rather than detaching into nothing", async () => {
+    const row = makeRow({ state: ServerState.Running });
+    const { service } = await makeService(row, docker);
     neuterGuards(service);
-    const calls: string[] = [];
-    withRecordedStop(service, row, calls);
-
-    let releasePull!: () => void;
-    const pulling = new Promise<void>((res) => (releasePull = res));
-    docker.pullImage = async () => {
-      await pulling;
+    (service as unknown as Record<string, unknown>).prisma = {
+      server: { findUnique: async () => null },
     };
+    await expect(service.restartDetached("nope")).rejects.toThrow(/not found/i);
+  });
 
-    await service.restartDetached(row.id);
-    expect(calls).toEqual([`stop:${row.id}`]);
-    const after = await prisma.server.findUnique();
-    expect(after?.state).toBe(ServerState.Starting);
-
-    releasePull();
+  it("still answers the Wine port guard synchronously", async () => {
+    // The one validation worth keeping in front of the caller: it is cheap, pure,
+    // and the alternative is a crash the user has to go and read (GH #39).
+    const row = makeRow({
+      game: Game.PALWORLD_WINE,
+      gamePort: 9000,
+      hostNetwork: true,
+      state: ServerState.Running,
+    });
+    const { service } = await makeService(row, docker);
+    neuterGuards(service);
+    await expect(service.restartDetached(row.id)).rejects.toThrow(/always listens on 8211/);
+    expect(docker.createdSpecs.length).toBe(0);
   });
 });


### PR DESCRIPTION
Follow-up to #49, which I got partly wrong. Testing on a real box caught it.

## What I had wrong

#49 detached only the relaunch, assuming the binding limit was Node's 5-minute `requestTimeout` and that the bounded stop leg fit comfortably inside it. It doesn't.

Measured on a live install, same request both ways:

| Path | Result |
|---|---|
| Direct to the API (`:8787`) | **201 in 43s** — correct |
| Through the web app's proxy (`:8970`) | **500 in 30s** — `ECONNRESET` |

So the real ceiling is the **rewrite proxy at ~30s**, not Node at five minutes. Next 15 exposes no timeout to raise — there's no `proxyTimeout` in its config schema.

A restart can't fit under 30s either way: the stop alone waits up to 30s for a world save *before* Docker's 60s stop grace begins.

## Change

The whole restart detaches now, stop included. The cheap checks still answer the caller — a bad id is a 404, a Wine server on an impossible port is a 400 (#39) — and everything after that is reported the way the UI already follows a restart: `Stopping`, `Starting`, then `Running` or `Crashed` with a reason.

Also corrects the rationale comment on `startDetached`, which named the wrong timeout. That fix works, but because it returns in ~0s — not because it fit inside five minutes.

## This makes the earlier audit worse, not better

A ~30s ceiling rather than 5 minutes means the endpoints I listed in #49 aren't edge cases on large installs — they're past it on essentially any install:

- **`POST /clusters/:id/start`** — sequential launches, minutes.
- **`POST /servers/:id/backups`** / **`…/restore`** — copies the instance dir.
- **`POST /replication/sync`** — SFTP upload.

Each wants the Job pattern the installer already uses (`{ jobId }` + realtime progress), not another bespoke detach.

## Verification

517 tests. The three new ones cover: it returns even when the stop never finishes, a bad id still 404s, and the Wine guard still answers synchronously.

`pnpm typecheck`, `pnpm lint`, `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)