### PR TITLE
Add UniFi as a port-forward router alongside pfSense

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ player administration, and even your router's port-forwards.
 - ARK cluster support (shared transfer dir across servers).
 - Discord/webhook notifications, host low-disk warnings, editable ports with a
   start-time port-conflict guard.
-- Optional **pfSense integration**: one-click WAN port-forward
-  create/fix/enable/disable/delete per server via the pfSense REST API.
+- Optional **router integration** (pfSense or UniFi): one-click WAN port-forward
+  create/fix/enable/disable/delete per server via the router's API.
 
 See [PLANNING.md](PLANNING.md) for architecture details.
 
@@ -337,6 +337,7 @@ It migrates itself, and a half-migrated install works throughout:
 | Steam Web API key | ASE/Conan Workshop browser | Free key from <https://steamcommunity.com/dev/apikey> |
 | Discord webhook | State changes, crashes, backups, schedule events | A channel webhook URL |
 | pfSense | Per-server WAN port-forward management (create / fix / enable / disable / delete, WAN IP display) | The free [pfSense REST API package](https://pfrest.org/) on your router + an API key (System → REST API). Works with any pfSense — nothing is network-specific. Use the **Test connection** button to validate. |
+| UniFi | Same port-forward management on a UniFi OS console (Dream Machine, Cloud Gateway, Cloud Key) | An API key from the Network app (Settings → Control Plane → Integrations, admin role) on Network 9.0+, plus the site name (`default` unless multi-site). Pick **UniFi** under Settings → Integrations → Port forwarding, then **Test connection**. |
 
 **CurseForge terms:** the mod browser uses the CurseForge API read-only to
 search and display mods; it never downloads or redistributes mod files — the

--- a/apps/api/src/manager-settings/manager-settings.controller.ts
+++ b/apps/api/src/manager-settings/manager-settings.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Patch } from "@nestjs/common";
 import { ModuleRef } from "@nestjs/core";
-import { IsBoolean, IsInt, IsOptional, IsString, Max, Min, ValidateIf } from "class-validator";
+import { IsBoolean, IsIn, IsInt, IsOptional, IsString, Max, Min, ValidateIf } from "class-validator";
 import { ManagerSettingsService, SettingKeys } from "./manager-settings.service";
 import { SchedulerService } from "../scheduler/scheduler.service";
 import { MinRole } from "../auth/min-role.decorator";
@@ -22,6 +22,11 @@ class UpdateSettingsBody {
   @IsOptional() @IsString() pfsenseHost?: string;
   @IsOptional() @IsString() pfsenseApiKey?: string;
   @IsOptional() @IsString() pfsenseTargetIp?: string;
+  @IsOptional() @IsIn(["pfsense", "unifi"]) portForwardRouter?: "pfsense" | "unifi";
+  @IsOptional() @IsString() unifiHost?: string;
+  @IsOptional() @IsString() unifiApiKey?: string;
+  @IsOptional() @IsString() unifiSite?: string;
+  @IsOptional() @IsString() unifiTargetIp?: string;
 }
 
 /** "" for null so the row exists but reads back as unset — the tri-state the
@@ -70,6 +75,13 @@ export class ManagerSettingsController {
     if (body.pfsenseApiKey) await this.settings.set(SettingKeys.PfsenseApiKey, body.pfsenseApiKey);
     if (body.pfsenseTargetIp !== undefined)
       await this.settings.set(SettingKeys.PfsenseTargetIp, body.pfsenseTargetIp);
+    if (body.portForwardRouter !== undefined)
+      await this.settings.set(SettingKeys.PortForwardRouter, body.portForwardRouter);
+    if (body.unifiHost !== undefined) await this.settings.set(SettingKeys.UnifiHost, body.unifiHost.trim());
+    if (body.unifiApiKey) await this.settings.set(SettingKeys.UnifiApiKey, body.unifiApiKey.trim());
+    if (body.unifiSite !== undefined) await this.settings.set(SettingKeys.UnifiSite, body.unifiSite.trim());
+    if (body.unifiTargetIp !== undefined)
+      await this.settings.set(SettingKeys.UnifiTargetIp, body.unifiTargetIp.trim());
 
     // Host overrides. An empty string / null means "defer to the env var again",
     // which is stored as "" and read back as unset by the tri-state getters.

--- a/apps/api/src/manager-settings/manager-settings.service.ts
+++ b/apps/api/src/manager-settings/manager-settings.service.ts
@@ -31,6 +31,13 @@ export const SettingKeys = {
   PfsenseHost: "pfsense_host",
   PfsenseApiKey: "pfsense_api_key", // secret
   PfsenseTargetIp: "pfsense_target_ip", // the LAN IP the game servers bind on
+  // Which router the port-forward integration drives: "pfsense" (default) or "unifi".
+  PortForwardRouter: "port_forward_router",
+  // UniFi Network API (API key from Settings → Control Plane → Integrations).
+  UnifiHost: "unifi_host",
+  UnifiApiKey: "unifi_api_key", // secret
+  UnifiSite: "unifi_site", // the Network app's site name ("default" unless multi-site)
+  UnifiTargetIp: "unifi_target_ip", // the LAN IP the game servers bind on
   Initialized: "initialized",
 } as const;
 
@@ -46,6 +53,7 @@ const SECRET_KEYS = new Set<string>([
   SettingKeys.CurseForgeApiKey,
   SettingKeys.SteamWebApiKey,
   SettingKeys.PfsenseApiKey,
+  SettingKeys.UnifiApiKey,
   SettingKeys.NotificationTargets,
   SettingKeys.BackupReplication,
   SettingKeys.SteamGridDbApiKey,

--- a/apps/api/src/portforwards/pfsense.client.ts
+++ b/apps/api/src/portforwards/pfsense.client.ts
@@ -1,0 +1,139 @@
+import { request as httpsRequest } from "node:https";
+import type { ForwardPort } from "../catalog/ports";
+import type { RouterClient, RouterRule } from "./router";
+
+/** The slice of a pfSense NAT rule we read. */
+interface NatRule {
+  id: number;
+  interface?: string;
+  protocol?: string;
+  destination_port?: string;
+  target?: string;
+  disabled?: boolean;
+}
+
+/**
+ * WAN port-forwards via the pfSense REST API (the jaredhendrickson13 package,
+ * /api/v2). Rules are created with associated_rule_id "pass" (auto firewall rule)
+ * and every change is applied by commit(). pfSense boxes run self-signed certs, so
+ * TLS verification is disabled for this client. API quirk: single-object
+ * DELETE/PATCH want `id` in the JSON body, not the query string.
+ */
+export class PfsenseClient implements RouterClient {
+  readonly kind = "pfsense" as const;
+
+  constructor(
+    readonly host: string,
+    private readonly apiKey: string,
+    readonly targetIp: string,
+  ) {}
+
+  /** Minimal JSON request against the pfSense REST API (self-signed cert tolerated). */
+  private api<T>(method: "GET" | "POST" | "PATCH" | "DELETE", path: string, body?: unknown): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const payload = body === undefined ? null : JSON.stringify(body);
+      const req = httpsRequest(
+        {
+          host: this.host,
+          path: `/api/v2${path}`,
+          method,
+          rejectUnauthorized: false, // pfSense self-signed cert
+          timeout: 15_000,
+          headers: {
+            "X-API-Key": this.apiKey,
+            ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
+          },
+        },
+        (res) => {
+          let data = "";
+          res.on("data", (d) => (data += d));
+          res.on("end", () => {
+            if ((res.statusCode ?? 500) >= 400) {
+              return reject(new Error(`pfSense ${res.statusCode}: ${data.slice(0, 200)}`));
+            }
+            try {
+              resolve(JSON.parse(data) as T);
+            } catch {
+              resolve(undefined as T);
+            }
+          });
+        },
+      );
+      req.on("error", reject);
+      req.on("timeout", () => req.destroy(new Error("pfSense request timeout")));
+      if (payload) req.write(payload);
+      req.end();
+    });
+  }
+
+  async list(): Promise<RouterRule[]> {
+    const res = await this.api<{ data?: NatRule[] }>("GET", "/firewall/nat/port_forwards?limit=0");
+    return (res.data ?? [])
+      .filter((r) => (r.interface ?? "wan") === "wan")
+      .map((r) => {
+        const proto = (r.protocol ?? "").toLowerCase();
+        return {
+          id: String(r.id),
+          proto: proto === "tcp/udp" ? "both" : proto === "tcp" ? "tcp" : "udp",
+          ports: String(r.destination_port ?? ""),
+          target: r.target ?? "",
+          enabled: !r.disabled,
+        };
+      });
+  }
+
+  async wanIp(): Promise<string | null> {
+    const res = await this.api<{ data?: Array<{ name?: string; ipaddr?: string }> }>(
+      "GET",
+      "/status/interfaces?limit=0",
+    );
+    const wan = (res.data ?? []).find((i) => (i.name ?? "").toLowerCase() === "wan") ?? res.data?.[0];
+    return wan?.ipaddr ?? null;
+  }
+
+  async describe(): Promise<string> {
+    const rules = await this.list();
+    return `${rules.length} NAT rule${rules.length === 1 ? "" : "s"}`;
+  }
+
+  async create(f: ForwardPort, description: string): Promise<void> {
+    await this.api("POST", "/firewall/nat/port_forward", {
+      interface: "wan",
+      ipprotocol: "inet",
+      protocol: f.proto,
+      source: "any",
+      destination: "wan:ip",
+      destination_port: String(f.port),
+      target: this.targetIp,
+      local_port: String(f.port),
+      descr: description,
+      associated_rule_id: "pass",
+      disabled: false,
+    });
+  }
+
+  async retarget(rule: RouterRule, f: ForwardPort): Promise<void> {
+    await this.api("PATCH", "/firewall/nat/port_forward", {
+      id: Number(rule.id),
+      target: this.targetIp,
+      local_port: String(f.port),
+    });
+  }
+
+  async setEnabled(rule: RouterRule, enabled: boolean): Promise<void> {
+    await this.api("PATCH", "/firewall/nat/port_forward", { id: Number(rule.id), disabled: !enabled });
+  }
+
+  async remove(rules: RouterRule[]): Promise<void> {
+    // Delete highest id first so earlier deletions don't shift later ids.
+    for (const r of [...rules].sort((a, b) => Number(b.id) - Number(a.id))) {
+      await this.api("DELETE", "/firewall/nat/port_forward", { id: Number(r.id) });
+    }
+  }
+
+  async commit(): Promise<void> {
+    // Apply twice — the reliable pattern against this API.
+    await this.api("POST", "/firewall/apply", {});
+    await this.api("POST", "/firewall/apply", {});
+  }
+}

--- a/apps/api/src/portforwards/pfsense.client.ts
+++ b/apps/api/src/portforwards/pfsense.client.ts
@@ -10,6 +10,7 @@ interface NatRule {
   destination_port?: string;
   target?: string;
   disabled?: boolean;
+  descr?: string;
 }
 
 /**
@@ -74,6 +75,7 @@ export class PfsenseClient implements RouterClient {
         const proto = (r.protocol ?? "").toLowerCase();
         return {
           id: String(r.id),
+          name: r.descr ?? "",
           proto: proto === "tcp/udp" ? "both" : proto === "tcp" ? "tcp" : "udp",
           ports: String(r.destination_port ?? ""),
           target: r.target ?? "",

--- a/apps/api/src/portforwards/portforwards.controller.ts
+++ b/apps/api/src/portforwards/portforwards.controller.ts
@@ -3,13 +3,13 @@ import { IsBoolean, IsIn, IsInt } from "class-validator";
 import { PortForwardsService } from "./portforwards.service";
 import { MinRole } from "../auth/min-role.decorator";
 
-/** Settings-scoped pfSense utilities (not tied to a server). */
+/** Settings-scoped router utilities (not tied to a server). */
 @MinRole("admin")
-@Controller("pfsense")
-export class PfsenseController {
+@Controller("router")
+export class RouterController {
   constructor(private readonly portforwards: PortForwardsService) {}
 
-  /** Validate the configured pfSense host + API key + target IP. */
+  /** Validate the configured router (pfSense or UniFi) host + API key + target IP. */
   @Post("test")
   test() {
     return this.portforwards.testConnection();
@@ -26,13 +26,13 @@ class ToggleForwardBody {
 export class PortForwardsController {
   constructor(private readonly portforwards: PortForwardsService) {}
 
-  /** Each player-facing forward's state on the pfSense router. */
+  /** Each player-facing forward's state on the router. */
   @Get()
   status(@Param("id") id: string) {
     return this.portforwards.status(id);
   }
 
-  /** Create missing forwards and re-target mismatched ones (auto pass rules) + apply. */
+  /** Create missing forwards and re-target mismatched ones + apply. */
   @Post()
   apply(@Param("id") id: string) {
     return this.portforwards.apply(id);

--- a/apps/api/src/portforwards/portforwards.controller.ts
+++ b/apps/api/src/portforwards/portforwards.controller.ts
@@ -1,7 +1,16 @@
 import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from "@nestjs/common";
-import { IsBoolean, IsIn, IsInt } from "class-validator";
+import { IsBoolean, IsIn, IsInt, IsOptional, IsString } from "class-validator";
 import { PortForwardsService } from "./portforwards.service";
 import { MinRole } from "../auth/min-role.decorator";
+
+/** The Settings form's current (possibly unsaved) router fields. */
+class RouterTestBody {
+  @IsOptional() @IsIn(["pfsense", "unifi"]) router?: "pfsense" | "unifi";
+  @IsOptional() @IsString() host?: string;
+  @IsOptional() @IsString() apiKey?: string;
+  @IsOptional() @IsString() site?: string;
+  @IsOptional() @IsString() targetIp?: string;
+}
 
 /** Settings-scoped router utilities (not tied to a server). */
 @MinRole("admin")
@@ -9,10 +18,12 @@ import { MinRole } from "../auth/min-role.decorator";
 export class RouterController {
   constructor(private readonly portforwards: PortForwardsService) {}
 
-  /** Validate the configured router (pfSense or UniFi) host + API key + target IP. */
+  /** Validate router (pfSense or UniFi) host + API key + target IP. The body
+   *  carries the form's current values so Test works before Save; blanks fall
+   *  back to the saved settings. */
   @Post("test")
-  test() {
-    return this.portforwards.testConnection();
+  test(@Body() body: RouterTestBody) {
+    return this.portforwards.testConnection(body);
   }
 }
 

--- a/apps/api/src/portforwards/portforwards.module.ts
+++ b/apps/api/src/portforwards/portforwards.module.ts
@@ -5,5 +5,6 @@ import { PortForwardsService } from "./portforwards.service";
 @Module({
   controllers: [PortForwardsController, RouterController],
   providers: [PortForwardsService],
+  exports: [PortForwardsService],
 })
 export class PortForwardsModule {}

--- a/apps/api/src/portforwards/portforwards.module.ts
+++ b/apps/api/src/portforwards/portforwards.module.ts
@@ -1,9 +1,9 @@
 import { Module } from "@nestjs/common";
-import { PortForwardsController, PfsenseController } from "./portforwards.controller";
+import { PortForwardsController, RouterController } from "./portforwards.controller";
 import { PortForwardsService } from "./portforwards.service";
 
 @Module({
-  controllers: [PortForwardsController, PfsenseController],
+  controllers: [PortForwardsController, RouterController],
   providers: [PortForwardsService],
 })
 export class PortForwardsModule {}

--- a/apps/api/src/portforwards/portforwards.service.test.ts
+++ b/apps/api/src/portforwards/portforwards.service.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { PortForwardsService } from "./portforwards.service";
+import type { RouterClient, RouterRule } from "./router";
+
+/** An in-memory router: rules live in an array and every write is recorded. */
+function fakeRouter(initial: RouterRule[], targetIp = "10.0.0.5") {
+  const rules = [...initial];
+  const calls: string[] = [];
+  let seq = 100;
+  const client: RouterClient = {
+    kind: "unifi",
+    host: "10.0.0.1",
+    targetIp,
+    list: async () => rules.map((r) => ({ ...r })),
+    wanIp: async () => "203.0.113.9",
+    describe: async () => `${rules.length} rules`,
+    create: async (f) => {
+      calls.push(`create ${f.port}/${f.proto}`);
+      rules.push({ id: String(seq++), proto: f.proto, ports: String(f.port), target: targetIp, enabled: true });
+    },
+    retarget: async (rule) => {
+      calls.push(`retarget ${rule.id}`);
+      rules.find((r) => r.id === rule.id)!.target = targetIp;
+    },
+    setEnabled: async (rule, enabled) => {
+      calls.push(`setEnabled ${rule.id} ${enabled}`);
+      rules.find((r) => r.id === rule.id)!.enabled = enabled;
+    },
+    remove: async (doomed) => {
+      for (const d of doomed) {
+        calls.push(`remove ${d.id}`);
+        rules.splice(rules.findIndex((r) => r.id === d.id), 1);
+      }
+    },
+    commit: async () => {
+      calls.push("commit");
+    },
+  };
+  return { client, calls, rules };
+}
+
+/** Valheim: 2456/udp game, 2457/udp query, 2458/udp crossplay. */
+const valheim = {
+  id: "srv1",
+  name: "Vikings",
+  game: "VALHEIM",
+  gamePort: 2456,
+  rawSocketPort: 2458,
+  queryPort: 2457,
+  rconPort: 0,
+};
+
+function service(router: ReturnType<typeof fakeRouter> | null) {
+  const prisma = { server: { findUnique: vi.fn(async () => valheim) } };
+  const settings = { get: vi.fn(async (key: string) => (key === "port_forward_router" ? "unifi" : null)) };
+  const svc = new PortForwardsService(prisma as never, settings as never);
+  // Bypass settings → client construction; the fake stands in for a real router.
+  (svc as unknown as { client: () => Promise<RouterClient | null> }).client = async () => router?.client ?? null;
+  return svc;
+}
+
+describe("PortForwardsService", () => {
+  it("reports unconfigured without touching the router", async () => {
+    const view = await service(null).status("srv1");
+    expect(view.configured).toBe(false);
+    expect(view.router).toBe("unifi");
+    expect(view.forwards.map((f) => f.state)).toEqual(["missing", "missing", "missing"]);
+  });
+
+  it("classifies ok / disabled / mismatched / missing, seeing through tcp+udp and range rules", async () => {
+    const router = fakeRouter([
+      { id: "a", proto: "both", ports: "2456", target: "10.0.0.5", enabled: true }, // ok via tcp_udp
+      { id: "b", proto: "udp", ports: "2457-2460", target: "10.0.0.9", enabled: true }, // mismatched via range
+    ]);
+    const view = await service(router).status("srv1");
+    expect(view.wanIp).toBe("203.0.113.9");
+    expect(view.forwards.map((f) => [f.port, f.state, f.ruleId, f.actualTarget ?? null])).toEqual([
+      [2456, "ok", "a", null],
+      [2457, "mismatched", "b", "10.0.0.9"],
+      [2458, "mismatched", "b", "10.0.0.9"],
+    ]);
+  });
+
+  it("prefers a rule already pointing at the target, then a dedicated single-port rule", async () => {
+    const router = fakeRouter([
+      { id: "shared", proto: "udp", ports: "2456,2457,2458", target: "10.0.0.9", enabled: true },
+      { id: "mine", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: false },
+      { id: "single", proto: "udp", ports: "2457", target: "10.0.0.7", enabled: true },
+    ]);
+    const view = await service(router).status("srv1");
+    expect(view.forwards.map((f) => [f.port, f.state, f.ruleId])).toEqual([
+      [2456, "disabled", "mine"],
+      [2457, "mismatched", "single"],
+      [2458, "mismatched", "shared"],
+    ]);
+  });
+
+  it("apply creates missing rules, re-targets mismatched ones, leaves disabled alone, commits once", async () => {
+    const router = fakeRouter([
+      { id: "b", proto: "udp", ports: "2457", target: "10.0.0.9", enabled: true },
+      { id: "c", proto: "udp", ports: "2458", target: "10.0.0.5", enabled: false },
+    ]);
+    const view = await service(router).apply("srv1");
+    expect(router.calls).toEqual(["create 2456/udp", "retarget b", "commit"]);
+    expect(view.forwards.map((f) => f.state)).toEqual(["ok", "ok", "disabled"]);
+  });
+
+  it("apply is a no-op (no commit) when everything is already forwarded", async () => {
+    const router = fakeRouter([
+      { id: "a", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true },
+      { id: "b", proto: "udp", ports: "2457", target: "10.0.0.5", enabled: true },
+      { id: "c", proto: "udp", ports: "2458", target: "10.0.0.5", enabled: true },
+    ]);
+    await service(router).apply("srv1");
+    expect(router.calls).toEqual([]);
+  });
+
+  it("setEnabled toggles the matched rule and rejects ports outside the spec", async () => {
+    const router = fakeRouter([{ id: "a", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true }]);
+    const svc = service(router);
+    const view = await svc.setEnabled("srv1", 2456, "udp", false);
+    expect(router.calls).toEqual(["setEnabled a false", "commit"]);
+    expect(view.forwards[0].state).toBe("disabled");
+    await expect(svc.setEnabled("srv1", 9999, "udp", true)).rejects.toThrow(/isn't one of this server's forwards/);
+    await expect(svc.setEnabled("srv1", 2457, "udp", true)).rejects.toThrow(/No rule exists/);
+  });
+
+  it("remove deletes one forward, or every rule behind the server — a shared rule only once", async () => {
+    const router = fakeRouter([
+      { id: "a", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true },
+      { id: "shared", proto: "udp", ports: "2457,2458", target: "10.0.0.5", enabled: true },
+    ]);
+    const svc = service(router);
+    await svc.remove("srv1", 2456, "udp");
+    expect(router.calls).toEqual(["remove a", "commit"]);
+    router.calls.length = 0;
+    await svc.remove("srv1");
+    expect(router.calls).toEqual(["remove shared", "commit"]);
+    expect(router.rules).toEqual([]);
+    await expect(svc.remove("srv1", 2456, "udp")).rejects.toThrow(/No rule exists/);
+  });
+});

--- a/apps/api/src/portforwards/portforwards.service.test.ts
+++ b/apps/api/src/portforwards/portforwards.service.test.ts
@@ -120,7 +120,7 @@ describe("PortForwardsService", () => {
     const svc = service(router);
     const view = await svc.setEnabled("srv1", 2456, "udp", false);
     expect(router.calls).toEqual(["setEnabled a false", "commit"]);
-    expect(view.forwards[0].state).toBe("disabled");
+    expect(view.forwards[0]?.state).toBe("disabled");
     await expect(svc.setEnabled("srv1", 9999, "udp", true)).rejects.toThrow(/isn't one of this server's forwards/);
     await expect(svc.setEnabled("srv1", 2457, "udp", true)).rejects.toThrow(/No rule exists/);
   });

--- a/apps/api/src/portforwards/portforwards.service.test.ts
+++ b/apps/api/src/portforwards/portforwards.service.test.ts
@@ -14,9 +14,16 @@ function fakeRouter(initial: RouterRule[], targetIp = "10.0.0.5") {
     list: async () => rules.map((r) => ({ ...r })),
     wanIp: async () => "203.0.113.9",
     describe: async () => `${rules.length} rules`,
-    create: async (f) => {
+    create: async (f, description) => {
       calls.push(`create ${f.port}/${f.proto}`);
-      rules.push({ id: String(seq++), proto: f.proto, ports: String(f.port), target: targetIp, enabled: true });
+      rules.push({
+        id: String(seq++),
+        name: description,
+        proto: f.proto,
+        ports: String(f.port),
+        target: targetIp,
+        enabled: true,
+      });
     },
     retarget: async (rule) => {
       calls.push(`retarget ${rule.id}`);
@@ -50,8 +57,8 @@ const valheim = {
   rconPort: 0,
 };
 
-function service(router: ReturnType<typeof fakeRouter> | null) {
-  const prisma = { server: { findUnique: vi.fn(async () => valheim) } };
+function service(router: ReturnType<typeof fakeRouter> | null, others: (typeof valheim)[] = []) {
+  const prisma = { server: { findUnique: vi.fn(async () => valheim), findMany: vi.fn(async () => others) } };
   const settings = { get: vi.fn(async (key: string) => (key === "port_forward_router" ? "unifi" : null)) };
   const svc = new PortForwardsService(prisma as never, settings as never);
   // Bypass settings → client construction; the fake stands in for a real router.
@@ -69,8 +76,8 @@ describe("PortForwardsService", () => {
 
   it("classifies ok / disabled / mismatched / missing, seeing through tcp+udp and range rules", async () => {
     const router = fakeRouter([
-      { id: "a", proto: "both", ports: "2456", target: "10.0.0.5", enabled: true }, // ok via tcp_udp
-      { id: "b", proto: "udp", ports: "2457-2460", target: "10.0.0.9", enabled: true }, // mismatched via range
+      { id: "a", name: "Palisade - x", proto: "both", ports: "2456", target: "10.0.0.5", enabled: true }, // ok via tcp_udp
+      { id: "b", name: "Palisade - x", proto: "udp", ports: "2457-2460", target: "10.0.0.9", enabled: true }, // mismatched via range
     ]);
     const view = await service(router).status("srv1");
     expect(view.wanIp).toBe("203.0.113.9");
@@ -83,9 +90,9 @@ describe("PortForwardsService", () => {
 
   it("prefers a rule already pointing at the target, then a dedicated single-port rule", async () => {
     const router = fakeRouter([
-      { id: "shared", proto: "udp", ports: "2456,2457,2458", target: "10.0.0.9", enabled: true },
-      { id: "mine", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: false },
-      { id: "single", proto: "udp", ports: "2457", target: "10.0.0.7", enabled: true },
+      { id: "shared", name: "Palisade - x", proto: "udp", ports: "2456,2457,2458", target: "10.0.0.9", enabled: true },
+      { id: "mine", name: "Palisade - x", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: false },
+      { id: "single", name: "Palisade - x", proto: "udp", ports: "2457", target: "10.0.0.7", enabled: true },
     ]);
     const view = await service(router).status("srv1");
     expect(view.forwards.map((f) => [f.port, f.state, f.ruleId])).toEqual([
@@ -97,8 +104,8 @@ describe("PortForwardsService", () => {
 
   it("apply creates missing rules, re-targets mismatched ones, leaves disabled alone, commits once", async () => {
     const router = fakeRouter([
-      { id: "b", proto: "udp", ports: "2457", target: "10.0.0.9", enabled: true },
-      { id: "c", proto: "udp", ports: "2458", target: "10.0.0.5", enabled: false },
+      { id: "b", name: "Palisade - x", proto: "udp", ports: "2457", target: "10.0.0.9", enabled: true },
+      { id: "c", name: "Palisade - x", proto: "udp", ports: "2458", target: "10.0.0.5", enabled: false },
     ]);
     const view = await service(router).apply("srv1");
     expect(router.calls).toEqual(["create 2456/udp", "retarget b", "commit"]);
@@ -107,16 +114,16 @@ describe("PortForwardsService", () => {
 
   it("apply is a no-op (no commit) when everything is already forwarded", async () => {
     const router = fakeRouter([
-      { id: "a", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true },
-      { id: "b", proto: "udp", ports: "2457", target: "10.0.0.5", enabled: true },
-      { id: "c", proto: "udp", ports: "2458", target: "10.0.0.5", enabled: true },
+      { id: "a", name: "Palisade - x", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true },
+      { id: "b", name: "Palisade - x", proto: "udp", ports: "2457", target: "10.0.0.5", enabled: true },
+      { id: "c", name: "Palisade - x", proto: "udp", ports: "2458", target: "10.0.0.5", enabled: true },
     ]);
     await service(router).apply("srv1");
     expect(router.calls).toEqual([]);
   });
 
   it("setEnabled toggles the matched rule and rejects ports outside the spec", async () => {
-    const router = fakeRouter([{ id: "a", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true }]);
+    const router = fakeRouter([{ id: "a", name: "Palisade - x", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true }]);
     const svc = service(router);
     const view = await svc.setEnabled("srv1", 2456, "udp", false);
     expect(router.calls).toEqual(["setEnabled a false", "commit"]);
@@ -127,8 +134,8 @@ describe("PortForwardsService", () => {
 
   it("remove deletes one forward, or every rule behind the server — a shared rule only once", async () => {
     const router = fakeRouter([
-      { id: "a", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true },
-      { id: "shared", proto: "udp", ports: "2457,2458", target: "10.0.0.5", enabled: true },
+      { id: "a", name: "Palisade - x", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true },
+      { id: "shared", name: "Palisade - x", proto: "udp", ports: "2457,2458", target: "10.0.0.5", enabled: true },
     ]);
     const svc = service(router);
     await svc.remove("srv1", 2456, "udp");
@@ -138,5 +145,48 @@ describe("PortForwardsService", () => {
     expect(router.calls).toEqual(["remove shared", "commit"]);
     expect(router.rules).toEqual([]);
     await expect(svc.remove("srv1", 2456, "udp")).rejects.toThrow(/No rule exists/);
+  });
+
+  it("names new rules Palisade - <Game> - <server> - <port label>", async () => {
+    const router = fakeRouter([]);
+    await service(router).apply("srv1");
+    expect(router.rules.map((r) => r.name)).toEqual([
+      "Palisade - Valheim - Vikings - game",
+      "Palisade - Valheim - Vikings - query (server browser)",
+      "Palisade - Valheim - Vikings - crossplay",
+    ]);
+  });
+
+  describe("removeForServer", () => {
+    it("removes the Palisade-made rules pointing at the target and commits once", async () => {
+      const router = fakeRouter([
+        { id: "a", name: "Palisade - Valheim - Vikings - game", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true },
+        { id: "b", name: "ASM Vikings — query", proto: "udp", ports: "2457", target: "10.0.0.5", enabled: false },
+        { id: "c", name: "Palisade - Valheim - Vikings - crossplay", proto: "udp", ports: "2458", target: "10.0.0.5", enabled: true },
+      ]);
+      expect(await service(router).removeForServer(valheim)).toBe(3);
+      expect(router.calls).toEqual(["remove a", "remove b", "remove c", "commit"]);
+      expect(router.rules).toEqual([]);
+    });
+
+    it("leaves hand-made rules, rules aimed elsewhere, and ports another server still needs", async () => {
+      const router = fakeRouter([
+        { id: "hand", name: "My own rule", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true },
+        { id: "else", name: "Palisade - Valheim - Old - query", proto: "udp", ports: "2457", target: "10.0.0.9", enabled: true },
+        { id: "shared", name: "Palisade - Valheim - Vikings - crossplay", proto: "udp", ports: "2458", target: "10.0.0.5", enabled: true },
+      ]);
+      const sibling = { ...valheim, id: "srv2", name: "Second" }; // same Valheim block → still needs 2458
+      expect(await service(router, [sibling]).removeForServer(valheim)).toBe(0);
+      expect(router.calls).toEqual([]);
+    });
+
+    it("is a silent no-op without a router, and swallows router errors", async () => {
+      expect(await service(null).removeForServer(valheim)).toBe(0);
+      const router = fakeRouter([{ id: "a", name: "Palisade - x", proto: "udp", ports: "2456", target: "10.0.0.5", enabled: true }]);
+      router.client.remove = async () => {
+        throw new Error("boom");
+      };
+      expect(await service(router).removeForServer(valheim)).toBe(0);
+    });
   });
 });

--- a/apps/api/src/portforwards/portforwards.service.ts
+++ b/apps/api/src/portforwards/portforwards.service.ts
@@ -1,9 +1,11 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
-import { request as httpsRequest } from "node:https";
 import { Game, DEFAULT_PORTS } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { ManagerSettingsService, SettingKeys } from "../manager-settings/manager-settings.service";
 import { forwardSpec, type ForwardPort } from "../catalog/ports";
+import { portSpecCovers, protoCovers, ROUTER_LABELS, type RouterClient, type RouterKind, type RouterRule } from "./router";
+import { PfsenseClient } from "./pfsense.client";
+import { UnifiClient } from "./unifi.client";
 
 /** Per-forward state on the router:
  *  ok         — enabled WAN rule exists and points at the target
@@ -14,14 +16,16 @@ export type ForwardState = "ok" | "disabled" | "mismatched" | "missing";
 
 export interface ForwardStatus extends ForwardPort {
   state: ForwardState;
-  /** pfSense rule id when one exists (for enable/disable/delete). */
-  ruleId: number | null;
+  /** The router's rule id when one exists (for enable/disable/delete). */
+  ruleId: string | null;
   /** The host a mismatched rule currently points at. */
   actualTarget?: string | null;
 }
 
 export interface PortForwardsView {
-  /** pfSense host + API key + target IP are all configured. */
+  /** Which router product Settings points at (pfSense unless switched). */
+  router: RouterKind;
+  /** Router host + API key + target IP are all configured. */
   configured: boolean;
   targetIp: string | null;
   /** The router's public (WAN) address — what friends connect to. */
@@ -29,25 +33,12 @@ export interface PortForwardsView {
   forwards: ForwardStatus[];
 }
 
-/** The slice of a pfSense NAT rule we read. */
-interface NatRule {
-  id: number;
-  interface?: string;
-  protocol?: string;
-  destination_port?: string;
-  target?: string;
-  disabled?: boolean;
-}
-
 /**
- * WAN port-forward management via the pfSense REST API (the jaredhendrickson13
- * package, /api/v2). The manager knows exactly which player-facing ports each game
- * needs (forwardSpec), so it can report each forward's state and fix it: create
- * missing rules, re-target mismatched ones, enable/disable, and delete. Rules are
- * created with associated_rule_id "pass" (auto firewall rule) and every change is
- * applied immediately. pfSense boxes run self-signed certs, so TLS verification is
- * disabled for this client. API quirk: single-object DELETE/PATCH want `id` in the
- * JSON body, not the query string.
+ * WAN port-forward management. The manager knows exactly which player-facing
+ * ports each game needs (forwardSpec), so it can report each forward's state and
+ * fix it: create missing rules, re-target mismatched ones, enable/disable, and
+ * delete. The router-specific wire work lives in one RouterClient per product
+ * (pfSense REST API, UniFi Network API); this service only reasons about rules.
  */
 @Injectable()
 export class PortForwardsService {
@@ -58,71 +49,42 @@ export class PortForwardsService {
     private readonly settings: ManagerSettingsService,
   ) {}
 
-  private async config(): Promise<{ host: string; apiKey: string; targetIp: string } | null> {
+  /** The router product Settings selects. Unset means pfSense — the only option
+   *  installs had before UniFi support, so their forwards keep working untouched. */
+  async routerKind(): Promise<RouterKind> {
+    const raw = await this.settings.get(SettingKeys.PortForwardRouter);
+    return raw === "unifi" ? "unifi" : "pfsense";
+  }
+
+  /** A client for the selected router, or null while its settings are incomplete. */
+  private async client(): Promise<RouterClient | null> {
+    const kind = await this.routerKind();
+    if (kind === "unifi") {
+      const [host, apiKey, site, targetIp] = await Promise.all([
+        this.settings.get(SettingKeys.UnifiHost),
+        this.settings.get(SettingKeys.UnifiApiKey),
+        this.settings.get(SettingKeys.UnifiSite),
+        this.settings.get(SettingKeys.UnifiTargetIp),
+      ]);
+      if (!host || !apiKey || !targetIp) return null;
+      return new UnifiClient(host, apiKey, site?.trim() || "default", targetIp);
+    }
     const [host, apiKey, targetIp] = await Promise.all([
       this.settings.get(SettingKeys.PfsenseHost),
       this.settings.get(SettingKeys.PfsenseApiKey),
       this.settings.get(SettingKeys.PfsenseTargetIp),
     ]);
     if (!host || !apiKey || !targetIp) return null;
-    return { host, apiKey, targetIp };
+    return new PfsenseClient(host, apiKey, targetIp);
   }
 
-  private async requireConfig() {
-    const cfg = await this.config();
-    if (!cfg) {
-      throw new BadRequestException("Configure the pfSense host, API key, and target IP in Settings first.");
+  private async requireClient(): Promise<RouterClient> {
+    const c = await this.client();
+    if (!c) {
+      const label = ROUTER_LABELS[await this.routerKind()];
+      throw new BadRequestException(`Configure the ${label} host, API key, and target IP in Settings first.`);
     }
-    return cfg;
-  }
-
-  /** Minimal JSON request against the pfSense REST API (self-signed cert tolerated). */
-  private api<T>(
-    cfg: { host: string; apiKey: string },
-    method: "GET" | "POST" | "PATCH" | "DELETE",
-    path: string,
-    body?: unknown,
-  ): Promise<T> {
-    return new Promise((resolve, reject) => {
-      const payload = body === undefined ? null : JSON.stringify(body);
-      const req = httpsRequest(
-        {
-          host: cfg.host,
-          path: `/api/v2${path}`,
-          method,
-          rejectUnauthorized: false, // pfSense self-signed cert
-          timeout: 15_000,
-          headers: {
-            "X-API-Key": cfg.apiKey,
-            ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
-          },
-        },
-        (res) => {
-          let data = "";
-          res.on("data", (d) => (data += d));
-          res.on("end", () => {
-            if ((res.statusCode ?? 500) >= 400) {
-              return reject(new Error(`pfSense ${res.statusCode}: ${data.slice(0, 200)}`));
-            }
-            try {
-              resolve(JSON.parse(data) as T);
-            } catch {
-              resolve(undefined as T);
-            }
-          });
-        },
-      );
-      req.on("error", reject);
-      req.on("timeout", () => req.destroy(new Error("pfSense request timeout")));
-      if (payload) req.write(payload);
-      req.end();
-    });
-  }
-
-  private async applyChanges(cfg: { host: string; apiKey: string }): Promise<void> {
-    // Apply twice — the reliable pattern against this API.
-    await this.api(cfg, "POST", "/firewall/apply", {});
-    await this.api(cfg, "POST", "/firewall/apply", {});
+    return c;
   }
 
   private async server(id: string) {
@@ -140,62 +102,54 @@ export class PortForwardsService {
     } as typeof DEFAULT_PORTS);
   }
 
-  private async rules(cfg: { host: string; apiKey: string }): Promise<NatRule[]> {
-    const res = await this.api<{ data?: NatRule[] }>(cfg, "GET", "/firewall/nat/port_forwards?limit=0");
-    return res.data ?? [];
-  }
+  private wanIpCache: { key: string; ip: string | null; at: number } | null = null;
 
-  private wanIpCache: { ip: string | null; at: number } | null = null;
-
-  /** The WAN interface's public address (cached 5 min; null on lookup failure). */
-  private async wanIp(cfg: { host: string; apiKey: string }): Promise<string | null> {
-    if (this.wanIpCache && Date.now() - this.wanIpCache.at < 300_000) return this.wanIpCache.ip;
+  /** The router's public address (cached 5 min per router; null on lookup failure). */
+  private async wanIp(c: RouterClient): Promise<string | null> {
+    const key = `${c.kind}:${c.host}`;
+    if (this.wanIpCache?.key === key && Date.now() - this.wanIpCache.at < 300_000) return this.wanIpCache.ip;
     let ip: string | null = null;
     try {
-      const res = await this.api<{ data?: Array<{ name?: string; hwif?: string; ipaddr?: string }> }>(
-        cfg,
-        "GET",
-        "/status/interfaces?limit=0",
-      );
-      const wan = (res.data ?? []).find((i) => (i.name ?? "").toLowerCase() === "wan") ?? res.data?.[0];
-      ip = wan?.ipaddr ?? null;
+      ip = await c.wanIp();
     } catch {
       /* status endpoint unavailable — just omit the WAN ip */
     }
-    this.wanIpCache = { ip, at: Date.now() };
+    this.wanIpCache = { key, ip, at: Date.now() };
     return ip;
   }
 
-  /** Validate the configured host + API key + target (for the Settings page's Test
-   *  button): reaches the API, reports the WAN address and how many NAT rules exist. */
+  /** Validate the configured router settings (for the Settings page's Test
+   *  button): reaches the API, reports the WAN address and how many rules exist. */
   async testConnection(): Promise<{ ok: boolean; message: string }> {
-    const cfg = await this.config();
-    if (!cfg) return { ok: false, message: "Fill in the pfSense host, API key, and target IP first." };
+    const kind = await this.routerKind();
+    const label = ROUTER_LABELS[kind];
+    const c = await this.client();
+    if (!c) return { ok: false, message: `Fill in the ${label} host, API key, and target IP first.` };
     try {
-      const [rules, wanIp] = await Promise.all([this.rules(cfg), this.wanIp(cfg)]);
+      const [detail, wanIp] = await Promise.all([c.describe(), this.wanIp(c)]);
       return {
         ok: true,
-        message: `Connected to ${cfg.host} — WAN ${wanIp ?? "unknown"}, ${rules.length} NAT rule${rules.length === 1 ? "" : "s"} found. Forwards will target ${cfg.targetIp}.`,
+        message: `Connected to ${c.host} — WAN ${wanIp ?? "unknown"}, ${detail}. Forwards will target ${c.targetIp}.`,
       };
     } catch (e) {
-      return { ok: false, message: `Could not reach the pfSense API: ${(e as Error).message}` };
+      return { ok: false, message: `Could not reach the ${label} API: ${(e as Error).message}` };
     }
   }
 
-  /** The WAN rule matching a forward's port/proto — target-matching rules first. */
-  private matchRule(rules: NatRule[], f: ForwardPort, targetIp: string): NatRule | undefined {
-    const candidates = rules.filter(
-      (r) =>
-        (r.interface ?? "wan") === "wan" &&
-        (r.protocol ?? "").toLowerCase() === f.proto &&
-        String(r.destination_port ?? "") === String(f.port),
+  /** The WAN rule covering a forward's port/proto — target-matching rules first,
+   *  then rules dedicated to exactly this port over shared lists/ranges. */
+  private matchRule(rules: RouterRule[], f: ForwardPort, targetIp: string): RouterRule | undefined {
+    const candidates = rules.filter((r) => protoCovers(r.proto, f.proto) && portSpecCovers(r.ports, f.port));
+    return (
+      candidates.find((r) => r.target === targetIp) ??
+      candidates.find((r) => r.ports.trim() === String(f.port)) ??
+      candidates[0]
     );
-    return candidates.find((r) => r.target === targetIp) ?? candidates[0];
   }
 
-  private classify(rule: NatRule | undefined, targetIp: string): ForwardState {
+  private classify(rule: RouterRule | undefined, targetIp: string): ForwardState {
     if (!rule) return "missing";
-    if (rule.disabled) return "disabled";
+    if (!rule.enabled) return "disabled";
     return rule.target === targetIp ? "ok" : "mismatched";
   }
 
@@ -203,23 +157,25 @@ export class PortForwardsService {
   async status(id: string): Promise<PortForwardsView> {
     const s = await this.server(id);
     const spec = this.specFor(s);
-    const cfg = await this.config();
-    if (!cfg) {
+    const c = await this.client();
+    if (!c) {
       return {
+        router: await this.routerKind(),
         configured: false,
         targetIp: null,
         wanIp: null,
         forwards: spec.map((f) => ({ ...f, state: "missing" as const, ruleId: null })),
       };
     }
-    const [rules, wanIp] = await Promise.all([this.rules(cfg), this.wanIp(cfg)]);
+    const [rules, wanIp] = await Promise.all([c.list(), this.wanIp(c)]);
     return {
+      router: c.kind,
       configured: true,
-      targetIp: cfg.targetIp,
+      targetIp: c.targetIp,
       wanIp,
       forwards: spec.map((f) => {
-        const rule = this.matchRule(rules, f, cfg.targetIp);
-        const state = this.classify(rule, cfg.targetIp);
+        const rule = this.matchRule(rules, f, c.targetIp);
+        const state = this.classify(rule, c.targetIp);
         return {
           ...f,
           state,
@@ -230,60 +186,54 @@ export class PortForwardsService {
     };
   }
 
+  /** The router's rule behind a forward-status row (re-listed so edits see fresh data). */
+  private async ruleFor(c: RouterClient, f: ForwardStatus): Promise<RouterRule | undefined> {
+    if (f.ruleId == null) return undefined;
+    return (await c.list()).find((r) => r.id === f.ruleId);
+  }
+
   /** Fix everything: create missing rules and re-target mismatched ones, then apply.
    *  Disabled rules are left alone (that's an explicit admin choice — use enable). */
   async apply(id: string): Promise<PortForwardsView> {
-    const cfg = await this.requireConfig();
+    const c = await this.requireClient();
     const s = await this.server(id);
     const before = await this.status(id);
+    const label = ROUTER_LABELS[c.kind];
     let changed = 0;
     for (const f of before.forwards) {
       if (f.state === "missing") {
-        await this.api(cfg, "POST", "/firewall/nat/port_forward", {
-          interface: "wan",
-          ipprotocol: "inet",
-          protocol: f.proto,
-          source: "any",
-          destination: "wan:ip",
-          destination_port: String(f.port),
-          target: cfg.targetIp,
-          local_port: String(f.port),
-          descr: `ASM ${s.name} — ${f.label}`,
-          associated_rule_id: "pass",
-          disabled: false,
-        });
-        this.logger.log(`pfSense forward created: ${f.port}/${f.proto} → ${cfg.targetIp} (${s.name})`);
+        await c.create(f, `ASM ${s.name} — ${f.label}`);
+        this.logger.log(`${label} forward created: ${f.port}/${f.proto} → ${c.targetIp} (${s.name})`);
         changed++;
-      } else if (f.state === "mismatched" && f.ruleId != null) {
-        await this.api(cfg, "PATCH", "/firewall/nat/port_forward", {
-          id: f.ruleId,
-          target: cfg.targetIp,
-          local_port: String(f.port),
-        });
-        this.logger.log(`pfSense forward re-targeted: ${f.port}/${f.proto} → ${cfg.targetIp} (${s.name})`);
+      } else if (f.state === "mismatched") {
+        const rule = await this.ruleFor(c, f);
+        if (!rule) continue;
+        await c.retarget(rule, f);
+        this.logger.log(`${label} forward re-targeted: ${f.port}/${f.proto} → ${c.targetIp} (${s.name})`);
         changed++;
       }
     }
-    if (changed > 0) await this.applyChanges(cfg);
+    if (changed > 0) await c.commit();
     return this.status(id);
   }
 
   /** Enable or disable one of this server's forwards on the router. */
   async setEnabled(id: string, port: number, proto: "udp" | "tcp", enabled: boolean): Promise<PortForwardsView> {
-    const cfg = await this.requireConfig();
+    const c = await this.requireClient();
     const view = await this.status(id);
     const f = view.forwards.find((x) => x.port === port && x.proto === proto);
     if (!f) throw new BadRequestException(`${port}/${proto} isn't one of this server's forwards`);
-    if (f.ruleId == null) throw new NotFoundException("No rule exists for that port — create it first");
-    await this.api(cfg, "PATCH", "/firewall/nat/port_forward", { id: f.ruleId, disabled: !enabled });
-    await this.applyChanges(cfg);
-    this.logger.log(`pfSense forward ${enabled ? "enabled" : "disabled"}: ${port}/${proto}`);
+    const rule = await this.ruleFor(c, f);
+    if (!rule) throw new NotFoundException("No rule exists for that port — create it first");
+    await c.setEnabled(rule, enabled);
+    await c.commit();
+    this.logger.log(`${ROUTER_LABELS[c.kind]} forward ${enabled ? "enabled" : "disabled"}: ${port}/${proto}`);
     return this.status(id);
   }
 
   /** Delete one forward (port+proto), or ALL of this server's forwards when omitted. */
   async remove(id: string, port?: number, proto?: "udp" | "tcp"): Promise<PortForwardsView> {
-    const cfg = await this.requireConfig();
+    const c = await this.requireClient();
     const view = await this.status(id);
     const targets = view.forwards.filter(
       (f) => f.ruleId != null && (port === undefined || (f.port === port && f.proto === proto)),
@@ -291,12 +241,13 @@ export class PortForwardsService {
     if (port !== undefined && targets.length === 0) {
       throw new NotFoundException("No rule exists for that port");
     }
-    // Delete highest id first so earlier deletions don't shift later ids.
-    for (const f of [...targets].sort((a, b) => (b.ruleId ?? 0) - (a.ruleId ?? 0))) {
-      await this.api(cfg, "DELETE", "/firewall/nat/port_forward", { id: f.ruleId });
-      this.logger.log(`pfSense forward deleted: ${f.port}/${f.proto}`);
-    }
-    if (targets.length > 0) await this.applyChanges(cfg);
+    const rules = await c.list();
+    // One router rule can back several forwards (a tcp_udp or multi-port rule) — delete it once.
+    const ids = new Set(targets.map((f) => f.ruleId));
+    const doomed = rules.filter((r) => ids.has(r.id));
+    await c.remove(doomed);
+    for (const f of targets) this.logger.log(`${ROUTER_LABELS[c.kind]} forward deleted: ${f.port}/${f.proto}`);
+    if (doomed.length > 0) await c.commit();
     return this.status(id);
   }
 }

--- a/apps/api/src/portforwards/portforwards.service.ts
+++ b/apps/api/src/portforwards/portforwards.service.ts
@@ -1,9 +1,18 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
-import { Game, DEFAULT_PORTS } from "@ark/shared";
+import { Game, DEFAULT_PORTS, GAME_LABELS } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { ManagerSettingsService, SettingKeys } from "../manager-settings/manager-settings.service";
 import { forwardSpec, type ForwardPort } from "../catalog/ports";
-import { portSpecCovers, protoCovers, ROUTER_LABELS, type RouterClient, type RouterKind, type RouterRule } from "./router";
+import {
+  isPalisadeRule,
+  portSpecCovers,
+  protoCovers,
+  ROUTER_LABELS,
+  ruleName,
+  type RouterClient,
+  type RouterKind,
+  type RouterRule,
+} from "./router";
 import { PfsenseClient } from "./pfsense.client";
 import { UnifiClient } from "./unifi.client";
 
@@ -20,6 +29,28 @@ export interface ForwardStatus extends ForwardPort {
   ruleId: string | null;
   /** The host a mismatched rule currently points at. */
   actualTarget?: string | null;
+}
+
+/** Unsaved Settings-form values the Test button sends, so a router can be tried
+ *  before Save. Anything omitted (or a blank API key) falls back to what's saved. */
+export interface RouterDraft {
+  router?: RouterKind;
+  host?: string;
+  apiKey?: string;
+  site?: string;
+  targetIp?: string;
+}
+
+/** The server columns port-forward logic needs; a deleted server is passed as
+ *  a plain object because its row is already gone. */
+export interface ForwardableServer {
+  id: string;
+  name: string;
+  game: string;
+  gamePort: number;
+  rawSocketPort: number;
+  queryPort: number;
+  rconPort: number;
 }
 
 export interface PortForwardsView {
@@ -56,23 +87,26 @@ export class PortForwardsService {
     return raw === "unifi" ? "unifi" : "pfsense";
   }
 
-  /** A client for the selected router, or null while its settings are incomplete. */
-  private async client(): Promise<RouterClient | null> {
-    const kind = await this.routerKind();
+  /** A client for the selected router, or null while its settings are incomplete.
+   *  A draft (the Test button's unsaved form) overrides saved values field by field. */
+  private async client(draft: RouterDraft = {}): Promise<RouterClient | null> {
+    const kind = draft.router ?? (await this.routerKind());
+    const pick = async (key: string, override: string | undefined) =>
+      override?.trim() || (await this.settings.get(key)) || null;
     if (kind === "unifi") {
       const [host, apiKey, site, targetIp] = await Promise.all([
-        this.settings.get(SettingKeys.UnifiHost),
-        this.settings.get(SettingKeys.UnifiApiKey),
-        this.settings.get(SettingKeys.UnifiSite),
-        this.settings.get(SettingKeys.UnifiTargetIp),
+        pick(SettingKeys.UnifiHost, draft.host),
+        pick(SettingKeys.UnifiApiKey, draft.apiKey),
+        pick(SettingKeys.UnifiSite, draft.site),
+        pick(SettingKeys.UnifiTargetIp, draft.targetIp),
       ]);
       if (!host || !apiKey || !targetIp) return null;
       return new UnifiClient(host, apiKey, site?.trim() || "default", targetIp);
     }
     const [host, apiKey, targetIp] = await Promise.all([
-      this.settings.get(SettingKeys.PfsenseHost),
-      this.settings.get(SettingKeys.PfsenseApiKey),
-      this.settings.get(SettingKeys.PfsenseTargetIp),
+      pick(SettingKeys.PfsenseHost, draft.host),
+      pick(SettingKeys.PfsenseApiKey, draft.apiKey),
+      pick(SettingKeys.PfsenseTargetIp, draft.targetIp),
     ]);
     if (!host || !apiKey || !targetIp) return null;
     return new PfsenseClient(host, apiKey, targetIp);
@@ -93,7 +127,7 @@ export class PortForwardsService {
     return s;
   }
 
-  private specFor(s: { game: string; gamePort: number; rawSocketPort: number; queryPort: number; rconPort: number }) {
+  private specFor(s: ForwardableServer) {
     return forwardSpec(s.game as Game, {
       game: s.gamePort,
       rawSocket: s.rawSocketPort,
@@ -118,12 +152,13 @@ export class PortForwardsService {
     return ip;
   }
 
-  /** Validate the configured router settings (for the Settings page's Test
-   *  button): reaches the API, reports the WAN address and how many rules exist. */
-  async testConnection(): Promise<{ ok: boolean; message: string }> {
-    const kind = await this.routerKind();
+  /** Validate router settings for the Settings page's Test button — the form's
+   *  current values, falling back to what's saved — by reaching the API and
+   *  reporting the WAN address and how many rules exist. */
+  async testConnection(draft: RouterDraft = {}): Promise<{ ok: boolean; message: string }> {
+    const kind = draft.router ?? (await this.routerKind());
     const label = ROUTER_LABELS[kind];
-    const c = await this.client();
+    const c = await this.client(draft);
     if (!c) return { ok: false, message: `Fill in the ${label} host, API key, and target IP first.` };
     try {
       const [detail, wanIp] = await Promise.all([c.describe(), this.wanIp(c)]);
@@ -155,7 +190,10 @@ export class PortForwardsService {
 
   /** Each of this server's player-facing forwards + its state on the router. */
   async status(id: string): Promise<PortForwardsView> {
-    const s = await this.server(id);
+    return this.viewFor(await this.server(id));
+  }
+
+  private async viewFor(s: ForwardableServer): Promise<PortForwardsView> {
     const spec = this.specFor(s);
     const c = await this.client();
     if (!c) {
@@ -202,7 +240,7 @@ export class PortForwardsService {
     let changed = 0;
     for (const f of before.forwards) {
       if (f.state === "missing") {
-        await c.create(f, `ASM ${s.name} — ${f.label}`);
+        await c.create(f, ruleName(GAME_LABELS[s.game as Game] ?? s.game, s.name, f.label));
         this.logger.log(`${label} forward created: ${f.port}/${f.proto} → ${c.targetIp} (${s.name})`);
         changed++;
       } else if (f.state === "mismatched") {
@@ -249,5 +287,47 @@ export class PortForwardsService {
     for (const f of targets) this.logger.log(`${ROUTER_LABELS[c.kind]} forward deleted: ${f.port}/${f.proto}`);
     if (doomed.length > 0) await c.commit();
     return this.status(id);
+  }
+
+  /**
+   * Server-deletion hook: drop the forwards Palisade made for a server that no
+   * longer exists. Only rules we created (by name) that point at the configured
+   * target go, and never one another server still needs — servers share a fixed
+   * port block, so deleting one ARK server must not unplug the next. Best-effort:
+   * a router problem is logged, never surfaced, because the server row is already
+   * gone. Returns how many rules were removed.
+   */
+  async removeForServer(s: ForwardableServer): Promise<number> {
+    let c: RouterClient | null;
+    try {
+      c = await this.client();
+    } catch {
+      return 0;
+    }
+    if (!c) return 0;
+    try {
+      const view = await this.viewFor(s);
+      const rules = await c.list();
+      const others = await this.prisma.server.findMany({ where: { id: { not: s.id } } });
+      const stillNeeded = new Set(
+        others.flatMap((o) => this.specFor(o as ForwardableServer).map((f) => `${f.port}/${f.proto}`)),
+      );
+      const doomed = new Map<string, RouterRule>();
+      for (const f of view.forwards) {
+        if (f.ruleId == null || stillNeeded.has(`${f.port}/${f.proto}`)) continue;
+        const rule = rules.find((r) => r.id === f.ruleId);
+        if (rule && rule.target === c.targetIp && isPalisadeRule(rule)) doomed.set(rule.id, rule);
+      }
+      if (doomed.size === 0) return 0;
+      await c.remove([...doomed.values()]);
+      await c.commit();
+      for (const r of doomed.values()) {
+        this.logger.log(`${ROUTER_LABELS[c.kind]} forward removed with server "${s.name}": ${r.ports}/${r.proto}`);
+      }
+      return doomed.size;
+    } catch (e) {
+      this.logger.warn(`Could not remove ${ROUTER_LABELS[c.kind]} forwards for "${s.name}": ${(e as Error).message}`);
+      return 0;
+    }
   }
 }

--- a/apps/api/src/portforwards/router.test.ts
+++ b/apps/api/src/portforwards/router.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { portSpecCovers, protoCovers } from "./router";
+import { isPalisadeRule, portSpecCovers, protoCovers, ruleName } from "./router";
 import { normalizeUnifiRule, parseUnifiHost } from "./unifi.client";
 
 describe("portSpecCovers", () => {
@@ -27,6 +27,21 @@ describe("portSpecCovers", () => {
     expect(portSpecCovers("", 7777)).toBe(false);
     expect(portSpecCovers(undefined, 7777)).toBe(false);
     expect(portSpecCovers("ark_ports", 7777)).toBe(false);
+  });
+});
+
+describe("ruleName / isPalisadeRule", () => {
+  it("formats Source - Game - Server - port and caps at UniFi's 128-char limit", () => {
+    expect(ruleName("Minecraft (Bedrock)", "test", "game (IPv4)")).toBe("Palisade - Minecraft (Bedrock) - test - game (IPv4)");
+    expect(ruleName("Valheim", "x".repeat(200), "game")).toHaveLength(128);
+  });
+
+  it("recognises current and legacy Palisade rule names only", () => {
+    const rule = { id: "1", proto: "udp" as const, ports: "1", target: "", enabled: true };
+    expect(isPalisadeRule({ ...rule, name: "Palisade - Valheim - a - game" })).toBe(true);
+    expect(isPalisadeRule({ ...rule, name: "ASM a — game" })).toBe(true);
+    expect(isPalisadeRule({ ...rule, name: "Shooter Alarm" })).toBe(false);
+    expect(isPalisadeRule({ ...rule, name: "" })).toBe(false);
   });
 });
 
@@ -63,7 +78,14 @@ describe("normalizeUnifiRule", () => {
         enabled: true,
         pfwd_interface: "wan",
       }),
-    ).toEqual({ id: "6aa2ba4a552cb06f99021735", proto: "both", ports: "27015", target: "10.0.0.5", enabled: true });
+    ).toEqual({
+      id: "6aa2ba4a552cb06f99021735",
+      name: "",
+      proto: "both",
+      ports: "27015",
+      target: "10.0.0.5",
+      enabled: true,
+    });
   });
 
   it("treats a missing enabled flag as enabled and a missing target as empty", () => {

--- a/apps/api/src/portforwards/router.test.ts
+++ b/apps/api/src/portforwards/router.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { portSpecCovers, protoCovers } from "./router";
+import { normalizeUnifiRule, parseUnifiHost } from "./unifi.client";
+
+describe("portSpecCovers", () => {
+  it("matches a single port exactly", () => {
+    expect(portSpecCovers("7777", 7777)).toBe(true);
+    expect(portSpecCovers(7777, 7777)).toBe(true);
+    expect(portSpecCovers("7778", 7777)).toBe(false);
+    expect(portSpecCovers("77770", 7777)).toBe(false);
+  });
+
+  it("matches inside UniFi comma lists and ranges", () => {
+    expect(portSpecCovers("2001,4001,7001", 4001)).toBe(true);
+    expect(portSpecCovers("2001, 4001 ,7001", 7001)).toBe(true);
+    expect(portSpecCovers("2001,4001,7001", 3001)).toBe(false);
+    expect(portSpecCovers("7777-7779", 7778)).toBe(true);
+    expect(portSpecCovers("7777-7779", 7780)).toBe(false);
+  });
+
+  it("matches inside pfSense colon ranges", () => {
+    expect(portSpecCovers("7777:7779", 7779)).toBe(true);
+    expect(portSpecCovers("7777:7779", 7776)).toBe(false);
+  });
+
+  it("never matches something it can't parse", () => {
+    expect(portSpecCovers("", 7777)).toBe(false);
+    expect(portSpecCovers(undefined, 7777)).toBe(false);
+    expect(portSpecCovers("ark_ports", 7777)).toBe(false);
+  });
+});
+
+describe("protoCovers", () => {
+  it("treats a tcp+udp rule as covering either protocol", () => {
+    expect(protoCovers("both", "udp")).toBe(true);
+    expect(protoCovers("both", "tcp")).toBe(true);
+    expect(protoCovers("udp", "udp")).toBe(true);
+    expect(protoCovers("udp", "tcp")).toBe(false);
+  });
+});
+
+describe("parseUnifiHost", () => {
+  it("accepts a bare IP, host:port, and a full URL", () => {
+    expect(parseUnifiHost("192.168.1.1")).toEqual({ hostname: "192.168.1.1", port: 443 });
+    expect(parseUnifiHost(" 192.168.1.1:8443 ")).toEqual({ hostname: "192.168.1.1", port: 8443 });
+    expect(parseUnifiHost("https://unifi.example.com/")).toEqual({ hostname: "unifi.example.com", port: 443 });
+    expect(parseUnifiHost("https://unifi.example.com:8443/network")).toEqual({
+      hostname: "unifi.example.com",
+      port: 8443,
+    });
+  });
+});
+
+describe("normalizeUnifiRule", () => {
+  it("maps UniFi's forward object onto the router-neutral rule", () => {
+    expect(
+      normalizeUnifiRule({
+        _id: "6aa2ba4a552cb06f99021735",
+        proto: "tcp_udp",
+        dst_port: "27015",
+        fwd: "10.0.0.5",
+        fwd_port: "27015",
+        enabled: true,
+        pfwd_interface: "wan",
+      }),
+    ).toEqual({ id: "6aa2ba4a552cb06f99021735", proto: "both", ports: "27015", target: "10.0.0.5", enabled: true });
+  });
+
+  it("treats a missing enabled flag as enabled and a missing target as empty", () => {
+    expect(normalizeUnifiRule({ _id: "x", proto: "udp", dst_port: "1" })).toMatchObject({
+      enabled: true,
+      target: "",
+      proto: "udp",
+    });
+  });
+});

--- a/apps/api/src/portforwards/router.ts
+++ b/apps/api/src/portforwards/router.ts
@@ -1,0 +1,69 @@
+import type { ForwardPort } from "../catalog/ports";
+
+/** Which router product the port-forward integration talks to. */
+export type RouterKind = "pfsense" | "unifi";
+export const ROUTER_KINDS: readonly RouterKind[] = ["pfsense", "unifi"];
+export const ROUTER_LABELS: Record<RouterKind, string> = { pfsense: "pfSense", unifi: "UniFi" };
+
+/** One WAN forward as the router reports it, normalised across products. */
+export interface RouterRule {
+  /** The router's own id (pfSense numeric index, UniFi object id) as a string. */
+  id: string;
+  /** "udp" | "tcp" | "both" (UniFi's tcp_udp). */
+  proto: "udp" | "tcp" | "both";
+  /** The WAN-side port spec as the router stores it: "7777", "7777,7778", "7777-7779". */
+  ports: string;
+  /** The LAN host the rule forwards to. */
+  target: string;
+  enabled: boolean;
+}
+
+/** What the port-forwards service needs from any router. Every client is
+ *  constructed from already-validated settings and talks to exactly one box. */
+export interface RouterClient {
+  readonly kind: RouterKind;
+  readonly host: string;
+  readonly targetIp: string;
+  /** Every WAN forward on the router. */
+  list(): Promise<RouterRule[]>;
+  /** The router's public address, or null when the router won't say. */
+  wanIp(): Promise<string | null>;
+  /** A one-line description of the box for the Settings "Test connection" button. */
+  describe(): Promise<string>;
+  create(f: ForwardPort, description: string): Promise<void>;
+  /** Point an existing rule at this client's target IP. */
+  retarget(rule: RouterRule, f: ForwardPort): Promise<void>;
+  setEnabled(rule: RouterRule, enabled: boolean): Promise<void>;
+  /** Delete a batch (the pfSense client orders these so ids don't shift mid-loop). */
+  remove(rules: RouterRule[]): Promise<void>;
+  /** Push pending changes live. pfSense needs an explicit apply; UniFi provisions on write. */
+  commit(): Promise<void>;
+}
+
+/**
+ * Whether a router's port spec covers one port. Routers store the WAN port as a
+ * string that may be a single port, a comma list, or a range (pfSense uses
+ * "a:b", UniFi "a-b"). Anything unparseable never matches, so a rule we don't
+ * understand is left alone rather than edited.
+ */
+export function portSpecCovers(spec: string | number | undefined | null, port: number): boolean {
+  if (spec === undefined || spec === null) return false;
+  for (const part of String(spec).split(",")) {
+    const p = part.trim();
+    if (!p) continue;
+    const range = p.match(/^(\d+)\s*[-:]\s*(\d+)$/);
+    if (range) {
+      const lo = Number(range[1]);
+      const hi = Number(range[2]);
+      if (port >= Math.min(lo, hi) && port <= Math.max(lo, hi)) return true;
+      continue;
+    }
+    if (/^\d+$/.test(p) && Number(p) === port) return true;
+  }
+  return false;
+}
+
+/** A rule's protocol covers a forward's when they match or the rule is "both". */
+export function protoCovers(rule: RouterRule["proto"], proto: ForwardPort["proto"]): boolean {
+  return rule === "both" || rule === proto;
+}

--- a/apps/api/src/portforwards/router.ts
+++ b/apps/api/src/portforwards/router.ts
@@ -9,6 +9,8 @@ export const ROUTER_LABELS: Record<RouterKind, string> = { pfsense: "pfSense", u
 export interface RouterRule {
   /** The router's own id (pfSense numeric index, UniFi object id) as a string. */
   id: string;
+  /** The rule's description / name on the router ("" when it has none). */
+  name: string;
   /** "udp" | "tcp" | "both" (UniFi's tcp_udp). */
   proto: "udp" | "tcp" | "both";
   /** The WAN-side port spec as the router stores it: "7777", "7777,7778", "7777-7779". */
@@ -38,6 +40,23 @@ export interface RouterClient {
   remove(rules: RouterRule[]): Promise<void>;
   /** Push pending changes live. pfSense needs an explicit apply; UniFi provisions on write. */
   commit(): Promise<void>;
+}
+
+/** Every rule Palisade creates is named with this prefix, which is how a later
+ *  cleanup tells our rules apart from ones an admin made by hand. */
+export const RULE_NAME_PREFIX = "Palisade - ";
+
+/** Older builds named rules "ASM <server> — <port>"; still recognised as ours. */
+const LEGACY_RULE_PREFIX = "ASM ";
+
+/** "Palisade - <Game> - <server> - <port label>", capped at UniFi's 128-char
+ *  name limit (pfSense descriptions have no practical limit). */
+export function ruleName(gameLabel: string, serverName: string, portLabel: string): string {
+  return `${RULE_NAME_PREFIX}${gameLabel} - ${serverName} - ${portLabel}`.slice(0, 128);
+}
+
+export function isPalisadeRule(rule: RouterRule): boolean {
+  return rule.name.startsWith(RULE_NAME_PREFIX) || rule.name.startsWith(LEGACY_RULE_PREFIX);
 }
 
 /**

--- a/apps/api/src/portforwards/unifi.client.ts
+++ b/apps/api/src/portforwards/unifi.client.ts
@@ -1,0 +1,202 @@
+import { request as httpsRequest } from "node:https";
+import type { ForwardPort } from "../catalog/ports";
+import { portSpecCovers, type RouterClient, type RouterRule } from "./router";
+
+/** The slice of a UniFi port-forward object we read. */
+interface UnifiForward {
+  _id: string;
+  name?: string;
+  enabled?: boolean;
+  /** "wan" | "wan2" | "all" — every value is a WAN-facing interface. */
+  pfwd_interface?: string;
+  proto?: string; // "tcp" | "udp" | "tcp_udp"
+  dst_port?: string; // "7777" | "7777,7778" | "7777-7779"
+  fwd?: string;
+  fwd_port?: string;
+}
+
+interface LegacyResponse<T> {
+  meta?: { rc?: string; msg?: string };
+  data?: T[];
+}
+
+/** Host as typed in Settings → hostname + port. Accepts "192.168.1.1",
+ *  "192.168.1.1:8443", "https://unifi.example.com" and trailing slashes. */
+export function parseUnifiHost(input: string): { hostname: string; port: number } {
+  const trimmed = input.trim();
+  const url = new URL(/^[a-z]+:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`);
+  return { hostname: url.hostname, port: url.port ? Number(url.port) : 443 };
+}
+
+/** UniFi's forward object → the router-neutral shape the service reasons about. */
+export function normalizeUnifiRule(r: UnifiForward): RouterRule {
+  const proto = (r.proto ?? "").toLowerCase();
+  return {
+    id: r._id,
+    proto: proto === "tcp_udp" ? "both" : proto === "tcp" ? "tcp" : "udp",
+    ports: String(r.dst_port ?? ""),
+    target: r.fwd ?? "",
+    enabled: r.enabled !== false,
+  };
+}
+
+/**
+ * WAN port-forwards via the UniFi Network application's classic REST API
+ * (`/api/s/{site}/rest/portforward`), authenticated with an API key (Settings →
+ * Control Plane → Integrations). Verified against a UniFi OS console on Network
+ * 10.5: the key works on the classic endpoints, which the newer Integration API
+ * (`/integration/v1`) has no port-forward equivalent for yet.
+ *
+ * UniFi OS consoles (UDM, UCG, Cloud Key) front the Network app at
+ * `/proxy/network`; a self-hosted Network application serves the same API at the
+ * root. The client tries the console prefix first and falls back on a 404, then
+ * remembers which one answered. Consoles run self-signed certs, so TLS
+ * verification is disabled. Changes provision immediately — there is no apply step.
+ */
+export class UnifiClient implements RouterClient {
+  readonly kind = "unifi" as const;
+  private readonly hostname: string;
+  private readonly port: number;
+  private prefix: string | null = null;
+
+  constructor(
+    readonly host: string,
+    private readonly apiKey: string,
+    readonly site: string,
+    readonly targetIp: string,
+  ) {
+    const parsed = parseUnifiHost(host);
+    this.hostname = parsed.hostname;
+    this.port = parsed.port;
+  }
+
+  private raw(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    path: string,
+    body?: unknown,
+  ): Promise<{ status: number; text: string }> {
+    return new Promise((resolve, reject) => {
+      const payload = body === undefined ? null : JSON.stringify(body);
+      const req = httpsRequest(
+        {
+          host: this.hostname,
+          port: this.port,
+          path,
+          method,
+          rejectUnauthorized: false, // UniFi self-signed cert
+          timeout: 15_000,
+          headers: {
+            "X-API-KEY": this.apiKey,
+            Accept: "application/json",
+            ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
+          },
+        },
+        (res) => {
+          let text = "";
+          res.on("data", (d) => (text += d));
+          res.on("end", () => resolve({ status: res.statusCode ?? 500, text }));
+        },
+      );
+      req.on("error", reject);
+      req.on("timeout", () => req.destroy(new Error("UniFi request timeout")));
+      if (payload) req.write(payload);
+      req.end();
+    });
+  }
+
+  /** Request against the Network app, resolving the UniFi OS `/proxy/network`
+   *  prefix on first use. `path` is relative to the Network app root. */
+  private async api<T>(method: "GET" | "POST" | "PUT" | "DELETE", path: string, body?: unknown): Promise<T[]> {
+    const candidates = this.prefix === null ? ["/proxy/network", ""] : [this.prefix];
+    let last: { status: number; text: string } | null = null;
+    for (const prefix of candidates) {
+      const res = await this.raw(method, `${prefix}${path}`, body);
+      last = res;
+      if (res.status === 404 && this.prefix === null) continue;
+      this.prefix = prefix;
+      break;
+    }
+    const res = last!;
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(
+        `UniFi ${res.status}: rejected — check the API key (it needs admin rights) and the site name "${this.site}"`,
+      );
+    }
+    let parsed: LegacyResponse<T> | null = null;
+    try {
+      parsed = JSON.parse(res.text) as LegacyResponse<T>;
+    } catch {
+      /* non-JSON body */
+    }
+    if (res.status >= 400 || (parsed?.meta?.rc && parsed.meta.rc !== "ok")) {
+      const detail = parsed?.meta?.msg ?? res.text.slice(0, 200);
+      throw new Error(`UniFi ${res.status}: ${detail}`);
+    }
+    return parsed?.data ?? [];
+  }
+
+  private sitePath(rest: string): string {
+    return `/api/s/${encodeURIComponent(this.site)}/${rest}`;
+  }
+
+  async list(): Promise<RouterRule[]> {
+    const rows = await this.api<UnifiForward>("GET", this.sitePath("rest/portforward"));
+    return rows.map(normalizeUnifiRule);
+  }
+
+  async wanIp(): Promise<string | null> {
+    const rows = await this.api<{ subsystem?: string; wan_ip?: string }>("GET", this.sitePath("stat/health"));
+    return rows.find((s) => s.subsystem === "wan")?.wan_ip ?? null;
+  }
+
+  async describe(): Promise<string> {
+    const rules = await this.list();
+    let version = "";
+    try {
+      const res = await this.raw("GET", `${this.prefix ?? "/proxy/network"}/integration/v1/info`);
+      const info = JSON.parse(res.text) as { applicationVersion?: string };
+      if (info.applicationVersion) version = ` (Network ${info.applicationVersion})`;
+    } catch {
+      /* the Integration API is optional here */
+    }
+    return `site "${this.site}"${version}, ${rules.length} port-forward rule${rules.length === 1 ? "" : "s"}`;
+  }
+
+  async create(f: ForwardPort, description: string): Promise<void> {
+    await this.api("POST", this.sitePath("rest/portforward"), {
+      name: description,
+      enabled: true,
+      pfwd_interface: "wan",
+      src: "any",
+      dst_port: String(f.port),
+      fwd: this.targetIp,
+      fwd_port: String(f.port),
+      proto: f.proto,
+      log: false,
+    });
+  }
+
+  async retarget(rule: RouterRule, f: ForwardPort): Promise<void> {
+    // A single-port rule gets its LAN port realigned too (parity with pfSense);
+    // a shared list/range rule keeps whatever port mapping it already has.
+    const single = /^\d+$/.test(rule.ports.trim()) && portSpecCovers(rule.ports, f.port);
+    await this.api("PUT", this.sitePath(`rest/portforward/${rule.id}`), {
+      fwd: this.targetIp,
+      ...(single ? { fwd_port: String(f.port) } : {}),
+    });
+  }
+
+  async setEnabled(rule: RouterRule, enabled: boolean): Promise<void> {
+    await this.api("PUT", this.sitePath(`rest/portforward/${rule.id}`), { enabled });
+  }
+
+  async remove(rules: RouterRule[]): Promise<void> {
+    for (const r of rules) {
+      await this.api("DELETE", this.sitePath(`rest/portforward/${r.id}`));
+    }
+  }
+
+  async commit(): Promise<void> {
+    /* UniFi provisions each write immediately */
+  }
+}

--- a/apps/api/src/portforwards/unifi.client.ts
+++ b/apps/api/src/portforwards/unifi.client.ts
@@ -33,6 +33,7 @@ export function normalizeUnifiRule(r: UnifiForward): RouterRule {
   const proto = (r.proto ?? "").toLowerCase();
   return {
     id: r._id,
+    name: r.name ?? "",
     proto: proto === "tcp_udp" ? "both" : proto === "tcp" ? "tcp" : "udp",
     ports: String(r.dst_port ?? ""),
     target: r.fwd ?? "",
@@ -164,7 +165,7 @@ export class UnifiClient implements RouterClient {
 
   async create(f: ForwardPort, description: string): Promise<void> {
     await this.api("POST", this.sitePath("rest/portforward"), {
-      name: description,
+      name: description.slice(0, 128), // UniFi validates name against .{1,128}
       enabled: true,
       pfwd_interface: "wan",
       src: "any",

--- a/apps/api/src/servers/servers.module.ts
+++ b/apps/api/src/servers/servers.module.ts
@@ -9,9 +9,10 @@ import { RconModule } from "../rcon/rcon.module";
 import { BackupsModule } from "../backups/backups.module";
 import { PlayersModule } from "../players/players.module";
 import { UpdatesModule } from "../updates/updates.module";
+import { PortForwardsModule } from "../portforwards/portforwards.module";
 
 @Module({
-  imports: [RconModule, BackupsModule, PlayersModule, ArtworkModule, UpdatesModule],
+  imports: [RconModule, BackupsModule, PlayersModule, ArtworkModule, UpdatesModule, PortForwardsModule],
   controllers: [ServersController],
   providers: [ServersService, ServerConfigWriter, StateMachineService, HistoryService],
   exports: [ServersService, StateMachineService],

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  Optional,
   type OnApplicationBootstrap,
   type OnApplicationShutdown,
 } from "@nestjs/common";
@@ -40,6 +41,7 @@ import { CryptoService } from "../crypto/crypto.service";
 import { EventsService } from "../events/events.service";
 import { RealtimeGateway } from "../realtime/realtime.gateway";
 import { DockerService } from "../docker/docker.service";
+import { PortForwardsService } from "../portforwards/portforwards.service";
 import { CatalogService } from "../catalog/catalog.service";
 import { ServerConfigWriter } from "./config-writer.service";
 import { ArtworkService } from "../artwork/artwork.service";
@@ -289,6 +291,9 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
     private readonly endpoints: GameEndpointService,
     private readonly configWriter: ServerConfigWriter,
     private readonly artwork: ArtworkService,
+    // Optional so the unit-test harnesses that build this service by hand keep
+    // working without a router; production always has it wired.
+    @Optional() private readonly portforwards?: PortForwardsService,
   ) {}
 
   /** The captured log / console for the current run (survives refresh + tab
@@ -917,9 +922,16 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
         this.logger.warn(`Delete: backups cleanup failed for ${id}: ${(e as Error).message}`),
       );
     }
+    // Router cleanup (GH #66): drop the WAN forwards Palisade created for this
+    // server, unless another server still needs the port. Best-effort.
+    const forwardsRemoved = (await this.portforwards?.removeForServer(server)) ?? 0;
+    const notes = [
+      ...(wipeFiles ? [] : ["files kept on disk"]),
+      ...(forwardsRemoved > 0 ? [`${forwardsRemoved} port forward${forwardsRemoved === 1 ? "" : "s"} removed`] : []),
+    ];
     await this.events.emit({
       type: EventType.ServerDeleted,
-      message: `Deleted server "${server.name}"${wipeFiles ? "" : " (files kept on disk)"}`,
+      message: `Deleted server "${server.name}"${notes.length ? ` (${notes.join(", ")})` : ""}`,
       serverId: id,
     });
   }

--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -538,8 +538,9 @@ function DeleteConfirm({
           <h2 className="text-lg font-semibold">Delete “{server.name}”?</h2>
         </div>
         <p className="text-sm leading-snug text-slate-300">
-          This permanently removes the server{isLive ? " (it will be force-stopped first)" : ""}. This cannot
-          be undone.
+          This permanently removes the server{isLive ? " (it will be force-stopped first)" : ""}. Router port
+          forwards Palisade created for it are removed too, unless another server still uses the
+          port. This cannot be undone.
         </p>
 
         {/* Keep-or-wipe choice */}

--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -709,7 +709,7 @@ function Overview({ server, onChanged }: { server: ServerSummary; onChanged: () 
       {!isCoreKeeper && <PortsCard server={server} onSaved={onChanged} />}
       <ImageVersionCard server={server} onSaved={onChanged} />
       <EnvVarsCard server={server} onSaved={onChanged} />
-      {!isCoreKeeper && <PortForwardsCard serverId={server.id} />}
+      {!isCoreKeeper && <PortForwardsCard serverId={server.id} ports={server.ports} />}
       {/* File-managed access lists (Valheim/Bedrock/7DTD); RCON games use the Console. */}
       {(isValheim || isBedrock || isSdtd) && <AccessListsCard serverId={server.id} />}
     </div>

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -25,6 +25,13 @@ export default function SettingsPage() {
   const [pfsenseApiKey, setPfsenseApiKey] = useState("");
   const [pfsenseTargetIp, setPfsenseTargetIp] = useState("");
   const [pfTestMsg, setPfTestMsg] = useState<string | null>(null);
+  // Which router the port-forward integration drives. Unset reads as pfSense so
+  // installs that predate UniFi support keep their forwards untouched.
+  const [portForwardRouter, setPortForwardRouter] = useState<"pfsense" | "unifi">("pfsense");
+  const [unifiHost, setUnifiHost] = useState("");
+  const [unifiApiKey, setUnifiApiKey] = useState("");
+  const [unifiSite, setUnifiSite] = useState("default");
+  const [unifiTargetIp, setUnifiTargetIp] = useState("");
   // Host overrides. "" means "not set here" — the env var keeps deciding.
   const [gameHostNetwork, setGameHostNetwork] = useState("");
   const [autoCreateNetwork, setAutoCreateNetwork] = useState("");
@@ -46,6 +53,10 @@ export default function SettingsPage() {
         setAutoStop(v.auto_stop_on_start !== "false"); // default on when unset
         if (typeof v.pfsense_host === "string") setPfsenseHost(v.pfsense_host);
         if (typeof v.pfsense_target_ip === "string") setPfsenseTargetIp(v.pfsense_target_ip);
+        setPortForwardRouter(v.port_forward_router === "unifi" ? "unifi" : "pfsense");
+        if (typeof v.unifi_host === "string") setUnifiHost(v.unifi_host);
+        if (typeof v.unifi_site === "string" && v.unifi_site) setUnifiSite(v.unifi_site);
+        if (typeof v.unifi_target_ip === "string") setUnifiTargetIp(v.unifi_target_ip);
         setGameHostNetwork(typeof v.game_host_network === "string" ? v.game_host_network : "");
         setAutoCreateNetwork(typeof v.auto_create_network === "string" ? v.auto_create_network : "");
         setPublicBaseUrl(typeof v.public_base_url === "string" ? v.public_base_url : "");
@@ -103,10 +114,24 @@ export default function SettingsPage() {
     });
   };
 
-  const savePfsense = () => {
-    const body: Record<string, string> = { pfsenseHost, pfsenseTargetIp };
-    if (pfsenseApiKey) body.pfsenseApiKey = pfsenseApiKey;
-    void saveCard("pfsense", body, () => setPfsenseApiKey(""));
+  /** Saves the router choice plus the fields of the router that's showing; the
+   *  other router's saved settings stay put so switching back costs nothing. */
+  const savePortForwarding = () => {
+    const body: Record<string, string> = { portForwardRouter };
+    if (portForwardRouter === "unifi") {
+      body.unifiHost = unifiHost;
+      body.unifiSite = unifiSite;
+      body.unifiTargetIp = unifiTargetIp;
+      if (unifiApiKey) body.unifiApiKey = unifiApiKey;
+    } else {
+      body.pfsenseHost = pfsenseHost;
+      body.pfsenseTargetIp = pfsenseTargetIp;
+      if (pfsenseApiKey) body.pfsenseApiKey = pfsenseApiKey;
+    }
+    void saveCard("portforwarding", body, () => {
+      setPfsenseApiKey("");
+      setUnifiApiKey("");
+    });
   };
 
   const saveBackups = () => {
@@ -153,10 +178,10 @@ export default function SettingsPage() {
   };
 
   // Tests the SAVED settings — remind the user to hit Save first if fields are dirty.
-  const testPfsense = async () => {
+  const testRouter = async () => {
     setPfTestMsg("Testing…");
     try {
-      const res = await apiPost<{ ok: boolean; message: string }>("/pfsense/test");
+      const res = await apiPost<{ ok: boolean; message: string }>("/router/test");
       setPfTestMsg(`${res.ok ? "✓ " : "✗ "}${res.message}`);
     } catch (err) {
       setPfTestMsg((err as Error).message);
@@ -335,55 +360,120 @@ export default function SettingsPage() {
           </div>
           <div className="card space-y-4">
             <h2 className="text-sm font-semibold uppercase tracking-wide text-ark-accent2">
-              pfSense port forwarding
+              Port forwarding
             </h2>
             <p className="text-xs text-slate-500">
-              With these set, each server&apos;s Overview gets one-click WAN port-forward management. Requires
-              the free{" "}
-              <a
-                href="https://pfrest.org/"
-                target="_blank"
-                rel="noreferrer"
-                className="text-ark-accent hover:underline"
-              >
-                pfSense REST API package
-              </a>{" "}
-              on your router (System → REST API → generate an API key). Works with any pfSense — nothing is
-              tied to a specific network.
+              With these set, each server&apos;s Overview gets one-click WAN port-forward management:
+              create, fix, enable/disable, and delete the player-facing forwards on your router. Nothing
+              is tied to a specific network.
             </p>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div>
-                <label className="label">pfSense host / IP</label>
-                <input
-                  className="input"
-                  placeholder="e.g. 192.168.1.1 (your router)"
-                  value={pfsenseHost}
-                  onChange={(e) => setPfsenseHost(e.target.value)}
-                />
-              </div>
-              <div>
-                <label className="label">Forward to (this machine&apos;s LAN IP)</label>
-                <input
-                  className="input"
-                  placeholder="e.g. 192.168.1.50 (this server box)"
-                  value={pfsenseTargetIp}
-                  onChange={(e) => setPfsenseTargetIp(e.target.value)}
-                />
-              </div>
-            </div>
-            <SecretField
-              label="pfSense REST API key"
-              value={pfsenseApiKey}
-              onChange={setPfsenseApiKey}
-              configured={configured("pfsense_api_key")}
-            />
             <div>
-              <button type="button" className="btn-secondary" onClick={testPfsense}>
+              <label className="label">Router</label>
+              <select
+                className="input"
+                value={portForwardRouter}
+                onChange={(e) => {
+                  setPortForwardRouter(e.target.value === "unifi" ? "unifi" : "pfsense");
+                  setPfTestMsg(null);
+                }}
+              >
+                <option value="pfsense">pfSense (REST API package)</option>
+                <option value="unifi">UniFi Network (UniFi OS console)</option>
+              </select>
+            </div>
+            {portForwardRouter === "pfsense" ? (
+              <>
+                <p className="text-xs text-slate-500">
+                  Requires the free{" "}
+                  <a
+                    href="https://pfrest.org/"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-ark-accent hover:underline"
+                  >
+                    pfSense REST API package
+                  </a>{" "}
+                  on your router (System → REST API → generate an API key).
+                </p>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <label className="label">pfSense host / IP</label>
+                    <input
+                      className="input"
+                      placeholder="e.g. 192.168.1.1 (your router)"
+                      value={pfsenseHost}
+                      onChange={(e) => setPfsenseHost(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label className="label">Forward to (LAN IP)</label>
+                    <input
+                      className="input"
+                      placeholder="e.g. 192.168.1.50 (this server box)"
+                      value={pfsenseTargetIp}
+                      onChange={(e) => setPfsenseTargetIp(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <SecretField
+                  label="pfSense REST API key"
+                  value={pfsenseApiKey}
+                  onChange={setPfsenseApiKey}
+                  configured={configured("pfsense_api_key")}
+                />
+              </>
+            ) : (
+              <>
+                <p className="text-xs text-slate-500">
+                  Works with UniFi OS consoles (Dream Machine, Cloud Gateway, Cloud Key) on Network 9.0 or
+                  newer. Create an API key in the Network app under Settings → Control Plane → Integrations;
+                  the key needs an admin role. Multi-site setups: use the site&apos;s short name from the URL
+                  (usually <span className="font-mono text-slate-400">default</span>).
+                </p>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <label className="label">Console host / IP</label>
+                    <input
+                      className="input"
+                      placeholder="e.g. 192.168.1.1 (your gateway)"
+                      value={unifiHost}
+                      onChange={(e) => setUnifiHost(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label className="label">Forward to (LAN IP)</label>
+                    <input
+                      className="input"
+                      placeholder="e.g. 192.168.1.50 (this server box)"
+                      value={unifiTargetIp}
+                      onChange={(e) => setUnifiTargetIp(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label className="label">Site</label>
+                    <input
+                      className="input"
+                      placeholder="default"
+                      value={unifiSite}
+                      onChange={(e) => setUnifiSite(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <SecretField
+                  label="UniFi API key"
+                  value={unifiApiKey}
+                  onChange={setUnifiApiKey}
+                  configured={configured("unifi_api_key")}
+                />
+              </>
+            )}
+            <div>
+              <button type="button" className="btn-secondary" onClick={testRouter}>
                 <Send className="h-4 w-4" /> Test connection
               </button>
               {pfTestMsg && <p className="mt-2 text-sm text-slate-400">{pfTestMsg}</p>}
             </div>
-            <CardSave card="pfsense" onClick={savePfsense} />
+            <CardSave card="portforwarding" onClick={savePortForwarding} />
           </div>
         </>
       )}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -177,11 +177,16 @@ export default function SettingsPage() {
     }
   };
 
-  // Tests the SAVED settings — remind the user to hit Save first if fields are dirty.
+  // Tests what's in the form right now (a blank key falls back to the saved one),
+  // so a router can be tried before Save.
   const testRouter = async () => {
     setPfTestMsg("Testing…");
     try {
-      const res = await apiPost<{ ok: boolean; message: string }>("/router/test");
+      const draft =
+        portForwardRouter === "unifi"
+          ? { router: "unifi", host: unifiHost, apiKey: unifiApiKey, site: unifiSite, targetIp: unifiTargetIp }
+          : { router: "pfsense", host: pfsenseHost, apiKey: pfsenseApiKey, targetIp: pfsenseTargetIp };
+      const res = await apiPost<{ ok: boolean; message: string }>("/router/test", draft);
       setPfTestMsg(`${res.ok ? "✓ " : "✗ "}${res.message}`);
     } catch (err) {
       setPfTestMsg((err as Error).message);

--- a/apps/web/components/port-forwards-card.tsx
+++ b/apps/web/components/port-forwards-card.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { Globe, Check, X, Loader2, ArrowUpRight, Power, Trash2, TriangleAlert } from "lucide-react";
+import type { PortSet } from "@ark/shared";
 import { apiGet, apiPost, apiPatch, apiDelete } from "@/lib/api";
 
 type ForwardState = "ok" | "disabled" | "mismatched" | "missing";
@@ -29,17 +30,21 @@ const ROUTER_LABELS = { pfsense: "pfSense", unifi: "UniFi" } as const;
  * create-and-fix, per-forward enable/disable and delete — against whichever
  * router Settings points at (pfSense REST API or UniFi Network API).
  */
-export function PortForwardsCard({ serverId }: { serverId: string }) {
+export function PortForwardsCard({ serverId, ports }: { serverId: string; ports: PortSet }) {
   const [view, setView] = useState<View | null>(null);
   const [busy, setBusy] = useState<string | null>(null); // "apply" | "<port>/<proto>"
   const [err, setErr] = useState<string | null>(null);
 
+  // The forwards are derived from the server's ports, so a save in the Ports card
+  // (which reloads the server) has to refetch here too — otherwise the card keeps
+  // offering the old ports until a page refresh (GH #66).
+  const portsKey = `${ports.game}/${ports.rawSocket}/${ports.query}/${ports.rcon}`;
   const refresh = useCallback(() => {
     apiGet<View>(`/servers/${serverId}/portforwards`)
       .then(setView)
       .catch((e) => setErr((e as Error).message));
   }, [serverId]);
-  useEffect(() => refresh(), [refresh]);
+  useEffect(() => refresh(), [refresh, portsKey]);
 
   const run = async (key: string, fn: () => Promise<View>) => {
     setBusy(key);

--- a/apps/web/components/port-forwards-card.tsx
+++ b/apps/web/components/port-forwards-card.tsx
@@ -10,21 +10,24 @@ interface ForwardStatus {
   proto: "udp" | "tcp";
   label: string;
   state: ForwardState;
-  ruleId: number | null;
+  ruleId: string | null;
   actualTarget?: string | null;
 }
 interface View {
+  router: "pfsense" | "unifi";
   configured: boolean;
   targetIp: string | null;
   wanIp: string | null;
   forwards: ForwardStatus[];
 }
 
+const ROUTER_LABELS = { pfsense: "pfSense", unifi: "UniFi" } as const;
+
 /**
  * Full WAN port-forward management for this server's player-facing ports:
  * per-forward state (ok / disabled / wrong target / missing), one-click
- * create-and-fix, per-forward enable/disable and delete — all against the pfSense
- * REST API (host + key + target IP in Settings).
+ * create-and-fix, per-forward enable/disable and delete — against whichever
+ * router Settings points at (pfSense REST API or UniFi Network API).
  */
 export function PortForwardsCard({ serverId }: { serverId: string }) {
   const [view, setView] = useState<View | null>(null);
@@ -51,6 +54,7 @@ export function PortForwardsCard({ serverId }: { serverId: string }) {
   };
 
   if (!view) return null;
+  const routerLabel = ROUTER_LABELS[view.router] ?? "router";
   const fixable = view.forwards.filter((f) => f.state === "missing" || f.state === "mismatched").length;
 
   const stateChip = (f: ForwardStatus) => {
@@ -88,7 +92,7 @@ export function PortForwardsCard({ serverId }: { serverId: string }) {
         <div className="flex items-center gap-2">
           <Globe className="h-4 w-4 text-ark-accent" />
           <h3 className="text-sm font-semibold uppercase tracking-wide text-ark-accent2">
-            Port forwarding (pfSense)
+            Port forwarding ({routerLabel})
           </h3>
         </div>
         {view.configured && fixable > 0 && (
@@ -101,7 +105,7 @@ export function PortForwardsCard({ serverId }: { serverId: string }) {
 
       {!view.configured ? (
         <p className="text-xs text-slate-500">
-          Set the pfSense host, API key, and target IP in{" "}
+          Set the {routerLabel} host, API key, and target IP in{" "}
           <Link href="/settings" className="text-ark-accent hover:underline">
             Settings
           </Link>{" "}
@@ -141,7 +145,7 @@ export function PortForwardsCard({ serverId }: { serverId: string }) {
                         </button>
                         <button
                           className="text-slate-500 hover:text-rose-400"
-                          title="Delete this forward from pfSense"
+                          title={`Delete this forward from ${routerLabel}`}
                           disabled={busy !== null}
                           onClick={() =>
                             run(key, () =>


### PR DESCRIPTION
Closes #66.

## What changes

- **Settings → Integrations → Port forwarding** gets a Router picker: pfSense (default, unchanged for existing installs) or UniFi Network. UniFi asks for the console host, an API key, the site name, and the LAN target IP. Test connection works for either.
- The per-server forwards card now names whichever router is selected; create, fix, enable/disable, and delete behave the same on both.
- The service is split into a router-neutral core plus one client per router (`pfsense.client.ts`, `unifi.client.ts`). Rule ids are strings now because UniFi's are object ids.

## UniFi details

- Uses the Network app's classic REST endpoint `/api/s/{site}/rest/portforward` with an `X-API-KEY` header. The Integration API on Network 10.5 has no port-forward resource, so this is the only route.
- Tries the UniFi OS `/proxy/network` prefix first and falls back to the root path for a self-hosted Network application.
- Rules are created per protocol on the WAN interface with source any, matching what the pfSense side does.
- Matching understands comma lists, ranges, and `tcp_udp` rules on both routers, so an existing hand-made rule that already covers a port is reused, and deleting a server's forwards removes a shared rule once.

## Testing

- Ran the real `UnifiClient` against a UniFi OS console on Network 10.5.67: describe, WAN IP, create, disable, enable, retarget, delete. The console was left with exactly the rules it started with.
- New unit tests: port-spec matching, host parsing, rule normalisation, and the service's classify/apply/toggle/remove logic against a fake router (15 tests).
- `pnpm -r typecheck`, web lint, and the full API suite (569 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
