### PR TITLE
Refuse a UE4SS build meant for the other Palworld variant (#48)

### DIFF
--- a/apps/api/src/common/safe-extract.ts
+++ b/apps/api/src/common/safe-extract.ts
@@ -32,6 +32,21 @@ async function stripSymlinks(dest: string): Promise<void> {
   await execFileP("find", [dest, "-type", "l", "-delete"]).catch(() => undefined);
 }
 
+/** Entry names inside a .zip, without extracting it — so a caller can vet an archive's
+ *  CONTENTS (not just its paths) before anything touches disk. */
+export async function listZipEntries(data: Buffer): Promise<string[]> {
+  const tmp = join(tmpdir(), `listzip-${process.pid}-${Date.now()}.zip`);
+  await writeFile(tmp, data);
+  try {
+    const { stdout } = await execFileP("unzip", ["-Z1", tmp]);
+    return stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+  } catch (e) {
+    throw new BadRequestException(`Could not read the upload: ${(e as Error).message}`);
+  } finally {
+    await rm(tmp, { force: true }).catch(() => undefined);
+  }
+}
+
 /** Extract an untrusted .zip (given as a Buffer) into `dest`. Rejects the whole archive
  *  up front if any entry is absolute or contains `..`, then strips any symlinks. */
 export async function extractZipSafe(data: Buffer, dest: string): Promise<void> {

--- a/apps/api/src/palmods/framework-variant.test.ts
+++ b/apps/api/src/palmods/framework-variant.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { frameworkArchiveIssue } from "./palmods.service";
+
+/**
+ * GH #48: someone reported UE4SS never loading on the Wine variant — no UE4SS.log,
+ * no crash, a server that just booted vanilla. The one-click install always picks
+ * the right build, but the "upload a different build" path beside it took any zip
+ * and extracted it into the variant's directory without looking inside. Put the
+ * native Linux build on a Wine server and libUE4SS.so lands in Win64, where nothing
+ * will ever load it — and nothing says so.
+ */
+const WINDOWS_BUILD = ["dwmapi.dll", "UE4SS.dll", "UE4SS-settings.ini", "Mods/keybinds.lua"];
+const LINUX_BUILD = ["libUE4SS.so", "UE4SS-settings.ini", "Mods/keybinds.lua"];
+
+describe("frameworkArchiveIssue", () => {
+  it("accepts the Windows build on the Wine variant", () => {
+    expect(frameworkArchiveIssue(WINDOWS_BUILD, true)).toBeNull();
+  });
+
+  it("accepts the Linux build on the native variant", () => {
+    expect(frameworkArchiveIssue(LINUX_BUILD, false)).toBeNull();
+  });
+
+  it("rejects the Linux build on the Wine variant, naming what went wrong", () => {
+    const issue = frameworkArchiveIssue(LINUX_BUILD, true);
+    expect(issue).toContain("libUE4SS.so");
+    expect(issue).toContain("dwmapi.dll");
+  });
+
+  it("rejects the Windows build on the native variant", () => {
+    const issue = frameworkArchiveIssue(WINDOWS_BUILD, false);
+    expect(issue).toContain("dwmapi.dll");
+    expect(issue).toContain("libUE4SS.so");
+  });
+
+  it("matches on the file name wherever it sits in the archive", () => {
+    // Some builds nest everything under a top-level folder.
+    expect(frameworkArchiveIssue(["UE4SS_v3.0.1/dwmapi.dll"], false)).not.toBeNull();
+    expect(frameworkArchiveIssue(["ue4ss/binaries/libUE4SS.so"], true)).not.toBeNull();
+  });
+
+  it("ignores case, since zip entries are not normalised", () => {
+    expect(frameworkArchiveIssue(["DWMAPI.DLL"], false)).not.toBeNull();
+    expect(frameworkArchiveIssue(["libUE4SS.SO"], true)).not.toBeNull();
+  });
+
+  it("handles Windows-style separators in entry names", () => {
+    expect(frameworkArchiveIssue(["UE4SS_v3.0.1\\dwmapi.dll"], false)).not.toBeNull();
+  });
+
+  it("stays out of the way for an archive it doesn't recognise", () => {
+    // The rest of this file is permissive about unfamiliar layouts; only object when
+    // the archive is definitely the other variant's.
+    expect(frameworkArchiveIssue(["some-fork/loader.dll", "readme.md"], true)).toBeNull();
+    expect(frameworkArchiveIssue([], true)).toBeNull();
+  });
+
+  it("says nothing when an archive carries both loaders", () => {
+    // A combined/universal build is the uploader's call, not ours to refuse.
+    expect(frameworkArchiveIssue([...WINDOWS_BUILD, ...LINUX_BUILD], true)).toBeNull();
+    expect(frameworkArchiveIssue([...WINDOWS_BUILD, ...LINUX_BUILD], false)).toBeNull();
+  });
+});

--- a/apps/api/src/palmods/palmods.service.ts
+++ b/apps/api/src/palmods/palmods.service.ts
@@ -5,7 +5,7 @@ import { join, basename } from "node:path";
 import { Game, type ServerConfigValues } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { LocalPaths } from "../common/paths";
-import { extractZipSafe } from "../common/safe-extract";
+import { extractZipSafe, listZipEntries } from "../common/safe-extract";
 
 
 /** UE4SS drops its loader here; the server is launched with this on LD_PRELOAD
@@ -41,6 +41,45 @@ export const UE4SS_WINDOWS = {
 
 /** Wine loads UE4SS via this proxy DLL (auto-loaded, no LD_PRELOAD). */
 export const PAL_FRAMEWORK_WINE_LOADER = "Pal/Binaries/Win64/dwmapi.dll";
+
+/**
+ * Why an uploaded framework archive is for the wrong Palworld variant, or null when
+ * it looks right (or unfamiliar enough that we shouldn't judge).
+ *
+ * The two builds are not interchangeable: the Wine variant loads a Windows
+ * dwmapi.dll proxy out of Pal/Binaries/Win64, the native one preloads libUE4SS.so
+ * from Pal/Binaries/Linux. Uploading the wrong one used to extract happily and then
+ * do nothing at all — no loader, no UE4SS.log, no error, a server that just boots
+ * vanilla (GH #48). The one-click install always picks correctly; this is for the
+ * "upload a different build" path beside it.
+ *
+ * Deliberately narrow: it only objects when the archive carries the OTHER variant's
+ * loader and not the expected one. An unusual-but-valid layout still goes through,
+ * which matches how the rest of this file treats archives it doesn't recognise.
+ */
+export function frameworkArchiveIssue(entries: string[], wine: boolean): string | null {
+  const has = (needle: string) =>
+    entries.some((e) => e.split(/[\\/]/).pop()?.toLowerCase() === needle);
+  const windows = has("dwmapi.dll");
+  const linux = has("libue4ss.so");
+
+  if (wine && linux && !windows) {
+    return (
+      "That looks like the native Linux UE4SS build (it contains libUE4SS.so). The Wine " +
+      "variant loads a Windows dwmapi.dll proxy instead, so this would extract and then " +
+      "never load. Use the official UE4SS Windows build — the Install button above fetches " +
+      "the right one."
+    );
+  }
+  if (!wine && windows && !linux) {
+    return (
+      "That looks like the Windows UE4SS build (it contains dwmapi.dll). The native Linux " +
+      "variant preloads libUE4SS.so instead, so this would extract and then never load. " +
+      "Use a native Linux build — the Install button above fetches the right one."
+    );
+  }
+  return null;
+}
 
 /**
  * Windows system DLL names that proxy-loader mods ship under, dropped next to the
@@ -201,7 +240,12 @@ export class PalModsService {
    *  for the native build, Pal/Binaries/Win64 for the Wine build. */
   async installFramework(id: string, data: Buffer) {
     const s = await this.palServer(id);
-    const dir = this.frameworkDir(id, this.isWine(s));
+    const wine = this.isWine(s);
+    // Check the archive is for THIS variant before writing any of it: the wrong build
+    // extracts cleanly and then silently never loads (GH #48).
+    const issue = frameworkArchiveIssue(await listZipEntries(data), wine);
+    if (issue) throw new BadRequestException(issue);
+    const dir = this.frameworkDir(id, wine);
     await mkdir(dir, { recursive: true });
     await this.extractZip(data, dir);
     await this.makeHeadlessSafe(dir);


### PR DESCRIPTION
From a question about #48: *can you install the Linux UE4SS build on a Wine server?*

## The answer is mixed

**The one-click install is correctly guarded.** `asset = wine ? UE4SS_WINDOWS : UE4SS_LINUX`, and the UI follows suit — the button reads "Install UE4SS (Windows)" on a Wine server, and only the matching release is linked. You can't pick the wrong one there.

**The upload path wasn't.** Right beside that button the UI says *"Prefer a different build? Upload its .zip below instead"*, and `installFramework` took any archive and extracted it into the variant's directory without looking inside.

## Why that matters

The two builds aren't interchangeable:

| Variant | Loader | Location |
|---|---|---|
| Wine | `dwmapi.dll` proxy | `Pal/Binaries/Win64` |
| Native | `libUE4SS.so` preload | `Pal/Binaries/Linux` |

Upload the Linux build to a Wine server and `libUE4SS.so` lands in `Win64`, where nothing will ever load it. Extraction succeeds. No loader runs. No `UE4SS.log` appears. The server boots vanilla, with no error anywhere.

That is **exactly** the symptom in #48 — "no UE4SS.log is ever created, no crash message, the server just boots as a completely vanilla/unmodded instance".

## Fix

Uploads are validated against the variant before anything reaches disk, reusing the entry listing `safe-extract` already performs for path safety.

The check is deliberately narrow — it only objects when the archive carries the **other** variant's loader and **not** the expected one. An unfamiliar-but-valid layout still goes through, matching how the rest of this file treats archives it doesn't recognise, and a combined build carrying both is the uploader's call rather than ours to refuse.

## Status on #48

Not confirmed as that reporter's cause — they've been asked what they uploaded and which build. But it's a real path to their symptom regardless, and the guard is worth having either way.

## Verification

531 tests (up from 522). Nine new: both builds accepted on their own variant, both rejected on the wrong one with a message naming the actual file, nested paths, case-insensitivity, Windows separators, and the two permissive cases.

`pnpm typecheck`, `pnpm lint`, `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)