### PR TITLE
Stop retention racing replication, and let Icarus load a prospect on boot

### DIFF
--- a/apps/api/src/backups/backups.service.ts
+++ b/apps/api/src/backups/backups.service.ts
@@ -100,6 +100,11 @@ export class BackupsService {
     const snapshot = await this.prisma.snapshot.create({
       data: { serverId, path: dest, reason, sizeBytes },
     });
+    // Rotate BEFORE announcing: BackupCreated kicks off off-box replication, which
+    // tars every snapshot the target is missing. Pruning afterwards deleted the
+    // oldest snapshot out from under that tar ("tar exited 2", GH #65) and the new
+    // backup then waited for the hourly reconcile to make it off the box.
+    await this.applyRetention(serverId);
     if (sizeBytes === 0) {
       this.logger.warn(`Backup (${reason}) for ${serverId} captured 0 bytes: ${dest}`);
       await this.events.emit({
@@ -116,7 +121,6 @@ export class BackupsService {
         data: { path: dest, sizeBytes },
       });
     }
-    await this.applyRetention(serverId);
     return snapshot;
   }
 

--- a/apps/api/src/backups/backups.test.ts
+++ b/apps/api/src/backups/backups.test.ts
@@ -24,3 +24,67 @@ describe("includeInBackup", () => {
     expect(includeInBackup("Cache/anything/at/all")).toBe(false);
   });
 });
+
+// ── create(): retention runs before the BackupCreated announcement (GH #65) ──────
+import { mkdtemp, mkdir, rm, writeFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EventType } from "@ark/shared";
+
+describe("BackupsService.create", () => {
+  it("prunes past-retention snapshots BEFORE emitting BackupCreated, so replication never tars a dir mid-delete", async () => {
+    process.env.SECRETS_KEY = "a".repeat(64);
+    process.env.JWT_SECRET = "test-jwt-secret-1234";
+    const root = await mkdtemp(join(tmpdir(), "palisade-backups-"));
+    process.env.DATA_DIR = root;
+    const { resetEnvCache } = await import("../config/env");
+    resetEnvCache();
+    try {
+      await mkdir(join(root, "instances", "srv1", "world"), { recursive: true });
+      await writeFile(join(root, "instances", "srv1", "world", "level.dat"), "live world");
+      // One automatic snapshot already on disk + in the DB; keep=1 means it goes
+      // as soon as the next one lands.
+      const oldPath = join(root, "backups", "srv1", "scheduled-2026-09-07T07-45-00-123Z");
+      await mkdir(oldPath, { recursive: true });
+      await writeFile(join(oldPath, "level.dat"), "old world");
+      const rows: { id: string; serverId: string; path: string; reason: string; createdAt: Date }[] = [
+        { id: "old", serverId: "srv1", path: oldPath, reason: "scheduled", createdAt: new Date("2026-09-07T07:45:00Z") },
+      ];
+      const prisma = {
+        server: { findUnique: async () => ({ id: "srv1", game: "MINECRAFT", backupKeep: 1 }) },
+        snapshot: {
+          create: async ({ data }: { data: { serverId: string; path: string; reason: string } }) => {
+            const row = { id: "new", createdAt: new Date(), ...data };
+            rows.push(row);
+            return row;
+          },
+          findMany: async () => rows.slice(),
+          delete: async ({ where }: { where: { id: string } }) => {
+            const i = rows.findIndex((r) => r.id === where.id);
+            if (i >= 0) rows.splice(i, 1);
+            return {};
+          },
+        },
+      };
+      const seenAtEmit: { type: EventType; oldStillOnDisk: boolean }[] = [];
+      const events = {
+        emit: async (e: { type: EventType }) => {
+          const oldStillOnDisk = await stat(oldPath).then(() => true, () => false);
+          seenAtEmit.push({ type: e.type, oldStillOnDisk });
+        },
+      };
+      const rcon = { saveWorld: async () => undefined };
+      const { BackupsService } = await import("./backups.service");
+      const svc = new BackupsService(prisma as never, events as never, rcon as never, {} as never);
+
+      const snap = await svc.create("srv1", "scheduled");
+      expect(snap.id).toBe("new");
+      expect(seenAtEmit).toEqual([{ type: EventType.BackupCreated, oldStillOnDisk: false }]);
+      expect(rows.map((r) => r.id)).toEqual(["new"]);
+      await expect(stat(join(snap.path, "world", "level.dat"))).resolves.toBeTruthy();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      resetEnvCache();
+    }
+  });
+});

--- a/apps/api/src/catalog/icarus.catalog.ts
+++ b/apps/api/src/catalog/icarus.catalog.ts
@@ -23,6 +23,12 @@ const settings: SettingDef[] = [
   iset("SERVER_RESUME_PROSPECT", "Resume last prospect on restart", "Session", "bool", true, {
     help: "When the server restarts, automatically resume the prospect (world) it was last running.",
   }),
+  // Not an image env var: the image blanks LoadProspect= in ServerSettings.ini on
+  // every boot, so a hand-edited value never survives a start (GH #62). The runtime
+  // spec turns this into a BOOTSTRAP_HOOK that re-applies it after the image's reset.
+  iset("LOAD_PROSPECT", "Load prospect on start", "Session", "string", "", {
+    help: "Name of an existing prospect (saved world) to load every time the server starts, instead of waiting in the lobby. Leave blank to pick one in-game. Letters, digits, spaces, dots, dashes and underscores only.",
+  }),
   iset("SERVER_SHUTDOWN_IF_NOT_JOINED", "Return to lobby if unjoined", "Session", "int", 300, {
     min: 0,
     max: 3600,

--- a/apps/api/src/replication/replication.service.ts
+++ b/apps/api/src/replication/replication.service.ts
@@ -177,8 +177,11 @@ export class ReplicationService implements OnModuleInit {
         const artifact = `${posix.basename(snap.path.replaceAll("\\", "/"))}.tar.gz`;
         if (existing.has(artifact)) continue;
         if (!(await this.exists(snap.path))) continue; // pruned locally before ever syncing
-        await this.uploadTarGz(snap.path, dest, this.remoteJoin(config, serverId, artifact));
-        uploaded++;
+        // Retention (or a manual delete) can still remove the directory while tar is
+        // reading it — that snapshot is simply gone, not a replication failure, so
+        // move on to the rest rather than abandoning the whole pass (GH #65).
+        if (await this.uploadTarGz(snap.path, dest, this.remoteJoin(config, serverId, artifact))) uploaded++;
+        else this.logger.debug(`Skipped ${artifact}: snapshot was deleted while it was being archived`);
       }
       // Remote retention mirrors local keep-N (manifest excluded from the count) —
       // including the manual exemption, or the copies we just protected locally
@@ -218,13 +221,23 @@ export class ReplicationService implements OnModuleInit {
     return uploaded;
   }
 
-  /** Stream `tar czf - -C <dir> .` straight into the destination — no temp file. */
-  private async uploadTarGz(localDir: string, dest: Destination, remotePath: string): Promise<void> {
+  /**
+   * Stream `tar czf - -C <dir> .` straight into the destination — no temp file.
+   * Resolves true when the artifact landed, false when the source directory
+   * disappeared underneath tar (nothing left to replicate; the partial artifact is
+   * removed). Any other tar failure throws, with tar's own complaint attached so
+   * the Warning says more than an exit code.
+   */
+  private async uploadTarGz(localDir: string, dest: Destination, remotePath: string): Promise<boolean> {
     const tar = spawn("tar", ["czf", "-", "-C", localDir, "."]);
     // Attach BEFORE any awaiting: tar can exit while the pipeline drains, and a
     // listener added after "close" fired would wait forever (hung the first
     // live sync exactly this way).
     const exited = new Promise<number>((resolve) => tar.on("close", resolve));
+    let stderr = "";
+    tar.stderr.on("data", (d: Buffer) => {
+      if (stderr.length < 2048) stderr += d.toString();
+    });
     const sink = await dest.createWriteStream(remotePath);
     try {
       await pipeline(tar.stdout, sink);
@@ -233,10 +246,11 @@ export class ReplicationService implements OnModuleInit {
       throw err;
     }
     const code = await exited;
-    if (code !== 0) {
-      await dest.remove(remotePath).catch(() => undefined);
-      throw new Error(`tar exited ${code} for ${localDir}`);
-    }
+    if (code === 0) return true;
+    await dest.remove(remotePath).catch(() => undefined);
+    if (!(await this.exists(localDir))) return false;
+    const detail = stderr.trim().split("\n").filter(Boolean).slice(-3).join("; ");
+    throw new Error(`tar exited ${code} for ${localDir}${detail ? ` (${detail})` : ""}`);
   }
 
   private remoteJoin(config: ReplicationConfig, ...parts: string[]): string {
@@ -269,7 +283,7 @@ interface Destination {
 }
 
 /** Another path visible inside the container (e.g. an Unraid share mapped in). */
-class LocalDestination implements Destination {
+export class LocalDestination implements Destination {
   async mkdirp(dir: string): Promise<void> {
     await mkdir(dir, { recursive: true });
   }

--- a/apps/api/src/replication/replication.test.ts
+++ b/apps/api/src/replication/replication.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile, readdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { EventType } from "@ark/shared";
+import { ReplicationService } from "./replication.service";
+
+const execFileP = promisify(execFile);
+
+/**
+ * Real tar + real files against a "local" destination. The point under test is the
+ * race with retention (GH #65): a snapshot directory can vanish while tar is
+ * reading it, which must not abort the sync or leave a half-written artifact.
+ */
+describe("ReplicationService", () => {
+  let root: string;
+  let target: string;
+  let snapshots: { serverId: string; path: string; server: { name: string; game: string; backupKeep: number | null } }[];
+  let emitted: { type: EventType; message: string }[];
+  let svc: ReplicationService;
+
+  beforeEach(async () => {
+    process.env.SECRETS_KEY = "a".repeat(64);
+    process.env.JWT_SECRET = "test-jwt-secret-1234";
+    root = await mkdtemp(join(tmpdir(), "palisade-repl-"));
+    process.env.DATA_DIR = join(root, "data");
+    const { resetEnvCache } = await import("../config/env");
+    resetEnvCache();
+    target = join(root, "target");
+    await mkdir(target, { recursive: true });
+    snapshots = [];
+    emitted = [];
+    const config = JSON.stringify({ enabled: true, kind: "local", dir: target });
+    const settings = {
+      get: async (key: string) => (key === "backup_replication" ? config : null),
+      set: async () => undefined,
+    };
+    const prisma = { snapshot: { findMany: async () => snapshots } };
+    const events = {
+      onEvent: () => undefined,
+      emit: async (e: { type: EventType; message: string }) => {
+        emitted.push(e);
+      },
+    };
+    svc = new ReplicationService(prisma as never, events as never, settings as never);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    const { resetEnvCache } = await import("../config/env");
+    resetEnvCache();
+  });
+
+  async function snapshot(serverId: string, name: string): Promise<string> {
+    const path = join(root, "data", "backups", serverId, name);
+    await mkdir(join(path, "world"), { recursive: true });
+    await writeFile(join(path, "world", "level.dat"), `save ${name}`);
+    snapshots.push({ serverId, path, server: { name: "Test", game: "MINECRAFT", backupKeep: 5 } });
+    return path;
+  }
+
+  it("uploads each snapshot as a .tar.gz the target can list back", async () => {
+    await snapshot("srv1", "scheduled-2026-09-07T10-45-00-000Z");
+    const result = await svc.sync();
+    expect(result).toEqual({ uploaded: 1, skipped: false });
+    const files = await readdir(join(target, "srv1"));
+    expect(files).toContain("scheduled-2026-09-07T10-45-00-000Z.tar.gz");
+    const { stdout } = await execFileP("tar", ["tzf", join(target, "srv1", "scheduled-2026-09-07T10-45-00-000Z.tar.gz")]);
+    expect(stdout).toContain("./world/level.dat");
+    expect(emitted).toEqual([]);
+  });
+
+  it("treats a snapshot deleted underneath tar as gone, not as a failed sync", async () => {
+    const doomed = join(root, "data", "backups", "srv1", "scheduled-2026-09-07T07-45-00-123Z");
+    const artifact = join(target, "srv1", "scheduled-2026-09-07T07-45-00-123Z.tar.gz");
+    await mkdir(join(target, "srv1"), { recursive: true });
+    // Directly exercise the tar path with a directory that is already gone — what
+    // tar sees when retention wins the race after the pre-flight exists() check.
+    const { LocalDestination } = await import("./replication.service");
+    const landed = await (svc as unknown as {
+      uploadTarGz: (dir: string, dest: InstanceType<typeof LocalDestination>, remote: string) => Promise<boolean>;
+    }).uploadTarGz(doomed, new LocalDestination(), artifact);
+    expect(landed).toBe(false);
+    await expect(stat(artifact)).rejects.toThrow(); // no half-written artifact left behind
+  });
+
+  it("keeps going past a vanished snapshot and still replicates the rest", async () => {
+    const older = await snapshot("srv1", "scheduled-2026-09-07T07-45-00-123Z");
+    await snapshot("srv1", "scheduled-2026-09-07T16-45-04-609Z");
+    const real = (svc as unknown as { uploadTarGz: (...a: unknown[]) => Promise<boolean> }).uploadTarGz.bind(svc);
+    // Retention deletes the older snapshot the instant its upload begins.
+    vi.spyOn(svc as unknown as { uploadTarGz: (...a: unknown[]) => Promise<boolean> }, "uploadTarGz").mockImplementation(
+      async (...args: unknown[]) => {
+        if (args[0] === older) await rm(older, { recursive: true, force: true });
+        return real(...args);
+      },
+    );
+    const result = await svc.sync();
+    expect(result).toEqual({ uploaded: 1, skipped: false });
+    const files = await readdir(join(target, "srv1"));
+    expect(files).toContain("scheduled-2026-09-07T16-45-04-609Z.tar.gz");
+    expect(files).not.toContain("scheduled-2026-09-07T07-45-00-123Z.tar.gz");
+    expect(emitted.filter((e) => e.type === EventType.Warning)).toEqual([]);
+  });
+
+  it("still reports a genuine tar failure, with tar's complaint attached", async () => {
+    const path = await snapshot("srv1", "scheduled-2026-09-07T10-45-00-000Z");
+    await mkdir(join(path, "unreadable"));
+    await writeFile(join(path, "unreadable", "secret"), "x", { mode: 0o000 });
+    if (process.getuid?.() === 0) return; // root reads anything — nothing to provoke
+    await expect(svc.sync()).rejects.toThrow(/tar exited \d+ .*Permission denied/);
+    expect(emitted.some((e) => e.type === EventType.Warning && /Permission denied/.test(e.message))).toBe(true);
+    await expect(stat(join(target, "srv1", "scheduled-2026-09-07T10-45-00-000Z.tar.gz"))).rejects.toThrow();
+  });
+});

--- a/apps/api/src/servers/runtime-spec.test.ts
+++ b/apps/api/src/servers/runtime-spec.test.ts
@@ -308,6 +308,26 @@ describe("buildContainerSpec (Icarus / mornedhels)", () => {
     expect(env).toContain("SERVER_ALLOW_NON_ADMINS_DELETE=True");
     expect(env).toContain("SERVER_SHUTDOWN_IF_EMPTY=120");
   });
+
+  // The image blanks LoadProspect= on every boot and has no env var for it, so the
+  // setting rides BOOTSTRAP_HOOK (which runs after that reset) — GH #62.
+  it("turns 'Load prospect on start' into a BOOTSTRAP_HOOK that re-applies LoadProspect", async () => {
+    const env = envOf(await buildIcarus({ values: { LOAD_PROSPECT: "World" } }));
+    expect(env).toContain(
+      "BOOTSTRAP_HOOK=sed -i '/^LoadProspect=/c\\LoadProspect=World' '/home/icarus/drive_c/icarus/Saved/Config/WindowsServer/ServerSettings.ini'",
+    );
+    expect(env.some((e) => e.startsWith("LOAD_PROSPECT="))).toBe(false); // not an image env var
+  });
+
+  it("emits no hook when the prospect is blank or has shell-unsafe characters", async () => {
+    for (const bad of ["", "   ", "x; rm -rf /", "a'b", "$(id)", "über"]) {
+      const env = envOf(await buildIcarus({ values: { LOAD_PROSPECT: bad } }));
+      expect(env.some((e) => e.startsWith("BOOTSTRAP_HOOK=")), JSON.stringify(bad)).toBe(false);
+    }
+    // Names with spaces are legitimate (the image's own loadProspect command allows them).
+    const env = envOf(await buildIcarus({ values: { LOAD_PROSPECT: "  My Base 2.0  " } }));
+    expect(env.find((e) => e.startsWith("BOOTSTRAP_HOOK="))).toContain("c\\LoadProspect=My Base 2.0'");
+  });
 });
 
 async function buildBedrock(config: ServerConfigValues) {

--- a/apps/api/src/servers/runtime-spec.ts
+++ b/apps/api/src/servers/runtime-spec.ts
@@ -983,17 +983,43 @@ function buildIcarusSpec(input: RuntimeSpecInput): Docker.ContainerCreateOptions
   };
 }
 
+/** Catalog key for the prospect Icarus should load on boot. */
+export const ICARUS_LOAD_PROSPECT_KEY = "LOAD_PROSPECT";
+/** Where the image keeps ServerSettings.ini inside the container (its `config_path`). */
+const ICARUS_SERVER_SETTINGS = `${ICARUS_CONFIG_DIR}/Saved/Config/WindowsServer/ServerSettings.ini`;
+
 /** Icarus settings -> mornedhels env vars. Booleans become ServerSettings' True/False. */
 function icarusCatalogEnv(input: RuntimeSpecInput): string[] {
   const out: string[] = [];
   for (const def of input.catalog.settings) {
     if (def.target !== SettingTarget.Env) continue;
+    if (def.key === ICARUS_LOAD_PROSPECT_KEY) continue; // no env var for it — see below
     const raw = input.config.values?.[def.key] ?? def.default;
     if (raw === undefined || raw === null) continue;
     const val = typeof raw === "boolean" ? (raw ? "True" : "False") : String(raw);
     out.push(`${def.emitAs ?? def.key}=${val}`);
   }
+  const hook = icarusLoadProspectHook(String(input.config.values?.[ICARUS_LOAD_PROSPECT_KEY] ?? ""));
+  if (hook) out.push(`BOOTSTRAP_HOOK=${hook}`);
   return out;
+}
+
+/**
+ * The image has no env var for LoadProspect — worse, its bootstrap force-resets
+ * `LoadProspect=` in ServerSettings.ini on every boot, so a value written into
+ * the file (by hand or by us) is gone before the server reads it (GH #62). The
+ * one thing the image does run AFTER that reset is BOOTSTRAP_HOOK, so we re-apply
+ * the line from there, the same way the image's own `icarus-commands loadProspect`
+ * does. Returns "" when there is nothing to load.
+ *
+ * The hook is `eval`ed by bash inside the container, so the name is confined to a
+ * plain allowlist (Icarus prospect names are simple words anyway) — anything else
+ * is dropped rather than quoted around.
+ */
+export function icarusLoadProspectHook(prospect: string): string {
+  const name = prospect.trim();
+  if (!name || !/^[A-Za-z0-9 _.-]+$/.test(name)) return "";
+  return `sed -i '/^LoadProspect=/c\\LoadProspect=${name}' '${ICARUS_SERVER_SETTINGS}'`;
 }
 
 /**

--- a/docs/games/icarus.md
+++ b/docs/games/icarus.md
@@ -8,7 +8,7 @@
 
 ## First boot
 - ~11 GB of game files via SteamCMD under Wine (15 GB disk preflight) — expect a long first install. Icarus is heavy at runtime too: RocketWerkz recommend 16 GB RAM; the panel budgets 12 GB.
-- There is no map or world to configure: the world is a "prospect" (map + mode + difficulty) that players create/select in-game from the lobby — the image has no env var to pre-set it. `SERVER_ALLOW_NON_ADMINS_LAUNCH` and `SERVER_RESUME_PROSPECT` control lobby behavior.
+- There is no map or world to configure: the world is a "prospect" (map + mode + difficulty) that players create/select in-game from the lobby. `SERVER_ALLOW_NON_ADMINS_LAUNCH` and `SERVER_RESUME_PROSPECT` control lobby behavior. To boot straight into a saved prospect, set **Load prospect on start** (Settings → Session) to its name.
 - Ready is detected when the Unreal server binds its port and the GameMode reaches the lobby ("Match State Changed from EnteringMap to WaitingToStart").
 - Config + saves (prospects) and the big game install are bound to separate dirs, so backups target the small config/saves dir.
 
@@ -18,3 +18,4 @@
 - Two hard mod rules: every player needs the same mods installed locally, and multiple mods must be merged into a single `._P.pak` (with Icarus Mod Manager) before upload.
 - Port forwarding needs BOTH UDP ports: 17777 (game) and 27015 (query) — 27015 is the one that makes the server appear in the in-game browser.
 - Player cap is 20 (RocketWerkz raised it from 8); the create form defaults to 8.
+- Editing `LoadProspect=` in `ServerSettings.ini` by hand does not stick: the image blanks that line on every boot. Use the **Load prospect on start** setting instead, which re-applies it after the image's reset. Every other line in that file the image does not manage survives restarts and can be edited from the Files tab.


### PR DESCRIPTION
Two bug reports, one PR.

## Backup replication failed with "tar exited 2" (#65)

The backup path emitted BackupCreated, which starts an off-box sync, and only then ran retention. The sync's snapshot list still held the oldest snapshot, and retention deleted that directory while tar was reading it. The sync aborted, so the new backup waited for the hourly reconcile. With hourly backups and a full retention window this happened on every run, which matches the "increasingly often" in the report and the log line naming a snapshot that no longer exists on disk.

Retention now runs before the event fires. Replication also treats a snapshot directory that disappears under tar as gone rather than as a failed pass: it removes the partial artifact and moves on to the rest. Real tar failures still throw, now with tar's own stderr in the message instead of a bare exit code.

## Icarus ignored a hand-edited LoadProspect= (#62)

The mornedhels image blanks that line in ServerSettings.ini on every boot and has no env var for it, so a value written into the file never reaches the server. The only thing the image runs after that reset is BOOTSTRAP_HOOK. A new "Load prospect on start" setting under Session turns into a hook that re-applies the line, using the same sed the image's own loadProspect command uses. The prospect name is limited to a plain allowlist because the hook is evaled by bash inside the container. The Icarus doc page explains why the hand edit does not stick and points at the setting.

## Tests

- Replication: real tar against a local destination. A directory that vanishes under tar is skipped without a Warning and leaves no half-written artifact. A genuine tar failure still surfaces with tar's complaint.
- Backups: the older snapshot is already gone from disk and the database by the time BackupCreated is emitted.
- Runtime spec: the setting becomes the expected BOOTSTRAP_HOOK, is not leaked as an env var, and unsafe names produce no hook at all.

Refs #62, #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
