### PR TITLE
Stop asking Docker about ark-net on installs that were never on it

### DIFF
--- a/apps/api/src/docker/game-endpoint.service.test.ts
+++ b/apps/api/src/docker/game-endpoint.service.test.ts
@@ -54,7 +54,10 @@ class FakeDocker {
     this.networks = this.networks.filter((n) => n !== name);
     return true;
   }
+  /** How often the legacy network was inspected — a 404 per call on a fresh install. */
+  legacyInspects = 0;
   async networkContainerIds() {
+    this.legacyInspects++;
     return this.legacyMembers;
   }
   async listManagedServers() {
@@ -225,6 +228,19 @@ describe("migrationNote", () => {
     docker.networks = ["br0", "palisade-net"];
     docker.legacyMembers = null;
     expect(await make(docker).migrationNote()).toBeNull();
+  });
+
+  it("never asks Docker about ark-net when the manager isn't on it (GH #71)", async () => {
+    // A fresh install has no such network, so each inspect is a 404 in the debug log:
+    // once at boot, then once per /health poll. The plan can't act without a legacy
+    // endpoint on the manager anyway, so there is nothing to look up.
+    const docker = new FakeDocker();
+    docker.networks = ["br0", "palisade-net"];
+    docker.legacyMembers = null;
+    const service = make(docker);
+    await service.ensureManagerNetworks();
+    expect(await service.migrationNote()).toBeNull();
+    expect(docker.legacyInspects).toBe(0);
   });
 });
 

--- a/apps/api/src/docker/game-endpoint.service.ts
+++ b/apps/api/src/docker/game-endpoint.service.ts
@@ -168,6 +168,11 @@ export class GameEndpointService {
   private async legacyPlan(): Promise<NetworkPlanInput | null> {
     const manager = await this.manager();
     if (!manager.inContainer) return null;
+    // Nothing to plan unless the manager itself still holds a legacy endpoint: both
+    // rules below stand down without one. Asking Docker anyway meant every boot and
+    // every /health poll on a fresh install logged a 404 for a network that never
+    // existed there (GH #71).
+    if (!manager.networks.includes(LEGACY_NETWORK)) return null;
     // Docker lists only containers with a LIVE endpoint here, so a stopped server on
     // the legacy network doesn't count — correctly: every start recreates the
     // container, so it comes back on the new network regardless.


### PR DESCRIPTION
Fixes #71.

Every boot and every `/health` poll inspected the legacy `ark-net` network to plan the migration off it. On a fresh install that network never existed, so the debug log filled with:

```
DEBUG [DockerService] could not inspect network ark-net ((HTTP code 404) no such network - network ark-net not found )
```

Harmless, but it reads like Palisade is still looking for the old name.

Both migration rules already stand down unless the manager itself holds an endpoint on `ark-net`, so `legacyPlan` now checks the manager's cached network list first and skips the inspect when the name isn't there. A mid-migration install behaves exactly as before. The new test counts inspects on an install that was never on `ark-net` and expects zero.

Typecheck clean; the API suite passes apart from one timing-flaky case in `start-detached.test.ts` that passes in isolation and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
