### PR TITLE
Run the gate in CI, and add an integration tier against a real Docker daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+# The gate that used to live only in whoever remembered to run it locally.
+#
+# Until this existed, nothing ran the test suite, typecheck, or lint automatically:
+# the only automation was audit + Trivy + image build, and only on release tags.
+# A community PR merged on a maintainer's local run alone. 500+ tests protected
+# nothing they weren't asked to.
+#
+# Two tiers, run in parallel:
+#   check       — the full local gate: prisma generate, typecheck, lint, tests, build.
+#   integration — the *.docker.test.ts suite against the runner's REAL Docker daemon.
+#                 The fast suite fakes Docker, and four bugs in one week were the fake
+#                 disagreeing with reality (container-id length, JSON key ordering,
+#                 network membership). This tier exists so those get caught here
+#                 instead of on someone's Unraid box.
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # typecheck reads the generated Prisma client; without this step it fails on a
+      # clean checkout for every model added since the last `build`.
+      - run: pnpm db:generate
+
+      - run: pnpm typecheck
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm build
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm db:generate
+
+      # The suite creates and removes its own uniquely-named networks and containers,
+      # and refuses to touch a pre-existing `ark-net`. This flag is its consent to run
+      # at all, so a developer's `pnpm test` never reaches for their Docker daemon.
+      - name: Integration tests against the runner's Docker daemon
+        env:
+          PALISADE_DOCKER_TESTS: "1"
+        run: pnpm --filter @ark/api test:docker

--- a/README.md
+++ b/README.md
@@ -410,6 +410,15 @@ Monorepo layout: `packages/shared` (types + settings catalogs contract),
 `apps/api` (NestJS orchestrator), `apps/web` (Next.js UI), `docker/` (manager
 entrypoint), `unraid/` (CA template).
 
+### Tests
+
+Two tiers:
+
+- `pnpm test` — the fast suite, fakes Docker. Runs on every PR and push to `main`.
+- `pnpm --filter @ark/api test:docker` — the `*.docker.test.ts` tier, against a **real Docker daemon**. Gated on `PALISADE_DOCKER_TESTS=1` so it never touches your daemon uninvited. It creates uniquely-named networks and containers, removes them afterwards, and skips the `ark-net` cases if you already have a network by that name. CI runs it on every PR too.
+
+The second tier exists because the fake is where bugs hid: container-id length, Docker's JSON key ordering, and network membership all disagreed with the real daemon in ways that passed 500+ unit tests and were found on a live box.
+
 ## Acknowledgements
 
 Palisade is a control plane — the actual game servers run on excellent

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,8 @@
     "db:push": "prisma db push",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
-    "lint": "echo \"(api) lint not configured yet\""
+    "lint": "echo \"(api) lint not configured yet\"",
+    "test:docker": "vitest run --config vitest.docker.config.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.6",

--- a/apps/api/src/docker/network-migration.docker.test.ts
+++ b/apps/api/src/docker/network-migration.docker.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { randomBytes } from "node:crypto";
+import { resetEnvCache } from "../config/env";
+import { sameContainerId } from "../common/shared-network";
+import { LEGACY_NETWORK } from "../common/naming";
+
+// The manager finds itself by hostname, which the test process doesn't have. Point
+// it at the "manager" container this file creates, by the SHORT id — because that is
+// what a real container's hostname is, and matching it against the FULL ids Docker
+// reports elsewhere is precisely the bug this tier exists to catch.
+let selfId: string | null = null;
+vi.mock("../config/ensure-host-data-dir", async (orig) => ({
+  ...(await orig<typeof import("../config/ensure-host-data-dir")>()),
+  findSelfContainerId: async () => selfId,
+}));
+
+import { DockerService } from "./docker.service";
+import { GameEndpointService } from "./game-endpoint.service";
+
+/**
+ * Against a REAL Docker daemon. Everything the fast suite fakes, this checks.
+ *
+ * Every fact pinned here was learned the hard way — shipped, then found on a live
+ * Unraid box after 500+ unit tests had passed:
+ *   - `docker network inspect` names members by their full 64-char id, while a
+ *     container's hostname (how the manager knows itself) is the 12-char short one.
+ *   - The API JSON-sorts a container's network map by name, whatever the attach
+ *     order — which is why the shared network is called what it is.
+ *   - Membership lists live endpoints only.
+ * A fake that agrees with the code proves nothing about the daemon.
+ *
+ * Gated: PALISADE_DOCKER_TESTS=1 is consent to touch the local daemon. The suite
+ * creates uniquely-named networks and containers, removes them all afterwards, and
+ * will not touch a pre-existing "ark-net" — that name is hard-coded in the code
+ * under test and might be somebody's real one.
+ */
+const enabled = process.env.PALISADE_DOCKER_TESTS === "1";
+const run = randomBytes(3).toString("hex");
+const nm = (s: string) => `palisade-it-${run}-${s}`;
+const IMAGE = "alpine:3.20";
+
+let docker: DockerService;
+const madeContainers: string[] = [];
+const madeNetworks: string[] = [];
+
+async function network(name: string): Promise<string> {
+  await docker.client.createNetwork({ Name: name, Driver: "bridge", CheckDuplicate: true });
+  madeNetworks.push(name);
+  return name;
+}
+
+async function container(name: string, primaryNetwork: string): Promise<string> {
+  const id = await docker.createContainer({
+    name,
+    Image: IMAGE,
+    Cmd: ["sleep", "600"],
+    HostConfig: { NetworkMode: primaryNetwork, AutoRemove: false },
+  });
+  madeContainers.push(id);
+  await docker.start(id);
+  return id;
+}
+
+const networksOf = async (id: string): Promise<string[]> =>
+  Object.keys((await docker.inspect(id)).NetworkSettings?.Networks ?? {});
+
+describe.skipIf(!enabled)("against a real Docker daemon", () => {
+  beforeAll(async () => {
+    process.env.SECRETS_KEY = "a".repeat(64);
+    process.env.JWT_SECRET = "b".repeat(32);
+    process.env.DOCKER_HOST = "unix:///var/run/docker.sock";
+    process.env.AUTO_CREATE_NETWORK = "true";
+    resetEnvCache();
+    docker = new DockerService();
+    expect(await docker.ping()).toBe(true);
+    await docker.pullImage(IMAGE);
+  });
+
+  afterAll(async () => {
+    for (const id of madeContainers) await docker.remove(id, true).catch(() => undefined);
+    for (const n of madeNetworks.reverse()) {
+      await docker.client.getNetwork(n).remove().catch(() => undefined);
+    }
+  });
+
+  describe("DockerService primitives", () => {
+    it("reports a network as absent, then present once created, and creates idempotently", async () => {
+      const name = nm("exists");
+      expect(await docker.networkExists(name)).toBe(false);
+      expect(await docker.createBridgeNetwork(name)).toBe(true);
+      madeNetworks.push(name);
+      expect(await docker.networkExists(name)).toBe(true);
+      // A concurrent create that lost the race is still success.
+      expect(await docker.createBridgeNetwork(name)).toBe(true);
+    });
+
+    it("attaches, sees, and detaches a live container", async () => {
+      const home = await network(nm("home"));
+      const extra = await network(nm("extra"));
+      const id = await container(nm("c1"), home);
+
+      expect(await docker.containerOnNetwork(extra, id)).toBe(false);
+      expect(await docker.connectToNetwork(extra, id)).toBe(true);
+      expect(await docker.containerOnNetwork(extra, id)).toBe(true);
+      // Attaching twice is "already done", not a failure.
+      expect(await docker.connectToNetwork(extra, id)).toBe(true);
+      expect(await docker.disconnectFromNetwork(extra, id)).toBe(true);
+      expect(await docker.containerOnNetwork(extra, id)).toBe(false);
+      // And the original network was never touched.
+      expect(await networksOf(id)).toEqual([home]);
+    });
+
+    it("lists network members by FULL id, which is not what a container calls itself", async () => {
+      // The bug: `id !== selfId` compared this 64-char id to a 12-char hostname.
+      const net = await network(nm("members"));
+      const id = await container(nm("c2"), net);
+      const members = await docker.networkContainerIds(net);
+      expect(members).toEqual([id]);
+      expect(id).toHaveLength(64);
+
+      const hostname = (await docker.inspect(id)).Config?.Hostname;
+      expect(hostname).toBe(id.slice(0, 12)); // Docker's default: hostname = short id
+      expect(sameContainerId(id, hostname)).toBe(true); // the fix, against real values
+      expect(members![0] === hostname).toBe(false); // the naive comparison, still wrong
+    });
+
+    it("returns null, not empty, for a network it cannot inspect", async () => {
+      // Null is load-bearing: acting on it would let the manager abandon a network
+      // that is still in use.
+      expect(await docker.networkContainerIds(nm("never-created"))).toBeNull();
+    });
+  });
+
+  describe("facts the shared-network rename depends on", () => {
+    it("JSON-sorts a container's networks by name regardless of attach order", async () => {
+      // Unraid builds a container's WebUI link from the FIRST network in this map.
+      // "ark-net" sorted ahead of "br0" and took the link with it; "palisade-net"
+      // sorts after. That only holds if Docker really does sort — so pin it.
+      const primary = await network(nm("zz-primary"));
+      const second = await network(nm("aa-second"));
+      const id = await container(nm("c3"), primary);
+      await docker.connectToNetwork(second, id);
+
+      // Read the raw JSON the API returns, not a Map that might re-order.
+      const raw = (await docker.client.getContainer(id).inspect()) as {
+        NetworkSettings: { Networks: Record<string, unknown> };
+      };
+      const keys = Object.keys(raw.NetworkSettings.Networks);
+      expect(keys).toEqual([second, primary]); // attached second, listed first
+    });
+  });
+
+  describe("the migration off ark-net, end to end", () => {
+    // Skipped, not failed, if the host already has an ark-net: that could be a real
+    // install's network, and this test attaches and detaches things to it.
+    let legacyPreexisted = false;
+    let target: string;
+
+    beforeAll(async () => {
+      legacyPreexisted = (await docker.networkExists(LEGACY_NETWORK)) === true;
+      target = nm("shared");
+      process.env.SHARED_NETWORK = target;
+      resetEnvCache();
+      await network(target);
+    });
+
+    const settings = { getAutoCreateNetwork: async () => null } as never;
+    const service = () => new GameEndpointService(docker, settings);
+
+    it("joins the new network and leaves ark-net once nothing else needs it", async (ctx) => {
+      if (legacyPreexisted) return ctx.skip();
+      await network(LEGACY_NETWORK);
+      const lan = await network(nm("lan"));
+      const manager = await container(nm("manager"), lan);
+      await docker.connectToNetwork(LEGACY_NETWORK, manager);
+      selfId = manager.slice(0, 12); // what the manager's own hostname would be
+
+      expect(await service().ensureManagerNetworks()).toBe(true);
+
+      const after = await networksOf(manager);
+      expect(after).toContain(target);
+      expect(after).toContain(lan); // the LAN network is never touched
+      expect(after).not.toContain(LEGACY_NETWORK); // retired: it was alone there
+    });
+
+    it("keeps ark-net while a container that is not ours is still on it", async (ctx) => {
+      if (legacyPreexisted) return ctx.skip();
+      // Fresh manager on both bridges, plus a stranger on the legacy one.
+      const lan = await network(nm("lan2"));
+      const manager = await container(nm("manager2"), lan);
+      await docker.connectToNetwork(LEGACY_NETWORK, manager);
+      await docker.connectToNetwork(target, manager);
+      await container(nm("stranger"), LEGACY_NETWORK);
+      selfId = manager.slice(0, 12);
+
+      await service().ensureManagerNetworks();
+
+      expect(await networksOf(manager)).toContain(LEGACY_NETWORK);
+      // And it can name the blocker.
+      expect(await service().migrationNote()).toMatch(/another container/);
+    });
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+    // The *.docker.test.ts tier talks to a real Docker daemon and is run separately
+    // (`pnpm test:docker`, gated on PALISADE_DOCKER_TESTS=1) so the default suite
+    // stays fast and never reaches for a developer's daemon uninvited.
+    exclude: ["**/node_modules/**", "src/**/*.docker.test.ts"],
   },
 });

--- a/apps/api/vitest.docker.config.ts
+++ b/apps/api/vitest.docker.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const dir = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * The integration tier: *.docker.test.ts, run against a REAL Docker daemon.
+ *
+ * The fast suite fakes Docker, and the fake is where several shipped bugs hid —
+ * `docker network inspect` returning 64-char ids while the manager knew itself by
+ * the 12-char hostname, the API JSON-sorting a container's network map, membership
+ * that only lists live endpoints. Each was found on a real box after the unit tests
+ * passed. This tier pins those facts against the daemon itself.
+ *
+ * Gated on PALISADE_DOCKER_TESTS=1 (each file checks) so it never runs uninvited.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@ark/shared": resolve(dir, "../../packages/shared/src/index.ts"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.docker.test.ts"],
+    // Real pulls, creates and inspects — nothing here is 5ms.
+    testTimeout: 60_000,
+    hookTimeout: 120_000,
+    // One file at a time: they share a daemon and clean up after themselves.
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Why

Until now **nothing ran the test suite, typecheck, or lint automatically.** The only automation was audit + Trivy + image build, and only on release tags. 547 tests protected exactly the commits someone remembered to run them against — #56 from an outside contributor merged this week on my local run alone.

## What

`ci.yml`, on every PR and push to `main`, two parallel jobs:

| Job | Runs |
|---|---|
| `check` | `prisma generate` → typecheck → lint → tests → build (the full local gate) |
| `integration` | the new `*.docker.test.ts` tier against the runner's **real Docker daemon** |

## The integration tier is the point

Four bugs in one week were the fake Docker disagreeing with the real one, and every one passed the unit suite and was found on a live Unraid box:

- `docker network inspect` names members by their **64-char** id; a container's hostname — how the manager knows itself — is the **12-char** one
- the API **JSON-sorts** a container's networks by name regardless of attach order (the entire premise of the `palisade-net` rename)
- membership lists **live** endpoints only

The new file pins each fact against the daemon itself, then runs the whole `ark-net → palisade-net` migration end to end with a real "manager" container, and again with a real stranger on the legacy network.

**Proven, not asserted.** I reintroduced the shipped id-comparison bug and ran both tiers:

| | Result |
|---|---|
| Fast suite | 4 fail — *but only because I rewrote its fixtures after finding the bug* |
| Docker tier | 1 fail — **with no fixture knowing the answer** |

It would have failed the day the bug was written.

## Safety

- Gated on `PALISADE_DOCKER_TESTS=1`, so `pnpm test` never reaches for a developer's daemon. Default vitest config excludes `*.docker.test.ts`; a second config includes only them.
- Every network and container is uniquely named (`palisade-it-<run>-*`) and removed in `afterAll`. Verified zero leftovers.
- **Refuses to touch a pre-existing `ark-net`** — that name is hard-coded in the code under test and might be a real install's. Those two cases skip rather than fail.
- Files run serially; they share a daemon.

Seven tests, ~7 seconds. README documents both tiers.

## Verification

Fast suite: 547 pass, docker tier excluded. Docker tier: 7 pass locally. `pnpm typecheck`, `pnpm lint`, `pnpm build` clean. This PR will be the first thing the new workflow runs on — the real verification is the checks on this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)