### PR TITLE
Detach cluster start/stop, the last endpoint the proxy ceiling actually reaches

### DIFF
--- a/apps/api/src/clusters/cluster-detach.test.ts
+++ b/apps/api/src/clusters/cluster-detach.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { NotFoundException } from "@nestjs/common";
+import { ClustersService } from "./clusters.service";
+
+/**
+ * Cluster start/stop walk their members sequentially on purpose, so the request was
+ * held for the sum of every launch or teardown. The web app's rewrite proxy severs a
+ * connection at ~30s (measured against a live install; Next 15 exposes no timeout to
+ * raise), so a cluster of any real size reported a failure for work that was running
+ * fine — the same false alarm that hit start and restart.
+ */
+const makeService = (opts: { members: number; cluster?: boolean; onStart?: () => Promise<void> }) => {
+  const started: string[] = [];
+  const prisma = {
+    cluster: { findUnique: async () => (opts.cluster === false ? null : { id: "c1" }) },
+    server: {
+      count: async () => opts.members,
+      findMany: async () =>
+        Array.from({ length: opts.members }, (_, i) => ({ id: `s${i}`, clusterId: "c1" })),
+    },
+  };
+  const servers = {
+    start: async (id: string) => {
+      started.push(id);
+      if (opts.onStart) await opts.onStart();
+    },
+    stop: async (id: string) => {
+      started.push(`stop:${id}`);
+      if (opts.onStart) await opts.onStart();
+    },
+  };
+  const service = new ClustersService(prisma as never, {} as never, servers as never);
+  return { service, started };
+};
+
+describe("startAllDetached", () => {
+  it("returns the member count without waiting for any of them", async () => {
+    // A launch that never finishes: the caller still gets an answer.
+    const { service, started } = makeService({
+      members: 3,
+      onStart: () => new Promise<void>(() => {}),
+    });
+    expect(await service.startAllDetached("c1")).toEqual({ started: 3 });
+    // Only the first is in flight — the loop is still sequential behind the scenes.
+    expect(started.length).toBeLessThanOrEqual(1);
+  });
+
+  it("still 404s a cluster that does not exist", async () => {
+    // Worth answering before detaching; everything else is visible on the servers list.
+    const { service } = makeService({ members: 0, cluster: false });
+    await expect(service.startAllDetached("nope")).rejects.toThrow(NotFoundException);
+  });
+
+  it("reports zero for an empty cluster rather than pretending", async () => {
+    const { service } = makeService({ members: 0 });
+    expect(await service.startAllDetached("c1")).toEqual({ started: 0 });
+  });
+});
+
+describe("stopAllDetached", () => {
+  it("returns the member count without waiting for the teardowns", async () => {
+    const { service, started } = makeService({
+      members: 2,
+      onStart: () => new Promise<void>(() => {}),
+    });
+    expect(await service.stopAllDetached("c1")).toEqual({ stopped: 2 });
+    expect(started.length).toBeLessThanOrEqual(1);
+  });
+
+  it("still 404s a cluster that does not exist", async () => {
+    const { service } = makeService({ members: 0, cluster: false });
+    await expect(service.stopAllDetached("nope")).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api/src/clusters/clusters.controller.ts
+++ b/apps/api/src/clusters/clusters.controller.ts
@@ -41,12 +41,13 @@ export class ClustersController {
 
   @Post(":id/start")
   startAll(@Param("id") id: string) {
-    return this.clusters.startAll(id);
+    // Detached: sequential member launches far outlast the proxy's ~30s ceiling.
+    return this.clusters.startAllDetached(id);
   }
 
   @Post(":id/stop")
   stopAll(@Param("id") id: string) {
-    return this.clusters.stopAll(id);
+    return this.clusters.stopAllDetached(id);
   }
 
   @Delete(":id")

--- a/apps/api/src/clusters/clusters.service.ts
+++ b/apps/api/src/clusters/clusters.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { randomBytes } from "node:crypto";
 import { EventType, ServerState } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
@@ -17,6 +17,8 @@ function slugify(name: string): string {
  */
 @Injectable()
 export class ClustersService {
+  private readonly logger = new Logger(ClustersService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly events: EventsService,
@@ -119,5 +121,43 @@ export class ClustersService {
     const members = await this.prisma.server.findMany({ where: { clusterId } });
     for (const m of members) await this.servers.stop(m.id).catch(() => undefined);
     return { stopped: members.length };
+  }
+
+  /**
+   * Start/stop every member for the HTTP layer, detached.
+   *
+   * Both loops are sequential on purpose, so the request would be held for the sum
+   * of every member's launch or teardown. The web app's rewrite proxy severs a
+   * connection at ~30s and Next 15 exposes no timeout to raise, so a cluster of any
+   * size reports a failure for work that is running fine — the same false alarm that
+   * hit start and restart.
+   *
+   * The count is what the caller wanted anyway ("this many were asked to start"),
+   * and each member's real progress is already on the servers list.
+   *
+   * startAll/stopAll are unchanged for internal callers.
+   */
+  async startAllDetached(clusterId: string) {
+    const members = await this.membersOf(clusterId);
+    void this.startAll(clusterId).catch((e) =>
+      this.logger.warn(`cluster ${clusterId} start failed: ${(e as Error).message}`),
+    );
+    return { started: members };
+  }
+
+  async stopAllDetached(clusterId: string) {
+    const members = await this.membersOf(clusterId);
+    void this.stopAll(clusterId).catch((e) =>
+      this.logger.warn(`cluster ${clusterId} stop failed: ${(e as Error).message}`),
+    );
+    return { stopped: members };
+  }
+
+  /** Member count, and a 404 for a cluster that isn't there — the one thing worth
+   *  answering before detaching. */
+  private async membersOf(clusterId: string): Promise<number> {
+    const cluster = await this.prisma.cluster.findUnique({ where: { id: clusterId } });
+    if (!cluster) throw new NotFoundException("Cluster not found");
+    return this.prisma.server.count({ where: { clusterId } });
   }
 }

--- a/apps/web/app/clusters/page.tsx
+++ b/apps/web/app/clusters/page.tsx
@@ -31,6 +31,23 @@ export default function ClustersPage() {
   }, []);
   useEffect(() => refresh(), [refresh]);
 
+  /**
+   * Start/stop-all now return as soon as the work is queued, because holding the
+   * request through every member's launch outlasts the proxy. So refresh on a few
+   * delays instead of once: members flip to Starting/Stopping over the following
+   * minute, and a single immediate refresh would always look like nothing happened.
+   */
+  const runOnCluster = async (path: string) => {
+    try {
+      await apiPost(path);
+    } catch (e) {
+      alert((e as Error).message);
+      return;
+    }
+    refresh();
+    for (const ms of [3000, 10000, 30000]) window.setTimeout(refresh, ms);
+  };
+
   const create = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
@@ -72,10 +89,10 @@ export default function ClustersPage() {
               </div>
             </div>
             <div className="flex gap-2">
-              <button className="btn-primary" onClick={() => apiPost(`/clusters/${c.id}/start`).then(refresh)}>
+              <button className="btn-primary" onClick={() => runOnCluster(`/clusters/${c.id}/start`)}>
                 <Play className="h-4 w-4" /> Start all
               </button>
-              <button className="btn-secondary" onClick={() => apiPost(`/clusters/${c.id}/stop`).then(refresh)}>
+              <button className="btn-secondary" onClick={() => runOnCluster(`/clusters/${c.id}/stop`)}>
                 <Square className="h-4 w-4" /> Stop all
               </button>
               <button


### PR DESCRIPTION
Closing out the audit from #50 — after measuring it, most of which turned out to be wrong.

## What I measured

| Endpoint | Result | Affected? |
|---|---|---|
| `POST /servers/:id/backups` (14 GB instance) | **201 in 0s** | No |
| `POST /servers/:id/backups/:id/restore` | **201 in 0s** | No |
| `POST /replication/sync` | already detached at the controller | No |
| `POST /clusters/:id/start` \| `/stop` | sequential member loop | **Yes** |

Backups aren't affected because they copy the **save directory, not the instance** — the Palworld server with 5.7 GB on disk moved 26 KB. Replication was already fixed, with a comment on the controller saying "far past proxy timeouts". I'd asserted both were broken without checking either.

## The one real case

Cluster start and stop walk their members sequentially on purpose, so the request was held for the sum of every launch or teardown — well past the proxy's ~30s. Same false failure that hit start and restart.

Both now return the member count immediately. That's what the caller wanted anyway ("this many were asked to start"), and each member's real progress is already on the servers list. A missing cluster is still a 404, and `startAll`/`stopAll` are unchanged for internal callers.

The clusters page refreshes on a short schedule after the call instead of once — members flip to `Starting`/`Stopping` over the following minute, so a single immediate refresh would always look like nothing happened.

## No job infrastructure

I'd proposed generalising the installer's Job pattern. Having looked: **the `Job` table is write-only.** Only `installer.service.ts` touches it, no controller exposes it, and the web app never references `jobId`. Building on it to fix one endpoint would have been scaffolding for its own sake. If job tracking is wanted later it's worth doing deliberately, with something that reads the rows.

## Verification

522 tests (up from 517). Five new ones: returns without waiting even when a launch never finishes, still 404s a missing cluster, and reports zero for an empty one.

`pnpm typecheck`, `pnpm lint`, `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)