### PR TITLE
Add Genesis: Part 1 to the ASA map picker

### DIFF
--- a/docs/games/asa.md
+++ b/docs/games/asa.md
@@ -9,7 +9,7 @@
 ## First boot
 - Big: ~13 GB depot (15 GB disk preflight), and plan on ~16 GB RAM for a populated server — by far the heaviest game in the panel. The image installs/updates the game files itself on every start (`UPDATE_SERVER=TRUE`).
 - Ready is detected on the log line "Server has completed startup and is now advertising for join" — the earlier "has successfully started!" and "Full Startup: N seconds" lines fire ~30 s before the server actually takes joins.
-- 10 official maps are selectable (The Island through Lost Colony plus Club ARK); mod maps are added dynamically.
+- 11 official maps are selectable (The Island through Lost Colony and Genesis: Part 1, plus Club ARK); mod maps are added dynamically.
 
 ## Gotchas
 - On a 32 GB box, run ONE ARK server at a time — two at once (ASA + ASE) has OOM'd the host into a swap thrash. Keep the per-server RAM cap set (~14 GB for ASA).

--- a/packages/shared/src/game.ts
+++ b/packages/shared/src/game.ts
@@ -559,6 +559,7 @@ export const ASA_OFFICIAL_MAPS = [
   "Valguero_WP",
   "Astraeos_WP",
   "LostColony_WP",
+  "Genesis_WP",
   "BobsMissions_WP",
 ] as const;
 
@@ -778,6 +779,7 @@ export const MAP_LABELS: Record<string, string> = {
   Valguero_WP: "Valguero",
   Astraeos_WP: "Astraeos",
   LostColony_WP: "Lost Colony",
+  Genesis_WP: "Genesis: Part 1",
   BobsMissions_WP: "Club ARK",
   // ASE
   TheIsland: "The Island",


### PR DESCRIPTION
Genesis Ascended shipped on July 3, 2026 as free DLC on the standard ASA server build, so no image or depot change is needed. This adds `Genesis_WP` to the ASA map list with the label "Genesis: Part 1", and bumps the map count in the ASA doc.

The Genesis settings tab matches on the "genesis" fragment of the map name, so it already shows for servers on this map. No settings changes needed.

Typecheck and the full test suite pass.

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
