### PR TITLE
Move every workflow action onto its Node 24 major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: pnpm
@@ -52,9 +52,9 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Audit production dependencies (fail on high+)
         run: pnpm audit --prod --audit-level high
@@ -36,13 +36,13 @@ jobs:
     needs: audit
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Derive image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # Lowercase image name (GHCR requires lowercase); links to this repo.
           images: ghcr.io/shakes63/palisade
@@ -64,7 +64,7 @@ jobs:
             type=sha,format=short
 
       - name: Build (amd64 — Unraid), load for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -85,7 +85,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Push (reuses the scanned build from cache)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Audit production dependencies (fail on high+)
         run: pnpm audit --prod --audit-level high
@@ -39,7 +39,7 @@ jobs:
     needs: audit
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Stamp prerelease version (workspace only — never committed)
         id: ver
@@ -56,10 +56,10 @@ jobs:
           echo "Stamped ${NIGHTLY}"
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Derive image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/shakes63/palisade
           # Deliberately no `latest` and no semver tags here — structurally
@@ -79,7 +79,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.ver.outputs.version }}
 
       - name: Build (amd64 — Unraid), load for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -100,7 +100,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Push (reuses the scanned build from cache)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/sync-ca-template.yml
+++ b/.github/workflows/sync-ca-template.yml
@@ -26,7 +26,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # A cross-repo push needs credentials the job's own GITHUB_TOKEN doesn't carry
       # (it is scoped to this repository). CA_TEMPLATE_KEY is the private half of a


### PR DESCRIPTION
The v1.12.1 publish run warned that checkout, setup-node, pnpm/action-setup and the four docker actions still target Node 20, which GitHub is forcing onto Node 24. Each moves to its current major.

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v7 |
| pnpm/action-setup | v4 | v6 |
| docker/build-push-action | v6 | v7 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/setup-buildx-action | v3 | v4 |

I read the release notes at each major boundary against how these workflows use the actions. Checkout runs with no options, so the v6 credential-file change and the v7 fork-PR block (pull_request_target only) do not apply. setup-node names its cache explicitly, so the v5/v6 auto-cache changes are moot. The docker actions dropped deprecated inputs and envs none of these steps set. Trivy stays pinned.

CI on this PR covers checkout, pnpm and setup-node. The docker actions are only exercised by the publish and nightly workflows, so nightly was dispatched against this branch to prove them before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
