### PR TITLE
Show installed vs latest game build, and update game files in place

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Keep the build context to source only. The image installs its own deps per
+# stage (deps/prodmods), so a developer's local node_modules must never reach
+# `COPY . .` — pnpm's symlinked store would land on top of the container's
+# install and break the build. Also keeps the context (and CI upload) small.
+node_modules
+**/node_modules
+.git
+.next
+**/.next
+dist
+**/dist
+data
+*.log

--- a/apps/api/src/scheduler/scheduler.service.ts
+++ b/apps/api/src/scheduler/scheduler.service.ts
@@ -1,11 +1,10 @@
 import { Injectable, Logger, OnModuleInit, BadRequestException } from "@nestjs/common";
 import * as cron from "node-cron";
-import { EventType, ServerState, Game } from "@ark/shared";
+import { EventType } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { EventsService } from "../events/events.service";
 import { ServersService } from "../servers/servers.service";
 import { RconService } from "../rcon/rcon.service";
-import { InstallerService } from "../installer/installer.service";
 import { BackupsService } from "../backups/backups.service";
 import { ManagerSettingsService } from "../manager-settings/manager-settings.service";
 import { PlayersService } from "../players/players.service";
@@ -29,7 +28,6 @@ export class SchedulerService implements OnModuleInit {
     private readonly events: EventsService,
     private readonly servers: ServersService,
     private readonly rcon: RconService,
-    private readonly installer: InstallerService,
     private readonly backups: BackupsService,
     private readonly settings: ManagerSettingsService,
     private readonly players: PlayersService,
@@ -193,22 +191,15 @@ export class SchedulerService implements OnModuleInit {
         case "backup":
           await this.backups.create(sched.serverId, "scheduled").catch(() => undefined);
           break;
-        case "update": {
-          const server = await this.prisma.server.findUnique({ where: { id: sched.serverId } });
-          if (!server) break;
-          // Only bring it back up if it was up — don't start a server the admin
-          // had deliberately stopped.
-          const wasUp = [ServerState.Running, ServerState.Starting].includes(
-            server.state as ServerState,
-          );
-          await this.servers.stop(sched.serverId).catch(() => undefined);
-          // Through installGame (not installer.install directly) so games whose image
-          // updater is normally disabled get their one-shot update flagged too
-          // (GH #8/#12/#14) — the start below then actually updates the game files.
-          await this.servers.installGame(sched.serverId);
-          if (wasUp) await this.servers.start(sched.serverId);
+        case "update":
+          // The same path as the UI's "Update game" button. It arms the one-shot
+          // update flag for the images whose updater the manager disables, restarts
+          // only if the server was up, and leaves a stopped server to update on its
+          // next start, so a scheduled update and a clicked one can't drift apart.
+          // Replaces a stop → installGame → start dance that ran a whole install job
+          // to achieve what the one-shot flag does on its own.
+          await this.servers.updateGame(sched.serverId);
           break;
-        }
         case "update-mods": {
           // Apply pending mod updates (files/config on disk), then restart to load
           // them if the server was up. updateAll owns the was-it-running decision.

--- a/apps/api/src/servers/servers.controller.ts
+++ b/apps/api/src/servers/servers.controller.ts
@@ -30,6 +30,7 @@ import type { CreateServerDto, UpdateServerDto } from "@ark/shared";
 import { ServersService } from "./servers.service";
 import { HistoryService } from "./history.service";
 import { EventsService } from "../events/events.service";
+import { UpdatesService } from "../updates/updates.service";
 import { CreateServerBody, UpdateServerBody, ExtraEnvBody } from "./servers.dto";
 import { MinRole } from "../auth/min-role.decorator";
 
@@ -52,6 +53,7 @@ export class ServersController {
     private readonly servers: ServersService,
     private readonly events: EventsService,
     private readonly history: HistoryService,
+    private readonly updates: UpdatesService,
   ) {}
 
   @Get()
@@ -183,6 +185,18 @@ export class ServersController {
   @Post(":id/install")
   install(@Param("id") id: string) {
     return this.servers.installGame(id);
+  }
+
+  /** Installed vs latest game build, and how an update reaches this game. */
+  @Get(":id/build-status")
+  buildStatus(@Param("id") id: string) {
+    return this.updates.buildStatus(id);
+  }
+
+  /** Update the game files: arm the image's update step and restart if running. */
+  @Post(":id/update-game")
+  updateGame(@Param("id") id: string) {
+    return this.servers.updateGame(id);
   }
 
   @Post(":id/start")

--- a/apps/api/src/servers/servers.module.ts
+++ b/apps/api/src/servers/servers.module.ts
@@ -8,9 +8,10 @@ import { HistoryService } from "./history.service";
 import { RconModule } from "../rcon/rcon.module";
 import { BackupsModule } from "../backups/backups.module";
 import { PlayersModule } from "../players/players.module";
+import { UpdatesModule } from "../updates/updates.module";
 
 @Module({
-  imports: [RconModule, BackupsModule, PlayersModule, ArtworkModule],
+  imports: [RconModule, BackupsModule, PlayersModule, ArtworkModule, UpdatesModule],
   controllers: [ServersController],
   providers: [ServersService, ServerConfigWriter, StateMachineService, HistoryService],
   exports: [ServersService, StateMachineService],

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -8,7 +8,7 @@ import {
   type OnApplicationShutdown,
 } from "@nestjs/common";
 import type Docker from "dockerode";
-import { mkdir, writeFile, rm, cp, chmod, chown, stat, readFile, readdir } from "node:fs/promises";
+import { mkdir, rm, cp, chmod, chown, stat, readFile, readdir } from "node:fs/promises";
 import { execFile, spawn } from "node:child_process";
 import type { Readable } from "node:stream";
 import { join, dirname, relative, sep } from "node:path";
@@ -22,6 +22,7 @@ import {
   RAM_ESTIMATE_MB,
   DISK_INSTALL_MB,
   GAME_LABELS,
+  type UpdateGameResult,
   type RunningServerRam,
   type InsufficientRamInfo,
   type CreateServerDto,
@@ -54,6 +55,7 @@ import { detectPalWineProxyDlls } from "../palmods/palmods.service";
 import { GameEndpointService } from "../docker/game-endpoint.service";
 import { palworldWinePortIssue, portsFor, serverPortSet } from "../catalog/ports";
 import { LocalPaths } from "../common/paths";
+import { gameUpdateMode } from "../updates/game-update-mode";
 import { containerName } from "../common/naming";
 import { hostStats } from "../common/host-stats";
 import { IMAGES, SERVER_UID, SERVER_GID } from "../common/images";
@@ -964,6 +966,53 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       });
     }
     return { jobId };
+  }
+
+  /**
+   * "Update game" — the action that actually moves a server onto a newer build.
+   *
+   * Palisade never runs SteamCMD itself: every game image installs/updates its own
+   * files when the container boots. So an update is always "arm it, then boot":
+   * arm whatever this image needs, restart if the server is up, and let a stopped
+   * server pick it up on its next start. doStart pulls the image on every launch,
+   * so an image-baked game (Zomboid, Factorio…) updates by exactly the same path.
+   */
+  async updateGame(id: string): Promise<UpdateGameResult> {
+    const server = await this.prisma.server.findUnique({ where: { id } });
+    if (!server) throw new NotFoundException("Server not found");
+    const game = server.game as Game;
+    const state = server.state as ServerState;
+    const label = GAME_LABELS[game];
+
+    // Arm the SAME one-shot flag installGame uses: runtime-spec forces the image's
+    // update env for exactly this boot (ONE_SHOT_UPDATE_ENV) and doStart clears the
+    // flag once the container is created. Games whose image already updates on every
+    // boot need nothing armed — the restart below is the whole update.
+    if (ONE_SHOT_UPDATE_ENV[game]) {
+      await this.prisma.server.update({ where: { id }, data: { updateRequested: true } });
+    }
+
+    if (state === ServerState.Running || state === ServerState.Starting) {
+      await this.events.emit({
+        type: EventType.InstallStarted,
+        message: `Updating ${label} — restarting so the image fetches the latest build`,
+        serverId: id,
+      });
+      // Detached, for the reason start/restart are (#46/#49/#50): this relaunch
+      // pulls an image AND runs the image's SteamCMD update, the longest boot the
+      // manager ever waits on. Blocking here would outlive the request timeout and
+      // report a failure for an update that is running fine. restartDetached still
+      // validates up front, so a bad port config is still answered to the caller.
+      await this.restartDetached(id);
+      return {
+        applied: "restarted",
+        message: `Restarting to update ${label}. The image downloads the new build during boot, so this start takes longer than usual.`,
+      };
+    }
+    return {
+      applied: "next-start",
+      message: `${label} will update on the next start — the image downloads the new build during boot.`,
+    };
   }
 
   async start(
@@ -2092,6 +2141,7 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
       updateAvailable: row.updateAvailable,
       modUpdateAvailable: row.modUpdateAvailable,
       imageTag: row.imageTag,
+      updateMode: gameUpdateMode(row.game as Game),
       crashReason: row.state === ServerState.Crashed ? row.crashReason : null,
       healthNote: row.state === ServerState.Running ? this.healthNoteFor(row.id) : null,
       imageReady,

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -1009,6 +1009,14 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
         message: `Restarting to update ${label}. The image downloads the new build during boot, so this start takes longer than usual.`,
       };
     }
+    // Say so even though nothing happens yet: a SCHEDULED update lands here whenever
+    // the server is down, and without an event the schedule fires and leaves no trace
+    // for the user who set it.
+    await this.events.emit({
+      type: EventType.ConfigChanged,
+      message: `${label} is set to update on the next start of "${server.name}"`,
+      serverId: id,
+    });
     return {
       applied: "next-start",
       message: `${label} will update on the next start — the image downloads the new build during boot.`,

--- a/apps/api/src/servers/update-game.test.ts
+++ b/apps/api/src/servers/update-game.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { Game, ServerState } from "@ark/shared";
+import { ServersService } from "./servers.service";
+
+/**
+ * updateGame() is the "Update game" button. Palisade never runs SteamCMD itself —
+ * the image does, at boot — so the contract is: arm the one-shot update flag when
+ * this game's image needs asking (ONE_SHOT_UPDATE_ENV: Palworld both variants,
+ * Conan), then restart if the server is up, or leave it armed for the next start.
+ * runtime-spec turns the flag into the image's update env for that single boot.
+ */
+
+beforeAll(() => {
+  process.env.DATA_DIR = "/tmp/palisade-update-game-test";
+  process.env.SECRETS_KEY = "a".repeat(64);
+  process.env.JWT_SECRET = "test-jwt-secret-1234";
+});
+
+function makeSvc(row: { id: string; game: Game; state: ServerState }) {
+  const prisma = {
+    server: {
+      findUnique: vi.fn(async () => ({ ...row, name: "Test Server" })),
+      update: vi.fn(async () => ({})),
+    },
+  };
+  const events = { emit: vi.fn(async () => undefined) };
+  const svc = new ServersService(
+    prisma as never,
+    {} as never, // crypto
+    events as never,
+    {} as never, // realtime
+    {} as never, // docker
+    {} as never, // catalog
+    {} as never, // installer
+    {} as never, // rcon
+    {} as never, // state machine
+    {} as never, // manager settings
+    {} as never, // logCapture
+    {} as never, // backups
+    {} as never, // players
+    {} as never, // endpoints
+    {} as never, // configWriter
+    {} as never, // artwork
+  );
+  // The service restarts DETACHED (a game update is the longest boot there is), so
+  // this is the call the assertions below care about.
+  const restart = vi.spyOn(svc, "restartDetached").mockResolvedValue(undefined);
+  return { svc, restart, prisma };
+}
+
+/** The flag the next start consumes, or undefined when nothing was armed. */
+const armed = (prisma: { server: { update: { mock: { calls: unknown[][] } } } }) =>
+  prisma.server.update.mock.calls.map((c) => (c[0] as { data?: { updateRequested?: boolean } }).data);
+
+describe("updateGame()", () => {
+  it("arms the one-shot flag and waits for the next start when stopped", async () => {
+    const { svc, restart, prisma } = makeSvc({
+      id: "pw-stopped",
+      game: Game.PALWORLD_WINE,
+      state: ServerState.Stopped,
+    });
+
+    const res = await svc.updateGame("pw-stopped");
+
+    expect(res.applied).toBe("next-start");
+    expect(armed(prisma)).toContainEqual({ updateRequested: true });
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it("restarts a running server so the update happens now", async () => {
+    const { svc, restart, prisma } = makeSvc({
+      id: "pw-running",
+      game: Game.PALWORLD_WINE,
+      state: ServerState.Running,
+    });
+
+    const res = await svc.updateGame("pw-running");
+
+    expect(res.applied).toBe("restarted");
+    expect(armed(prisma)).toContainEqual({ updateRequested: true });
+    expect(restart).toHaveBeenCalledWith("pw-running");
+  });
+
+  it("arms nothing for images that update on every boot", async () => {
+    // ASA (POK) sets UPDATE_SERVER=TRUE — the restart alone is the update, so there
+    // is no flag to force and no pointless write.
+    const { svc, restart, prisma } = makeSvc({ id: "asa1", game: Game.ASA, state: ServerState.Running });
+
+    const res = await svc.updateGame("asa1");
+
+    expect(res.applied).toBe("restarted");
+    expect(armed(prisma)).toEqual([]);
+    expect(restart).toHaveBeenCalledWith("asa1");
+  });
+
+  it("also arms Palworld native and Conan, whose image updaters the manager disables", async () => {
+    for (const game of [Game.PALWORLD, Game.CONAN]) {
+      const { svc, prisma } = makeSvc({ id: `s-${game}`, game, state: ServerState.Stopped });
+      await svc.updateGame(`s-${game}`);
+      expect(armed(prisma)).toContainEqual({ updateRequested: true });
+    }
+  });
+
+  it("never restarts mid-transition (a stopping server updates on its next start)", async () => {
+    const { svc, restart } = makeSvc({
+      id: "pw-stopping",
+      game: Game.PALWORLD_WINE,
+      state: ServerState.Stopping,
+    });
+
+    const res = await svc.updateGame("pw-stopping");
+
+    expect(res.applied).toBe("next-start");
+    expect(restart).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/servers/update-game.test.ts
+++ b/apps/api/src/servers/update-game.test.ts
@@ -45,7 +45,7 @@ function makeSvc(row: { id: string; game: Game; state: ServerState }) {
   // The service restarts DETACHED (a game update is the longest boot there is), so
   // this is the call the assertions below care about.
   const restart = vi.spyOn(svc, "restartDetached").mockResolvedValue(undefined);
-  return { svc, restart, prisma };
+  return { svc, restart, prisma, events };
 }
 
 /** The flag the next start consumes, or undefined when nothing was armed. */
@@ -65,6 +65,17 @@ describe("updateGame()", () => {
     expect(res.applied).toBe("next-start");
     expect(armed(prisma)).toContainEqual({ updateRequested: true });
     expect(restart).not.toHaveBeenCalled();
+  });
+
+  it("records the armed update even though nothing starts yet", async () => {
+    // A scheduled update on a stopped server lands here; with no event the schedule
+    // fires and leaves nothing behind for whoever set it.
+    const { svc, events } = makeSvc({ id: "s1", game: Game.PALWORLD, state: ServerState.Stopped });
+    await svc.updateGame("s1");
+    expect(events.emit).toHaveBeenCalledTimes(1);
+    expect(events.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/next start/i) }),
+    );
   });
 
   it("restarts a running server so the update happens now", async () => {

--- a/apps/api/src/updates/game-update-mode.ts
+++ b/apps/api/src/updates/game-update-mode.ts
@@ -1,0 +1,15 @@
+import { Game, type GameUpdateMode } from "@ark/shared";
+import { IMAGE_BAKED_GAMES } from "../common/images";
+import { ONE_SHOT_UPDATE_ENV } from "../servers/runtime-spec";
+
+/**
+ * What it takes to move one game to a newer build, derived from the two tables that
+ * already decide it: the game is baked into its image, or the manager disables the
+ * image's own updater and has to arm it for a single boot, or the image just updates
+ * every time it boots. Derived, not declared — a hand-maintained third table would
+ * silently disagree with the behaviour the other two produce.
+ */
+export function gameUpdateMode(game: Game): GameUpdateMode {
+  if (IMAGE_BAKED_GAMES.has(game)) return "image";
+  return ONE_SHOT_UPDATE_ENV[game] ? "on-request" : "on-start";
+}

--- a/apps/api/src/updates/updates.service.ts
+++ b/apps/api/src/updates/updates.service.ts
@@ -1,8 +1,14 @@
-import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { Injectable, Logger, NotFoundException, OnModuleInit } from "@nestjs/common";
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import * as cron from "node-cron";
-import { Game, EventType, STEAM_APP_ID, resolveVersionTag } from "@ark/shared";
+import {
+  Game,
+  EventType,
+  STEAM_APP_ID,
+  resolveVersionTag,
+  type GameBuildStatus,
+} from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { EventsService } from "../events/events.service";
 import { LocalPaths } from "../common/paths";
@@ -10,6 +16,7 @@ import { IMAGE_BAKED_GAMES, imageRefFor, splitImageRef } from "../common/images"
 import { DockerService } from "../docker/docker.service";
 import { ImageTagsService } from "../images/image-tags.service";
 import { digestsDiffer, remoteImageDigest } from "./registry-digest";
+import { gameUpdateMode } from "./game-update-mode";
 
 // Every 3 hours, offset off the top of the hour. ARK ships updates a few times a
 // week at most, so this is plenty without hammering the API.
@@ -132,7 +139,7 @@ export class UpdatesService implements OnModuleInit {
         if (outdated && !server.updateAvailable) {
           await this.events.emit({
             type: EventType.UpdateAvailable,
-            message: `Update available for "${server.name}" (installed build ${installed}, latest ${newest}). Use Install / Update, then restart.`,
+            message: `Update available for "${server.name}" (installed build ${installed}, latest ${newest}). Use Update game on the server page to apply it.`,
             serverId: server.id,
             data: { installed: String(installed), latest: String(newest) },
           });
@@ -203,6 +210,37 @@ export class UpdatesService implements OnModuleInit {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Everything the Version & updates card shows for one server: the build on disk,
+   * the newest published build, and how an update reaches this game. Each half
+   * degrades to null independently — a server that has never started has no
+   * manifest, and the build API can be down — so the card can say "unknown"
+   * instead of implying "up to date".
+   */
+  async buildStatus(serverId: string): Promise<GameBuildStatus> {
+    const server = await this.prisma.server.findUnique({ where: { id: serverId } });
+    if (!server) throw new NotFoundException("Server not found");
+    const game = server.game as Game;
+    const appId = STEAM_APP_ID[game] || null;
+    const mode = gameUpdateMode(game);
+    if (!appId) {
+      // Not installed from Steam (image-baked or a non-Steam downloader) — there's
+      // no build id to compare, so the card explains the mode instead.
+      return { appId: null, installed: null, latest: null, outdated: null, mode };
+    }
+    const [latest, installed] = await Promise.all([
+      this.latestBuildId(game),
+      this.installedBuildId(serverId, game),
+    ]);
+    return {
+      appId,
+      installed: installed === null ? null : String(installed),
+      latest: latest === null ? null : String(latest),
+      outdated: latest === null || installed === null ? null : latest > installed,
+      mode,
+    };
   }
 
   /** Live check for one server: newest public build vs the installed .acf.

--- a/apps/api/src/updates/updates.test.ts
+++ b/apps/api/src/updates/updates.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
-import { parseAcfBuildId, pickPublicBuildId, findManifest } from "./updates.service";
+import { Game, STEAM_APP_ID } from "@ark/shared";
+import { parseAcfBuildId, pickPublicBuildId, findManifest, UpdatesService } from "./updates.service";
 
 describe("parseAcfBuildId", () => {
   it("extracts the build id from a SteamCMD appmanifest", () => {
@@ -87,5 +88,76 @@ describe("findManifest", () => {
     await writeFile(tooDeep, '"buildid" "9"');
     expect(await findManifest(root, "appmanifest_9.acf")).toBeNull(); // depth 3 > default 2
     expect(await findManifest(root, "appmanifest_9.acf", 3)).toBe(tooDeep);
+  });
+});
+
+// What the Version & updates card reads: the build on disk vs the newest published
+// one, and how an update reaches this game. The two halves must fail INDEPENDENTLY —
+// an unreachable build API has to read "unknown", never "up to date".
+describe("buildStatus", () => {
+  let tmp: string;
+
+  beforeAll(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "ark-builds-"));
+    process.env.DATA_DIR = tmp;
+    process.env.SECRETS_KEY = "a".repeat(64);
+    process.env.JWT_SECRET = "test-jwt-secret-1234";
+  });
+
+  afterAll(async () => {
+    await rm(tmp, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  function makeSvc(game: Game, latest: number | null) {
+    const prisma = { server: { findUnique: async () => ({ id: "s1", game, updateAvailable: false }) } };
+    vi.stubGlobal("fetch", async () => ({
+      ok: latest !== null,
+      json: async () => ({
+        data: { [String(STEAM_APP_ID[game])]: { depots: { branches: { public: { buildid: String(latest) } } } } },
+      }),
+    }));
+    return new UpdatesService(
+      prisma as never,
+      { emit: async () => undefined } as never,
+      // buildStatus touches neither Docker nor the registry — the baked-image
+      // path is what needs those (see checkBakedImage).
+      {} as never,
+      {} as never,
+    );
+  }
+
+  const manifest = (buildId: number) => `"AppState"\n{\n\t"buildid"\t\t"${buildId}"\n}`;
+
+  it("finds a manifest under steamapps/ and flags the server as outdated", async () => {
+    const dir = join(tmp, "instances", "s1", "steamapps");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, `appmanifest_${STEAM_APP_ID[Game.PALWORLD_WINE]}.acf`), manifest(24370498));
+
+    const svc = makeSvc(Game.PALWORLD_WINE, 24575149);
+    const status = await svc.buildStatus("s1");
+
+    expect(status.installed).toBe("24370498");
+    expect(status.latest).toBe("24575149");
+    expect(status.outdated).toBe(true);
+    expect(status.mode).toBe("on-request");
+  });
+
+  it("reports outdated as null (not 'up to date') when the build API is unreachable", async () => {
+    const svc = makeSvc(Game.PALWORLD_WINE, null);
+    const status = await svc.buildStatus("s1");
+
+    expect(status.installed).toBe("24370498");
+    expect(status.latest).toBeNull();
+    expect(status.outdated).toBeNull();
+  });
+
+  it("skips the build comparison for games whose files ship in the image", async () => {
+    const svc = makeSvc(Game.FACTORIO, 1);
+    const status = await svc.buildStatus("s1");
+
+    expect(status.appId).toBeNull();
+    expect(status.outdated).toBeNull();
+    expect(status.mode).toBe("image");
   });
 });

--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -2,8 +2,16 @@
 import { use, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Play, Square, RotateCw, Download, Loader2, Pencil, Check, X, Trash2, AlertTriangle, Image as ImageIcon } from "lucide-react";
-import { mapLabel, Game, ServerState, type ServerSummary, type ServerConfigValues } from "@ark/shared";
+import { ArrowLeft, Play, Square, RotateCw, Download, Loader2, Pencil, Check, X, Trash2, AlertTriangle, ArrowUpCircle, Image as ImageIcon } from "lucide-react";
+import {
+  mapLabel,
+  Game,
+  ServerState,
+  GAME_LABELS,
+  type ServerSummary,
+  type ServerConfigValues,
+  type UpdateGameResult,
+} from "@ark/shared";
 import { apiGet, apiPost, apiPatch, apiDelete, apiDownload } from "@/lib/api";
 import { useRealtime } from "@/lib/socket";
 import { StateBadge } from "@/components/state-badge";
@@ -60,6 +68,11 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
   const [savingName, setSavingName] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [confirmingUpdate, setConfirmingUpdate] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  // What the last "Update game" actually did — the update happens during the next
+  // boot, so without this the click looks like it did nothing.
+  const [updateNote, setUpdateNote] = useState<string | null>(null);
 
   // Keep the active tab in the URL (?tab=settings) so a refresh lands you back
   // on the same tab instead of Overview. Uses replaceState — no scroll/navigation.
@@ -141,6 +154,23 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
     }
   };
 
+  /** Update the game files. The server image does the downloading on its next boot,
+   *  so this either restarts a running server or arms the update for the next start. */
+  const doUpdateGame = async () => {
+    setConfirmingUpdate(false);
+    setUpdating(true);
+    setUpdateNote(null);
+    try {
+      const res = await apiPost<UpdateGameResult>(`/servers/${id}/update-game`);
+      setUpdateNote(res.message);
+      await refresh();
+    } catch (e) {
+      alert((e as Error).message);
+    } finally {
+      setUpdating(false);
+    }
+  };
+
   const doDelete = async (wipeFiles: boolean) => {
     setDeleting(true);
     try {
@@ -175,6 +205,20 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
   const showStopping = pending === "stop" || st === ServerState.Stopping;
   const showInstalling =
     pending === "install" || st === ServerState.Installing || st === ServerState.Updating;
+  // Updating is legal from any settled state: running (restart to apply it now) or
+  // stopped (armed for the next start). Only mid-transition states block it.
+  const isLive = st === ServerState.Running || st === ServerState.Starting;
+  const canUpdate =
+    !pending &&
+    !updating &&
+    !starting &&
+    [ServerState.Running, ServerState.Starting, ServerState.Stopped, ServerState.Crashed].includes(st);
+  const updateHint =
+    server.updateMode === "image"
+      ? "Pull a newer server image and recreate the container — for this game the image IS the game version"
+      : server.updateMode === "on-request"
+        ? "Ask the image to run SteamCMD once on the next boot (no need to turn on update-on-start)"
+        : null;
 
   // No-RCON games hide the Console tab. Icarus + Bedrock keep an uploader Mods tab
   // (.pak files / add-on packs); Valheim's mods are settings toggles (BepInEx/
@@ -289,10 +333,38 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
         </div>
         <div className="flex flex-wrap gap-2">
           <CopyMenu server={server} onAfterCopyIn={reload} />
-          <button className="btn-secondary" disabled={!canInstall} onClick={() => act("install")}>
-            {showInstalling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}{" "}
-            {showInstalling ? "Installing…" : "Install / Update"}
-          </button>
+          {/* One slot, two honest actions: pull the image while it's missing, then
+              update the GAME once it's there. The old combined "Install / Update"
+              button only ever pulled the image — which Start does anyway — so it
+              looked broken to anyone clicking it to update their game. */}
+          {server.imageReady ? (
+            <button
+              className="btn-secondary"
+              disabled={!canUpdate}
+              title={
+                updateHint ??
+                "Update the game files — the image downloads the new build on its next boot"
+              }
+              onClick={() => (isLive ? setConfirmingUpdate(true) : void doUpdateGame())}
+            >
+              {updating ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowUpCircle className="h-4 w-4" />
+              )}{" "}
+              {updating ? "Updating…" : "Update game"}
+            </button>
+          ) : (
+            <button
+              className="btn-secondary"
+              disabled={!canInstall}
+              title="Download the game server image now (optional — Start pulls it too)"
+              onClick={() => act("install")}
+            >
+              {showInstalling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}{" "}
+              {showInstalling ? "Installing…" : "Install"}
+            </button>
+          )}
           <button className="btn-primary" disabled={!canStart} onClick={() => act("start")}>
             {showStarting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}{" "}
             {showStarting ? "Starting…" : "Start"}
@@ -315,6 +387,46 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
           </button>
         </div>
       </div>
+
+      {updateNote && (
+        <div className="flex items-start gap-2 rounded-md border border-sky-900/40 bg-sky-950/20 px-3 py-2 text-sm text-sky-200/90">
+          <ArrowUpCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span className="flex-1">{updateNote}</span>
+          <button onClick={() => setUpdateNote(null)} className="text-slate-400 hover:text-slate-200" title="Dismiss">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {confirmingUpdate && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setConfirmingUpdate(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-lg border border-ark-border bg-ark-panel p-5 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-3 flex items-center gap-2 text-sky-300">
+              <ArrowUpCircle className="h-5 w-5" />
+              <h2 className="text-lg font-semibold">Update {GAME_LABELS[server.game]}?</h2>
+            </div>
+            <p className="text-sm leading-snug text-slate-300">
+              The server image downloads game files as it boots, so “{server.name}” has to restart to
+              update. Players are disconnected, and this start takes longer than usual while the new
+              build downloads.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button className="btn-secondary" onClick={() => setConfirmingUpdate(false)}>
+                Cancel
+              </button>
+              <button className="btn-primary" onClick={() => void doUpdateGame()}>
+                Restart &amp; update
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {confirmingDelete && (
         <DeleteConfirm

--- a/apps/web/components/image-version-card.tsx
+++ b/apps/web/components/image-version-card.tsx
@@ -1,20 +1,23 @@
 "use client";
-import { useEffect, useState } from "react";
-import { Boxes, Save, Check, ChevronDown, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Boxes, Save, Check, ChevronDown, Loader2, ArrowUpCircle, RefreshCw } from "lucide-react";
 import {
   ServerState,
   GAME_VERSION_PINNING,
   resolveVersionTag,
   GAME_LABELS,
+  type GameBuildStatus,
   type ImageTagsResult,
   type ServerSummary,
+  type UpdateGameResult,
 } from "@ark/shared";
-import { apiGet, apiPatch } from "@/lib/api";
+import { apiGet, apiPatch, apiPost } from "@/lib/api";
 
 /**
- * Advanced: pin the game's Docker image to a specific tag (e.g. roll back to a prior
- * version) instead of the shipped default. Editable only while stopped — the new tag
- * is pulled and the container recreated on the next start. Collapsed by default.
+ * Version & updates: where this server's game build stands against the latest
+ * published one (and how to move it), plus the advanced image-tag pin. Both live
+ * here because "what version am I on?" is one question — the card used to answer
+ * only the Docker half of it, which left the game build invisible.
  */
 export function ImageVersionCard({ server, onSaved }: { server: ServerSummary; onSaved: () => void }) {
   const stopped = server.state === ServerState.Stopped || server.state === ServerState.Crashed;
@@ -76,7 +79,7 @@ export function ImageVersionCard({ server, onSaved }: { server: ServerSummary; o
         onClick={() => setOpen((v) => !v)}
       >
         <span className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-ark-accent2">
-          <Boxes className="h-4 w-4" /> Image version
+          <Boxes className="h-4 w-4" /> Version &amp; updates
           <span className="ml-1 rounded bg-slate-700/60 px-1.5 py-0.5 font-mono text-[11px] font-normal normal-case text-slate-300">
             {current}
           </span>
@@ -88,88 +91,231 @@ export function ImageVersionCard({ server, onSaved }: { server: ServerSummary; o
               {currentVersion}
             </span>
           )}
+          {server.updateAvailable && (
+            <span className="rounded-full border border-amber-500/30 bg-amber-500/15 px-2 py-0.5 text-[11px] font-medium normal-case tracking-normal text-amber-400">
+              Game update available
+            </span>
+          )}
         </span>
         <ChevronDown className={`h-4 w-4 text-slate-400 transition-transform ${open ? "rotate-180" : ""}`} />
       </button>
 
       {open && (
-        <div className="mt-3 space-y-3">
-          <p className="text-[11px] leading-snug text-slate-500">
-            Advanced. Pin the game container to a specific published tag instead of the shipped
-            default (<span className="font-mono">{data?.defaultTag ?? "…"}</span>) — useful to roll back a
-            bad update. Applied on the next start (the image is pulled and the container recreated).
-          </p>
-          {/* Per-game: make clear whether the image tag == the game version. */}
-          {(() => {
-            const kind = GAME_VERSION_PINNING[server.game];
-            const label = GAME_LABELS[server.game];
-            if (kind === "image-tag") {
-              return (
-                <p className="rounded-md border border-emerald-900/40 bg-emerald-950/20 px-2.5 py-1.5 text-[11px] leading-snug text-emerald-200/90">
-                  For {label}, the image tag <span className="font-semibold">is</span> the game version — pick a
-                  version here to change the game itself.
-                </p>
-              );
-            }
-            if (kind === "game-version") {
-              return (
-                <p className="rounded-md border border-sky-900/40 bg-sky-950/20 px-2.5 py-1.5 text-[11px] leading-snug text-sky-200/90">
-                  This changes the management image (its runtime/wrapper), <span className="font-semibold">not</span>{" "}
-                  the game version. Set {label}&apos;s game version in the <span className="font-semibold">Settings</span> tab.
-                </p>
-              );
-            }
-            return (
-              <p className="rounded-md border border-amber-900/40 bg-amber-950/20 px-2.5 py-1.5 text-[11px] leading-snug text-amber-200/90">
-                {label}&apos;s game version can&apos;t be pinned — the image always installs the latest version
-                on start. This dropdown changes the management image only.
-              </p>
-            );
-          })()}
-          {err && <div className="text-xs text-rose-300">{err}</div>}
+        <div className="mt-3 space-y-4">
+          <GameBuildBlock server={server} onChanged={onSaved} />
 
-          <div className="flex flex-wrap items-center gap-2">
-            <select
-              className="input max-w-xs"
-              value={choice}
-              disabled={!stopped || busy}
-              onChange={(e) => setChoice(e.target.value)}
-            >
-              <option value="">Default ({data?.defaultTag ?? "latest"}) — track the shipped tag</option>
-              {loading && <option disabled>Loading versions…</option>}
-              {[...extra].map((name) => (
-                <option key={name} value={name}>
-                  {name} (pinned, not in list)
-                </option>
-              ))}
-              {tags.map((t) => (
-                <option key={t.name} value={t.name}>
-                  {t.name}
-                  {t.updatedAt ? ` — ${new Date(t.updatedAt).toLocaleDateString()}` : ""}
-                </option>
-              ))}
-            </select>
-            <button className="btn-secondary" disabled={!stopped || busy || !changed} onClick={save}>
-              {busy ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : saved ? (
-                <Check className="h-4 w-4 text-emerald-400" />
-              ) : (
-                <Save className="h-4 w-4" />
-              )}
-              {saved ? "Saved" : "Save"}
-            </button>
-          </div>
-
-          {!stopped && (
-            <p className="text-[11px] text-amber-400">Stop the server to change its image version.</p>
-          )}
-          {data && (
-            <p className="text-[11px] text-slate-500">
-              Repository: <span className="font-mono">{data.repo}</span>
+          <div className="space-y-3 border-t border-ark-border pt-3">
+            <p className="text-[11px] leading-snug text-slate-500">
+              Advanced. Pin the game container to a specific published tag instead of the shipped
+              default (<span className="font-mono">{data?.defaultTag ?? "…"}</span>) — useful to roll back a
+              bad update. Applied on the next start (the image is pulled and the container recreated).
             </p>
-          )}
+            {/* Per-game: make clear whether the image tag == the game version. */}
+            {(() => {
+              const kind = GAME_VERSION_PINNING[server.game];
+              const label = GAME_LABELS[server.game];
+              if (kind === "image-tag") {
+                return (
+                  <p className="rounded-md border border-emerald-900/40 bg-emerald-950/20 px-2.5 py-1.5 text-[11px] leading-snug text-emerald-200/90">
+                    For {label}, the image tag <span className="font-semibold">is</span> the game version — pick a
+                    version here to change the game itself.
+                  </p>
+                );
+              }
+              if (kind === "game-version") {
+                return (
+                  <p className="rounded-md border border-sky-900/40 bg-sky-950/20 px-2.5 py-1.5 text-[11px] leading-snug text-sky-200/90">
+                    This changes the management image (its runtime/wrapper), <span className="font-semibold">not</span>{" "}
+                    the game version. Set {label}&apos;s game version in the <span className="font-semibold">Settings</span> tab.
+                  </p>
+                );
+              }
+              return (
+                <p className="rounded-md border border-amber-900/40 bg-amber-950/20 px-2.5 py-1.5 text-[11px] leading-snug text-amber-200/90">
+                  {label}&apos;s game version can&apos;t be pinned — the image always installs the latest version
+                  on start. This dropdown changes the management image only.
+                </p>
+              );
+            })()}
+            {err && <div className="text-xs text-rose-300">{err}</div>}
+
+            <div className="flex flex-wrap items-center gap-2">
+              <select
+                className="input max-w-xs"
+                value={choice}
+                disabled={!stopped || busy}
+                onChange={(e) => setChoice(e.target.value)}
+              >
+                <option value="">Default ({data?.defaultTag ?? "latest"}) — track the shipped tag</option>
+                {loading && <option disabled>Loading versions…</option>}
+                {[...extra].map((name) => (
+                  <option key={name} value={name}>
+                    {name} (pinned, not in list)
+                  </option>
+                ))}
+                {tags.map((t) => (
+                  <option key={t.name} value={t.name}>
+                    {t.name}
+                    {t.updatedAt ? ` — ${new Date(t.updatedAt).toLocaleDateString()}` : ""}
+                  </option>
+                ))}
+              </select>
+              <button className="btn-secondary" disabled={!stopped || busy || !changed} onClick={save}>
+                {busy ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : saved ? (
+                  <Check className="h-4 w-4 text-emerald-400" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                {saved ? "Saved" : "Save"}
+              </button>
+            </div>
+
+            {!stopped && (
+              <p className="text-[11px] text-amber-400">Stop the server to change its image version.</p>
+            )}
+            {data && (
+              <p className="text-[11px] text-slate-500">
+                Repository: <span className="font-mono">{data.repo}</span>
+              </p>
+            )}
+          </div>
         </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The game build itself: what's on disk, what Steam publishes, and the one button
+ * that closes the gap. Every image downloads its own game files at boot, so an
+ * update is always "arm it, then boot" — the copy says so per game rather than
+ * leaving people to guess why a click didn't move the version.
+ */
+function GameBuildBlock({ server, onChanged }: { server: ServerSummary; onChanged: () => void }) {
+  const [status, setStatus] = useState<GameBuildStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [arming, setArming] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      setStatus(await apiGet<GameBuildStatus>(`/servers/${server.id}/build-status`));
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [server.id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const isLive = server.state === ServerState.Running || server.state === ServerState.Starting;
+  // The mode rides along on the build status the card already fetches, so the UI
+  // keeps no second copy of how each game updates.
+  const mode = status?.mode;
+  const label = GAME_LABELS[server.game];
+
+  const update = async () => {
+    setConfirming(false);
+    setArming(true);
+    setNote(null);
+    try {
+      const res = await apiPost<UpdateGameResult>(`/servers/${server.id}/update-game`);
+      setNote(res.message);
+      onChanged();
+      void load();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setArming(false);
+    }
+  };
+
+  const verdict =
+    status?.outdated === true
+      ? { text: "Update available", cls: "text-amber-400" }
+      : status?.outdated === false
+        ? { text: "Up to date", cls: "text-emerald-400" }
+        : { text: "Unknown", cls: "text-slate-400" };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-semibold uppercase tracking-wide text-slate-300">Game build</span>
+        <button
+          className="text-slate-400 hover:text-slate-200 disabled:opacity-50"
+          onClick={() => void load()}
+          disabled={loading}
+          title="Check Steam for the latest build"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+        </button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-400">
+        <span>
+          Installed:{" "}
+          <span className="font-mono text-slate-200">{status?.installed ?? "unknown"}</span>
+        </span>
+        <span>
+          Latest: <span className="font-mono text-slate-200">{status?.latest ?? "unknown"}</span>
+        </span>
+        <span className={verdict.cls}>{verdict.text}</span>
+      </div>
+
+      {status && status.installed === null && status.appId !== null && (
+        <p className="text-[11px] leading-snug text-slate-500">
+          No SteamCMD manifest on disk yet — the build id appears once the server has started and
+          installed its game files at least once.
+        </p>
+      )}
+
+      {mode && (
+        <p className="text-[11px] leading-snug text-slate-500">
+          {mode === "image"
+            ? `${label}'s game files ship inside the Docker image, so updating means pulling a newer image and recreating the container.`
+            : mode === "on-request"
+              ? `The ${label} image only runs SteamCMD when asked. Update game requests exactly one update, applied on the next boot — or turn on “Update game files on start” in Settings → Version to update on every start.`
+              : `The ${label} image installs and updates its game files while the container boots, so a restart is the update.`}
+        </p>
+      )}
+
+      {err && <div className="text-xs text-rose-300">{err}</div>}
+      {note && (
+        <div className="rounded-md border border-sky-900/40 bg-sky-950/20 px-2.5 py-1.5 text-[11px] leading-snug text-sky-200/90">
+          {note}
+        </div>
+      )}
+
+      {confirming ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-[11px] text-amber-400">
+            Restarts the server — players are disconnected and the new build downloads during boot.
+          </span>
+          <button className="btn-primary" onClick={() => void update()}>
+            Restart &amp; update
+          </button>
+          <button className="btn-secondary" onClick={() => setConfirming(false)}>
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          className="btn-secondary"
+          disabled={arming}
+          onClick={() => (isLive ? setConfirming(true) : void update())}
+        >
+          {arming ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUpCircle className="h-4 w-4" />}{" "}
+          {arming ? "Updating…" : "Update game"}
+        </button>
       )}
     </div>
   );

--- a/apps/web/components/update-badge.tsx
+++ b/apps/web/components/update-badge.tsx
@@ -1,10 +1,10 @@
 import { ArrowUpCircle } from "lucide-react";
 
-/** Shown when a newer ARK server build is available than the one installed. */
+/** Shown when a newer server build is available than the one installed. */
 export function UpdateBadge({ className = "" }: { className?: string }) {
   return (
     <span
-      title="A newer ARK server build is available — run Install / Update, then restart to apply it"
+      title="A newer game build is available — hit Update game to apply it (the image downloads it on the next boot)"
       className={`inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/15 px-2 py-0.5 text-xs font-medium text-amber-400 ${className}`}
     >
       <ArrowUpCircle className="h-3.5 w-3.5" /> Update available

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -1,4 +1,5 @@
 import type { Game, PortSet } from "./game";
+import type { GameUpdateMode } from "./game-updates";
 import type { ServerState } from "./server-state";
 import type { ServerConfigValues } from "./settings-catalog";
 
@@ -24,6 +25,9 @@ export interface ServerSummary {
   modUpdateAvailable: boolean;
   /** Advanced: pinned game-image tag, or null to use the shipped default. */
   imageTag?: string | null;
+  /** What it takes to move THIS game onto a newer build — derived server-side from
+   *  the image tables (see GameUpdateMode), so the UI never keeps its own copy. */
+  updateMode: GameUpdateMode;
   /** When the server is Crashed, why its container died: exit code (or OOM) plus a
    *  log tail — or the launch error for a start that never got a container. Null
    *  otherwise. Lets the UI explain a crash (e.g. a pinned image that won't boot). */
@@ -64,6 +68,35 @@ export interface ServerSummary {
   artwork?: GameArtwork | null;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Where a server's game files stand against the latest published build — what the
+ * Version & updates card shows. `installed` comes from SteamCMD's appmanifest on
+ * disk, `latest` from the public steamcmd.net build API; either is null when it
+ * can't be read (not installed yet, non-Steam game, API unreachable), which is why
+ * `outdated` is nullable rather than defaulting to "up to date".
+ */
+export interface GameBuildStatus {
+  /** Dedicated-server SteamCMD app id, or null for games not installed from Steam. */
+  appId: number | null;
+  /** Build id on disk, or null if no appmanifest was found. */
+  installed: string | null;
+  /** Newest public-branch build id, or null if the lookup failed. */
+  latest: string | null;
+  /** installed < latest, or null when it can't be determined. */
+  outdated: boolean | null;
+  /** What it takes to move this game to a newer build (see GAME_UPDATE_MODE). */
+  mode: GameUpdateMode;
+}
+
+/** Outcome of "Update game": whether the update ran now or is queued for the next start. */
+export interface UpdateGameResult {
+  /** "restarted" — the server was running and has been restarted to pull the new
+   *  build; "next-start" — the update is armed and lands when the server starts. */
+  applied: "restarted" | "next-start";
+  /** Human-readable summary for the UI to echo back. */
+  message: string;
 }
 
 /** One selectable SteamGridDB asset for the per-server artwork picker. */

--- a/packages/shared/src/game-updates.ts
+++ b/packages/shared/src/game-updates.ts
@@ -1,0 +1,19 @@
+/**
+ * How a game's FILES get updated — the counterpart to GAME_VERSION_PINNING (which
+ * is about pinning a version, not refreshing one). Palisade never runs SteamCMD
+ * itself: the game image does, on container start. So "update the game" always
+ * means "make the next start fetch the new build", and this says what that takes.
+ *
+ * - "on-start": the image runs SteamCMD (or its own downloader) on every boot, so
+ *   a restart IS the update. Most wrappers work this way.
+ * - "on-request": the manager disables the image's updater (it would fight the
+ *   manager's own restart/backup loops), so an update has to be armed for exactly
+ *   one boot — see ONE_SHOT_UPDATE_ENV.
+ * - "image": the game files are baked into the Docker image, so updating means
+ *   pulling a newer image and recreating the container — see IMAGE_BAKED_GAMES.
+ *
+ * The mode is DERIVED server-side from those two tables rather than hand-listed
+ * per game (a parallel table drifts the moment either one changes) and reaches the
+ * UI on GameBuildStatus.mode.
+ */
+export type GameUpdateMode = "on-start" | "on-request" | "image";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./game";
 export * from "./version-pinning";
+export * from "./game-updates";
 export * from "./server-state";
 export * from "./settings-catalog";
 export * from "./settings-rules";


### PR DESCRIPTION
Servers show which game build they're on and whether it's current, and get a button that moves them onto a newer one.

Palisade never runs SteamCMD itself. Every game image installs or updates its own files when the container boots, so "update the game" always means "make the next start fetch the new build". What that takes differs per game, and that is the part this exposes.

## What's here

`GET :id/build-status` returns the installed build, read from the on-disk appmanifest, against the latest from the public steamcmd.net build API. Both are nullable, and so is `outdated`, so a failed lookup reads as "unknown" instead of a confident "up to date".

`POST :id/update-game` arms whatever the image needs, restarts if the server is up, and leaves a stopped server to update on its next start.

That restart is detached, matching #46/#49/#50. A game update is the longest boot the manager waits on, an image pull plus a multi-GB SteamCMD download, so blocking the request would outlive the proxy timeout and report a failure for an update that is running fine. `restartDetached` still validates first, so a bad port config comes back to the caller as an error.

`GameUpdateMode` (`on-start`, `on-request`, `image`) is derived from `IMAGE_BAKED_GAMES` and `ONE_SHOT_UPDATE_ENV` rather than declared in a third table, which would drift from both the moment either one changed.

## Commits

The first commit is a drive-by, unrelated to the rest: `COPY . .` was dragging local `node_modules` into the image, where pnpm's symlinked store landed on top of the container's own install and broke the build. Happy to split it out if you would rather take it separately.

The second is the feature itself. The third moves the scheduled `update` job onto the same `updateGame()` the button calls. That job used to stop the server, run a full install, and start it again, and everything it got from that comes from the one-shot flag `updateGame()` already sets. It also drops the `InstallerService` dependency, which had no other use there. That third commit is optional, since the old path works. It just has its own way of doing the same thing.

## Testing

`typecheck`, `lint`, `build`, and `test` pass on top of e6219eb: 530 tests across 57 files. Five are new, covering a stopped server that arms and waits, a running server that restarts, images that update on every boot and so arm nothing, Palworld native and Conan arming the flag, and a server mid-transition that never restarts.
