### PR TITLE
Per-user server and cluster access for operators and viewers

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -14,7 +14,7 @@ provides a live RCON console, and runs scheduled tasks.
 | Games supported | **Both ASE + ASA** (ASA first) |
 | Tech stack | **Node/TypeScript full-stack** |
 | Runtime model | **Manager spawns one container per game server** (mounts Docker socket) |
-| Auth (v1) | **Single admin** (designed so RBAC/multi-user can be added later) |
+| Auth (v1) | **Single admin** at first; now roles (viewer/operator/admin) plus per-user server/cluster access (GH #73) |
 | Build order | **ASA first**, then ASE |
 | Mod browser | **Full in-app browser** using CurseForge API (ASA) + Steam Web API (ASE) |
 | UI exposure | **LAN-first but reverse-proxy friendly** (configurable base URL, correct headers) |
@@ -283,7 +283,7 @@ audit even in single-admin mode).
 | **2 — Mods + mod browser** | Install-by-ID pipeline (ASA `-mods=`), load-order + optional version-pin UI, then CurseForge-backed browser. |
 | **3 — Clusters** | Cluster create, shared transfer dir, member management, coordinated control, cross-server transfer. |
 | **4 — ASE support** | Native ASE base image, SteamCMD Workshop install/extract, Steam Workshop browser, ASE settings catalog. |
-| **5 — Backups, notifications, polish** | Full backup retention/restore UI, **adopt-existing-instance import**, Discord/webhook events, reverse-proxy hardening + TLS docs, RBAC/multi-user. |
+| **5 — Backups, notifications, polish** | Full backup retention/restore UI, **adopt-existing-instance import**, Discord/webhook events, reverse-proxy hardening + TLS docs, RBAC/multi-user (done: roles plus per-user server/cluster access, GH #73). |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -357,11 +357,27 @@ The app is LAN-first but proxy-friendly:
 - The manager controls Docker via the host socket. If you expose the UI beyond
   your LAN, strongly consider the socket-proxy setup above.
 
+## Users and access
+
+The first-run screen creates the admin account. After that, Settings → Users
+manages the rest. There are three roles:
+
+- **viewer**: read-only. Dashboards, players, logs.
+- **operator**: day-to-day ops. Start/stop, console, backups, mods, schedules.
+- **admin**: everything, including settings, users, and deletes.
+
+A viewer or operator can also be limited to specific servers. Tick
+"Restrict to selected servers" on the user, then pick servers and/or
+clusters. A cluster grant covers every server in that cluster, including ones
+added later. Restricted users only see what they were granted, and they
+cannot create or import servers. Admins always see everything.
+
 ## Security
 
 What's built in:
 
-- **Auth**: single-admin JWT auth (bcrypt cost 12), 7-day tokens carrying a
+- **Auth**: JWT auth (bcrypt cost 12) with roles and per-user server access
+  (see [Users and access](#users-and-access)), 7-day tokens carrying a
   version claim checked against the DB on every request — `POST
   /auth/logout-all` instantly invalidates every outstanding token. Login and
   first-run are rate-limited (5/min per client). The realtime socket requires

--- a/apps/api/prisma/migrations/20260911000000_user_server_access/migration.sql
+++ b/apps/api/prisma/migrations/20260911000000_user_server_access/migration.sql
@@ -1,0 +1,26 @@
+-- Per-user server/cluster access (GH #73). Existing users get restricted=false,
+-- so nothing changes on upgrade until an admin restricts someone. Grants cascade
+-- away with the user, server, or cluster they point at.
+ALTER TABLE "User" ADD COLUMN "restricted" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE "UserServerAccess" (
+    "userId" TEXT NOT NULL,
+    "serverId" TEXT NOT NULL,
+
+    PRIMARY KEY ("userId", "serverId"),
+    CONSTRAINT "UserServerAccess_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "UserServerAccess_serverId_fkey" FOREIGN KEY ("serverId") REFERENCES "Server" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "UserServerAccess_serverId_idx" ON "UserServerAccess"("serverId");
+
+CREATE TABLE "UserClusterAccess" (
+    "userId" TEXT NOT NULL,
+    "clusterId" TEXT NOT NULL,
+
+    PRIMARY KEY ("userId", "clusterId"),
+    CONSTRAINT "UserClusterAccess_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "UserClusterAccess_clusterId_fkey" FOREIGN KEY ("clusterId") REFERENCES "Cluster" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "UserClusterAccess_clusterId_idx" ON "UserClusterAccess"("clusterId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -18,8 +18,38 @@ model User {
   role         String   @default("admin")
   /// Bumped to invalidate every outstanding JWT for this user (logout-all).
   tokenVersion Int      @default(0)
+  /// When true, this (non-admin) user only sees the servers granted below plus
+  /// every member of any granted cluster. False = every server, as before
+  /// per-user access existed. Admins are never restricted (GH #73).
+  restricted   Boolean  @default(false)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+
+  serverAccess  UserServerAccess[]
+  clusterAccess UserClusterAccess[]
+}
+
+/// Direct per-server grant for a restricted user (GH #73).
+model UserServerAccess {
+  userId   String
+  user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  serverId String
+  server   Server @relation(fields: [serverId], references: [id], onDelete: Cascade)
+
+  @@id([userId, serverId])
+  @@index([serverId])
+}
+
+/// Cluster-wide grant for a restricted user: covers every current AND future
+/// member server of the cluster (GH #73).
+model UserClusterAccess {
+  userId    String
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  clusterId String
+  cluster   Cluster @relation(fields: [clusterId], references: [id], onDelete: Cascade)
+
+  @@id([userId, clusterId])
+  @@index([clusterId])
 }
 
 /// Manager-level key/value config. Secret values are AES-256-GCM encrypted at rest.
@@ -38,6 +68,7 @@ model Cluster {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   servers     Server[]
+  userAccess  UserClusterAccess[]
 }
 
 model Server {
@@ -116,6 +147,7 @@ model Server {
   schedules   Schedule[]
   snapshots   Snapshot[]
   sightings   PlayerSighting[]
+  userAccess  UserServerAccess[]
 
   @@index([clusterId])
 }

--- a/apps/api/src/auth/access.service.test.ts
+++ b/apps/api/src/auth/access.service.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from "vitest";
+import { NotFoundException } from "@nestjs/common";
+import { AccessService } from "./access.service";
+import type { AuthUser } from "./auth-user";
+
+// Per-user server/cluster visibility (GH #73). Admins and unrestricted users
+// see "all"; a restricted user sees direct grants plus the members of any
+// granted cluster, resolved fresh on every call so membership edits apply
+// without touching the grant.
+interface Fixture {
+  /** userId -> directly granted server ids */
+  serverGrants?: Record<string, string[]>;
+  /** userId -> directly granted cluster ids */
+  clusterGrants?: Record<string, string[]>;
+  /** clusterId -> member server ids (mutable: tests add members mid-flight) */
+  clusters?: Record<string, string[]>;
+}
+
+function makeService(fx: Fixture = {}) {
+  const clusters = fx.clusters ?? {};
+  const prisma = {
+    userServerAccess: {
+      findMany: async ({ where }: { where: { userId: string } }) =>
+        (fx.serverGrants?.[where.userId] ?? []).map((serverId) => ({ serverId })),
+    },
+    userClusterAccess: {
+      findMany: async ({ where }: { where: { userId: string } }) =>
+        (fx.clusterGrants?.[where.userId] ?? []).map((clusterId) => ({ clusterId })),
+    },
+    server: {
+      findMany: async ({ where }: { where: { clusterId: { in: string[] } } }) =>
+        where.clusterId.in.flatMap((cid) => (clusters[cid] ?? []).map((id) => ({ id }))),
+    },
+    cluster: {
+      findUnique: async ({ where }: { where: { id: string } }) =>
+        where.id in clusters ? { servers: clusters[where.id]!.map((id) => ({ id })) } : null,
+    },
+  };
+  return { svc: new AccessService(prisma as never), clusters };
+}
+
+const user = (over: Partial<AuthUser> = {}): AuthUser => ({
+  sub: "u1",
+  ver: 0,
+  role: "operator",
+  restricted: false,
+  ...over,
+});
+
+const restricted = (over: Partial<AuthUser> = {}) => user({ restricted: true, ...over });
+
+const ids = (allowed: "all" | Set<string>) => (allowed === "all" ? "all" : [...allowed].sort());
+
+describe("AccessService.allowedServerIds", () => {
+  it("admins see everything regardless of the restricted flag", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1"] } });
+    expect(await svc.allowedServerIds(user({ role: "admin", restricted: true }))).toBe("all");
+    expect(await svc.allowedServerIds(user({ role: "admin", restricted: false }))).toBe("all");
+  });
+
+  it("an unrestricted non-admin sees everything", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1"] } });
+    expect(await svc.allowedServerIds(user({ role: "viewer" }))).toBe("all");
+    expect(await svc.allowedServerIds(user({ role: "operator" }))).toBe("all");
+  });
+
+  it("legacy tokens with no role claim count as admin", async () => {
+    const { svc } = makeService();
+    expect(await svc.allowedServerIds(user({ role: undefined, restricted: true }))).toBe("all");
+    expect(await svc.allowedServerIds(undefined)).toBe("all");
+  });
+
+  it("a restricted user sees only direct grants", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1", "s2"], u2: ["s3"] } });
+    expect(ids(await svc.allowedServerIds(restricted()))).toEqual(["s1", "s2"]);
+    expect(ids(await svc.allowedServerIds(restricted({ sub: "u3" })))).toEqual([]);
+  });
+
+  it("a cluster grant expands to its members and follows later membership changes", async () => {
+    const { svc, clusters } = makeService({
+      serverGrants: { u1: ["s1"] },
+      clusterGrants: { u1: ["c1"] },
+      clusters: { c1: ["s2", "s3"], c2: ["s4"] },
+    });
+    expect(ids(await svc.allowedServerIds(restricted()))).toEqual(["s1", "s2", "s3"]);
+
+    clusters.c1!.push("s9");
+    expect(ids(await svc.allowedServerIds(restricted()))).toEqual(["s1", "s2", "s3", "s9"]);
+  });
+});
+
+describe("AccessService.canSeeServer / canUseCluster", () => {
+  it("canSeeServer reflects the allowed set", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1"] } });
+    expect(await svc.canSeeServer(restricted(), "s1")).toBe(true);
+    expect(await svc.canSeeServer(restricted(), "s2")).toBe(false);
+    expect(await svc.canSeeServer(user({ role: "admin" }), "s2")).toBe(true);
+  });
+
+  it("a directly granted cluster is usable", async () => {
+    const { svc } = makeService({ clusterGrants: { u1: ["c1"] }, clusters: { c1: ["s1", "s2"] } });
+    expect(await svc.canUseCluster(restricted(), "c1")).toBe(true);
+  });
+
+  it("a cluster whose every member is directly granted is usable", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1", "s2"] }, clusters: { c1: ["s1", "s2"] } });
+    expect(await svc.canUseCluster(restricted(), "c1")).toBe(true);
+  });
+
+  it("a cluster with only some members visible is not usable", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1"] }, clusters: { c1: ["s1", "s2"] } });
+    expect(await svc.canUseCluster(restricted(), "c1")).toBe(false);
+  });
+
+  it("an unknown cluster is not usable; unrestricted users skip the lookup", async () => {
+    const { svc } = makeService({ clusters: {} });
+    expect(await svc.canUseCluster(restricted(), "ghost")).toBe(false);
+    expect(await svc.canUseCluster(user(), "ghost")).toBe(true);
+  });
+
+  it("grantedClusterIds lists only direct cluster grants", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1", "s2"] }, clusterGrants: { u1: ["c2"] }, clusters: { c1: ["s1", "s2"], c2: ["s3"] } });
+    expect(ids(await svc.grantedClusterIds(restricted()))).toEqual(["c2"]);
+    expect(await svc.grantedClusterIds(user())).toBe("all");
+  });
+});
+
+describe("AccessService.assert*", () => {
+  it("assertServer denies with NotFoundException so hidden and missing look the same", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1"] } });
+    await expect(svc.assertServer(restricted(), "s1")).resolves.toBeUndefined();
+    await expect(svc.assertServer(restricted(), "s2")).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("assertCluster denies with NotFoundException", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1"] }, clusters: { c1: ["s1", "s2"] } });
+    await expect(svc.assertCluster(restricted(), "c1")).rejects.toBeInstanceOf(NotFoundException);
+    await expect(svc.assertCluster(user({ role: "admin" }), "c1")).resolves.toBeUndefined();
+  });
+
+  it("assertServers fails on the first hidden id and passes an all-visible list", async () => {
+    const { svc } = makeService({ serverGrants: { u1: ["s1", "s3"] } });
+    await expect(svc.assertServers(restricted(), ["s1", "s3"])).resolves.toBeUndefined();
+    await expect(svc.assertServers(restricted(), ["s1", "s2", "s4"])).rejects.toMatchObject({
+      message: "Server s2 not found",
+    });
+    await expect(svc.assertServers(user(), ["s2", "s4"])).resolves.toBeUndefined();
+  });
+});
+
+describe("AccessService.filterByServer", () => {
+  const rows = [
+    { id: "a", serverId: "s1" },
+    { id: "b", serverId: null },
+    { id: "c", serverId: "s2" },
+  ];
+
+  it("passes everything through for 'all'", () => {
+    const { svc } = makeService();
+    expect(svc.filterByServer(rows, "all")).toBe(rows);
+  });
+
+  it("drops null serverIds and hidden ids", () => {
+    const { svc } = makeService();
+    expect(svc.filterByServer(rows, new Set(["s1"])).map((r) => r.id)).toEqual(["a"]);
+    expect(svc.filterByServer(rows, new Set())).toEqual([]);
+  });
+});
+
+describe("AccessService change notifications", () => {
+  it("onChanged receives notifyChanged userIds until unsubscribed", () => {
+    const { svc } = makeService();
+    const listener = vi.fn();
+    const off = svc.onChanged(listener);
+
+    svc.notifyChanged("u1");
+    svc.notifyChanged("u2");
+    expect(listener.mock.calls).toEqual([["u1"], ["u2"]]);
+
+    off();
+    svc.notifyChanged("u3");
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/auth/access.service.ts
+++ b/apps/api/src/auth/access.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { EventEmitter } from "node:events";
+import { PrismaService } from "../prisma/prisma.service";
+import type { AuthUser } from "./auth-user";
+
+/** "all" for admins and unrestricted users; otherwise the visible server ids. */
+export type AllowedServers = "all" | Set<string>;
+
+/**
+ * Per-user server/cluster visibility (GH #73).
+ *
+ * Admins see everything. A non-admin user with `restricted` unset also sees
+ * everything (that is how every account behaved before this existed). A
+ * restricted user sees the servers granted directly plus every member of any
+ * cluster granted to them, so a cluster grant follows membership changes.
+ *
+ * Denials are 404s, not 403s: a restricted user should not be able to tell a
+ * server they cannot see apart from one that does not exist.
+ */
+@Injectable()
+export class AccessService {
+  private readonly bus = new EventEmitter();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** True when the user is exempt from per-server checks. */
+  static unrestricted(user: Pick<AuthUser, "role" | "restricted"> | undefined): boolean {
+    if (!user) return true;
+    const role = user.role ?? "admin";
+    return role === "admin" || !user.restricted;
+  }
+
+  async allowedServerIds(user: AuthUser | undefined): Promise<AllowedServers> {
+    if (AccessService.unrestricted(user)) return "all";
+    const [direct, clusters] = await Promise.all([
+      this.prisma.userServerAccess.findMany({
+        where: { userId: user!.sub },
+        select: { serverId: true },
+      }),
+      this.prisma.userClusterAccess.findMany({
+        where: { userId: user!.sub },
+        select: { clusterId: true },
+      }),
+    ]);
+    const ids = new Set(direct.map((d) => d.serverId));
+    if (clusters.length > 0) {
+      const members = await this.prisma.server.findMany({
+        where: { clusterId: { in: clusters.map((c) => c.clusterId) } },
+        select: { id: true },
+      });
+      for (const m of members) ids.add(m.id);
+    }
+    return ids;
+  }
+
+  /** Cluster ids granted directly (NOT clusters merely containing a visible server). */
+  async grantedClusterIds(user: AuthUser | undefined): Promise<"all" | Set<string>> {
+    if (AccessService.unrestricted(user)) return "all";
+    const rows = await this.prisma.userClusterAccess.findMany({
+      where: { userId: user!.sub },
+      select: { clusterId: true },
+    });
+    return new Set(rows.map((r) => r.clusterId));
+  }
+
+  async canSeeServer(user: AuthUser | undefined, serverId: string): Promise<boolean> {
+    const allowed = await this.allowedServerIds(user);
+    return allowed === "all" || allowed.has(serverId);
+  }
+
+  /**
+   * A cluster is usable when granted directly or when every member is visible.
+   * A cluster with one visible member is still LISTED (for context) but cluster-
+   * wide actions (start/stop all, membership, delete) need full access.
+   */
+  async canUseCluster(user: AuthUser | undefined, clusterId: string): Promise<boolean> {
+    if (AccessService.unrestricted(user)) return true;
+    const granted = await this.grantedClusterIds(user);
+    if (granted !== "all" && granted.has(clusterId)) return true;
+    const cluster = await this.prisma.cluster.findUnique({
+      where: { id: clusterId },
+      select: { servers: { select: { id: true } } },
+    });
+    if (!cluster) return false;
+    const allowed = await this.allowedServerIds(user);
+    return allowed === "all" || cluster.servers.every((s) => allowed.has(s.id));
+  }
+
+  async assertServer(user: AuthUser | undefined, serverId: string): Promise<void> {
+    if (!(await this.canSeeServer(user, serverId))) {
+      throw new NotFoundException(`Server ${serverId} not found`);
+    }
+  }
+
+  async assertServers(user: AuthUser | undefined, serverIds: string[]): Promise<void> {
+    const allowed = await this.allowedServerIds(user);
+    if (allowed === "all") return;
+    const missing = serverIds.find((id) => !allowed.has(id));
+    if (missing) throw new NotFoundException(`Server ${missing} not found`);
+  }
+
+  async assertCluster(user: AuthUser | undefined, clusterId: string): Promise<void> {
+    if (!(await this.canUseCluster(user, clusterId))) {
+      throw new NotFoundException(`Cluster ${clusterId} not found`);
+    }
+  }
+
+  /** Narrow a list of server-bearing rows to what the user may see. */
+  filterByServer<T extends { serverId: string | null }>(rows: T[], allowed: AllowedServers): T[] {
+    return allowed === "all" ? rows : rows.filter((r) => r.serverId !== null && allowed.has(r.serverId));
+  }
+
+  // ── Change notifications (the realtime gateway re-scopes open sockets) ─────
+
+  /** Fired with the userId whenever an admin edits that user's access. */
+  onChanged(listener: (userId: string) => void): () => void {
+    this.bus.on("changed", listener);
+    return () => this.bus.off("changed", listener);
+  }
+
+  notifyChanged(userId: string): void {
+    this.bus.emit("changed", userId);
+  }
+}

--- a/apps/api/src/auth/auth-user.ts
+++ b/apps/api/src/auth/auth-user.ts
@@ -1,0 +1,16 @@
+import type { Role } from "@ark/shared";
+
+/**
+ * What JwtAuthGuard leaves on `req.user` (and the realtime gateway on
+ * `socket.data.user`): the JWT claims plus the DB-backed `restricted` flag, which
+ * is looked up per request (alongside tokenVersion) so an admin's access edits
+ * apply immediately instead of at the next login.
+ */
+export interface AuthUser {
+  sub: string;
+  username?: string;
+  /** Legacy single-admin tokens carry no role and count as admin. */
+  role?: Role;
+  ver: number;
+  restricted: boolean;
+}

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,9 +1,11 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, Post, UseGuards } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { Public } from "./public.decorator";
 import { MinRole } from "./min-role.decorator";
 import { AuthThrottlerGuard } from "./auth-throttler.guard";
 import { FirstRunBody, LoginBody } from "./auth.dto";
+import { CurrentUser } from "./current-user.decorator";
+import type { AuthUser } from "./auth-user";
 
 @Controller("auth")
 export class AuthController {
@@ -30,16 +32,16 @@ export class AuthController {
     return this.auth.login(body);
   }
 
-  /** Who am I — username + role for the web UI's gating. */
+  /** Who am I — username, role and server access for the web UI's gating. */
   @Get("me")
-  me(@Req() req: { user: { sub: string; username?: string; role?: string } }) {
-    return { id: req.user.sub, username: req.user.username ?? "", role: req.user.role ?? "admin" };
+  me(@CurrentUser() user: AuthUser) {
+    return this.auth.me(user.sub);
   }
 
   /** Invalidate every outstanding token for the calling user (bumps tokenVersion). */
   @MinRole("viewer") // self-service — every role may log itself out everywhere
   @Post("logout-all")
-  logoutAll(@Req() req: { user: { sub: string } }) {
-    return this.auth.logoutAll(req.user.sub);
+  logoutAll(@CurrentUser() user: AuthUser) {
+    return this.auth.logoutAll(user.sub);
   }
 }

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -7,6 +7,8 @@ import { UsersController } from "./users.controller";
 import { AuthService } from "./auth.service";
 import { JwtAuthGuard } from "./jwt-auth.guard";
 import { RolesGuard } from "./roles.guard";
+import { ServerAccessGuard } from "./server-access.guard";
+import { AccessService } from "./access.service";
 import { AuthThrottlerGuard } from "./auth-throttler.guard";
 import { loadEnv } from "../config/env";
 
@@ -23,13 +25,17 @@ import { loadEnv } from "../config/env";
   controllers: [AuthController, UsersController],
   providers: [
     AuthService,
+    AccessService,
     AuthThrottlerGuard,
     // Protect every route by default; opt out with @Public(). RolesGuard layers
     // on top (registration order matters — it reads req.user set by the JWT guard):
     // GET = any role, mutations = operator+, @MinRole overrides per route.
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
+    // Per-user server/cluster scoping (GH #73), after roles so a viewer's
+    // forbidden mutation is still reported as a role problem, not a 404.
+    { provide: APP_GUARD, useClass: ServerAccessGuard },
   ],
-  exports: [AuthService],
+  exports: [AuthService, AccessService],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/auth.service.test.ts
+++ b/apps/api/src/auth/auth.service.test.ts
@@ -10,7 +10,7 @@ function makeService(users: Record<string, { tokenVersion: number }>) {
     user: {
       findUnique: async ({ where }: { where: { id: string } }) => {
         const user = users[where.id];
-        return user ? { tokenVersion: user.tokenVersion } : null;
+        return user ? { tokenVersion: user.tokenVersion, restricted: false } : null;
       },
       update: async ({ where }: { where: { id: string } }) => {
         const user = users[where.id]!;
@@ -20,7 +20,7 @@ function makeService(users: Record<string, { tokenVersion: number }>) {
     },
   };
   const jwt = new JwtService({ secret: "test-secret" });
-  return new AuthService(prisma as never, jwt, {} as never);
+  return new AuthService(prisma as never, jwt, {} as never, {} as never);
 }
 
 describe("token revocation (tokenVersion)", () => {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -177,25 +177,29 @@ export class AuthService {
     const role = (access.role ?? current.role) as Role;
     if (current.role === "admin" && role !== "admin") await this.assertAnotherAdmin(id);
 
+    // Admins are never restricted: promoting to admin clears the flag and
+    // grants so nothing stale lingers if they are later demoted.
+    const isAdmin = role === "admin";
+    const serverIds = isAdmin ? [] : access.serverIds;
+    const clusterIds = isAdmin ? [] : access.clusterIds;
+    const restricted = isAdmin ? false : access.restricted;
+
     const user = await this.prisma.$transaction(async (tx) => {
-      if (access.serverIds) {
+      if (serverIds) {
         await tx.userServerAccess.deleteMany({ where: { userId: id } });
         await tx.userServerAccess.createMany({
-          data: [...new Set(access.serverIds)].map((serverId) => ({ userId: id, serverId })),
+          data: [...new Set(serverIds)].map((serverId) => ({ userId: id, serverId })),
         });
       }
-      if (access.clusterIds) {
+      if (clusterIds) {
         await tx.userClusterAccess.deleteMany({ where: { userId: id } });
         await tx.userClusterAccess.createMany({
-          data: [...new Set(access.clusterIds)].map((clusterId) => ({ userId: id, clusterId })),
+          data: [...new Set(clusterIds)].map((clusterId) => ({ userId: id, clusterId })),
         });
       }
       return tx.user.update({
         where: { id },
-        data: {
-          role,
-          ...(access.restricted !== undefined ? { restricted: access.restricted } : {}),
-        },
+        data: { role, ...(restricted !== undefined ? { restricted } : {}) },
         select: AuthService.USER_SELECT,
       });
     });
@@ -207,8 +211,10 @@ export class AuthService {
     const count = await this.prisma.user.count();
     if (count <= 1) throw new BadRequestException("Cannot delete the last user");
     const target = await this.prisma.user.findUnique({ where: { id }, select: { role: true } });
-    if (target?.role === "admin") await this.assertAnotherAdmin(id);
+    if (!target) throw new NotFoundException("User not found");
+    if (target.role === "admin") await this.assertAnotherAdmin(id);
     await this.prisma.user.delete({ where: { id } });
+    this.access.notifyChanged(id);
     return { ok: true };
   }
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,13 +1,15 @@
 import {
   BadRequestException,
   Injectable,
+  NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import * as bcrypt from "bcryptjs";
-import type { FirstRunDto, LoginDto } from "@ark/shared";
+import type { FirstRunDto, LoginDto, Role, UserAccessDto, UserDto } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { ManagerSettingsService, SettingKeys } from "../manager-settings/manager-settings.service";
+import { AccessService } from "./access.service";
 
 @Injectable()
 export class AuthService {
@@ -15,6 +17,7 @@ export class AuthService {
     private readonly prisma: PrismaService,
     private readonly jwt: JwtService,
     private readonly settings: ManagerSettingsService,
+    private readonly access: AccessService,
   ) {}
 
   async status(): Promise<{ initialized: boolean }> {
@@ -56,12 +59,23 @@ export class AuthService {
 
   /** Reject tokens whose `ver` claim no longer matches the user's tokenVersion. */
   async isTokenCurrent(sub: unknown, ver: unknown): Promise<boolean> {
-    if (typeof sub !== "string" || typeof ver !== "number") return false;
+    return (await this.resolveToken(sub, ver)) !== null;
+  }
+
+  /**
+   * The per-request user lookup: null when the token is revoked or the user is
+   * gone, otherwise the DB-backed bits the guards need. `restricted` rides along
+   * so per-server access (GH #73) is read fresh on every request rather than
+   * frozen into the JWT at login.
+   */
+  async resolveToken(sub: unknown, ver: unknown): Promise<{ restricted: boolean } | null> {
+    if (typeof sub !== "string" || typeof ver !== "number") return null;
     const user = await this.prisma.user.findUnique({
       where: { id: sub },
-      select: { tokenVersion: true },
+      select: { tokenVersion: true, restricted: true },
     });
-    return user !== null && user.tokenVersion === ver;
+    if (user === null || user.tokenVersion !== ver) return null;
+    return { restricted: user.restricted };
   }
 
   /** Invalidate every outstanding token for this user. */
@@ -80,29 +94,127 @@ export class AuthService {
     );
   }
 
-  // ── User management (foundation for multi-user / RBAC) ─────────────────────
-  listUsers() {
-    return this.prisma.user.findMany({
-      select: { id: true, username: true, role: true, createdAt: true },
-      orderBy: { createdAt: "asc" },
-    });
+  // ── User management ────────────────────────────────────────────────────────
+
+  private static readonly USER_SELECT = {
+    id: true,
+    username: true,
+    role: true,
+    restricted: true,
+    createdAt: true,
+    serverAccess: { select: { serverId: true } },
+    clusterAccess: { select: { clusterId: true } },
+  } as const;
+
+  private static toDto(u: {
+    id: string;
+    username: string;
+    role: string;
+    restricted: boolean;
+    createdAt: Date;
+    serverAccess: { serverId: string }[];
+    clusterAccess: { clusterId: string }[];
+  }): UserDto {
+    return {
+      id: u.id,
+      username: u.username,
+      role: u.role as Role,
+      restricted: u.role !== "admin" && u.restricted,
+      serverIds: u.serverAccess.map((a) => a.serverId),
+      clusterIds: u.clusterAccess.map((a) => a.clusterId),
+      createdAt: u.createdAt.toISOString(),
+    };
   }
 
-  async createUser(username: string, password: string, role = "admin") {
+  async listUsers(): Promise<UserDto[]> {
+    const rows = await this.prisma.user.findMany({
+      select: AuthService.USER_SELECT,
+      orderBy: { createdAt: "asc" },
+    });
+    return rows.map(AuthService.toDto);
+  }
+
+  async me(id: string): Promise<UserDto> {
+    const row = await this.prisma.user.findUnique({ where: { id }, select: AuthService.USER_SELECT });
+    if (!row) throw new UnauthorizedException("Token revoked");
+    return AuthService.toDto(row);
+  }
+
+  async createUser(username: string, password: string, access: UserAccessDto = {}): Promise<UserDto> {
     if (!username || password.length < 8) {
       throw new BadRequestException("Username required and password must be 8+ chars");
     }
     const exists = await this.prisma.user.findUnique({ where: { username } });
     if (exists) throw new BadRequestException("Username already taken");
     const passwordHash = await bcrypt.hash(password, 12);
-    const user = await this.prisma.user.create({ data: { username, passwordHash, role } });
-    return { id: user.id, username: user.username, role: user.role };
+    // Least privilege by default: an omitted role used to mean admin.
+    const role: Role = access.role ?? "operator";
+    const restricted = role !== "admin" && (access.restricted ?? false);
+    const user = await this.prisma.user.create({
+      data: {
+        username,
+        passwordHash,
+        role,
+        restricted,
+        serverAccess: { create: (restricted ? access.serverIds ?? [] : []).map((serverId) => ({ serverId })) },
+        clusterAccess: {
+          create: (restricted ? access.clusterIds ?? [] : []).map((clusterId) => ({ clusterId })),
+        },
+      },
+      select: AuthService.USER_SELECT,
+    });
+    return AuthService.toDto(user);
+  }
+
+  /**
+   * Edit role and/or per-server access (GH #73). Omitted fields are left alone;
+   * `serverIds`/`clusterIds`, when present, REPLACE the existing grants. Refuses
+   * to leave the panel without an unrestricted admin.
+   */
+  async updateUser(id: string, access: UserAccessDto): Promise<UserDto> {
+    const current = await this.prisma.user.findUnique({ where: { id }, select: { role: true } });
+    if (!current) throw new NotFoundException("User not found");
+    const role = (access.role ?? current.role) as Role;
+    if (current.role === "admin" && role !== "admin") await this.assertAnotherAdmin(id);
+
+    const user = await this.prisma.$transaction(async (tx) => {
+      if (access.serverIds) {
+        await tx.userServerAccess.deleteMany({ where: { userId: id } });
+        await tx.userServerAccess.createMany({
+          data: [...new Set(access.serverIds)].map((serverId) => ({ userId: id, serverId })),
+        });
+      }
+      if (access.clusterIds) {
+        await tx.userClusterAccess.deleteMany({ where: { userId: id } });
+        await tx.userClusterAccess.createMany({
+          data: [...new Set(access.clusterIds)].map((clusterId) => ({ userId: id, clusterId })),
+        });
+      }
+      return tx.user.update({
+        where: { id },
+        data: {
+          role,
+          ...(access.restricted !== undefined ? { restricted: access.restricted } : {}),
+        },
+        select: AuthService.USER_SELECT,
+      });
+    });
+    this.access.notifyChanged(id);
+    return AuthService.toDto(user);
   }
 
   async deleteUser(id: string) {
     const count = await this.prisma.user.count();
     if (count <= 1) throw new BadRequestException("Cannot delete the last user");
+    const target = await this.prisma.user.findUnique({ where: { id }, select: { role: true } });
+    if (target?.role === "admin") await this.assertAnotherAdmin(id);
     await this.prisma.user.delete({ where: { id } });
     return { ok: true };
+  }
+
+  /** Someone other than `exceptId` must remain an admin, or nobody could manage users. */
+  private async assertAnotherAdmin(exceptId: string): Promise<void> {
+    const others = await this.prisma.user.count({ where: { role: "admin", id: { not: exceptId } } });
+    if (others === 0) throw new BadRequestException("At least one admin must remain");
   }
 }

--- a/apps/api/src/auth/current-user.decorator.ts
+++ b/apps/api/src/auth/current-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import type { AuthUser } from "./auth-user";
+
+/** The authenticated caller, as populated by JwtAuthGuard. */
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuthUser =>
+    ctx.switchToHttp().getRequest<{ user: AuthUser }>().user,
+);

--- a/apps/api/src/auth/jwt-auth.guard.ts
+++ b/apps/api/src/auth/jwt-auth.guard.ts
@@ -8,10 +8,11 @@ import { Reflector } from "@nestjs/core";
 import { JwtService } from "@nestjs/jwt";
 import { IS_PUBLIC_KEY } from "./public.decorator";
 import { AuthService } from "./auth.service";
+import type { AuthUser } from "./auth-user";
 
 interface RequestLike {
   headers: Record<string, string | undefined>;
-  user?: unknown;
+  user?: AuthUser;
 }
 
 @Injectable()
@@ -39,10 +40,9 @@ export class JwtAuthGuard implements CanActivate {
     } catch {
       throw new UnauthorizedException("Invalid or expired token");
     }
-    if (!(await this.auth.isTokenCurrent(payload.sub, payload.ver))) {
-      throw new UnauthorizedException("Token revoked");
-    }
-    req.user = payload;
+    const resolved = await this.auth.resolveToken(payload.sub, payload.ver);
+    if (!resolved) throw new UnauthorizedException("Token revoked");
+    req.user = { ...(payload as unknown as AuthUser), restricted: resolved.restricted };
     return true;
   }
 }

--- a/apps/api/src/auth/server-access.guard.test.ts
+++ b/apps/api/src/auth/server-access.guard.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { ForbiddenException, NotFoundException } from "@nestjs/common";
+import { ServerAccessGuard } from "./server-access.guard";
+import type { AuthUser } from "./auth-user";
+
+// Per-user scoping from the route template alone (GH #73): `servers/:id`
+// routes check the server, `clusters/:id` routes check the cluster, and
+// restricted users may never create servers. Everything else is left to the
+// handlers, which check with AccessService themselves.
+interface Options {
+  method: string;
+  /** Express route template as the app sees it, e.g. "/api/servers/:id/start". */
+  path: string;
+  params?: Record<string, string>;
+  user?: Partial<AuthUser> | null;
+  isPublic?: boolean;
+  /** Server/cluster ids the fake AccessService should deny. */
+  deny?: string[];
+}
+
+function makeContext(opts: Options) {
+  const reflector = {
+    getAllAndOverride: (key: string) => (key === "isPublic" ? (opts.isPublic ?? false) : undefined),
+  };
+  const calls: string[] = [];
+  const deny = new Set(opts.deny ?? []);
+  const access = {
+    assertServer: async (_user: AuthUser | undefined, id: string) => {
+      calls.push(`server:${id}`);
+      if (deny.has(id)) throw new NotFoundException(`Server ${id} not found`);
+    },
+    assertCluster: async (_user: AuthUser | undefined, id: string) => {
+      calls.push(`cluster:${id}`);
+      if (deny.has(id)) throw new NotFoundException(`Cluster ${id} not found`);
+    },
+  };
+  const user: AuthUser | undefined =
+    opts.user === null
+      ? undefined
+      : { sub: "u1", ver: 0, role: "operator", restricted: true, ...opts.user };
+  const context = {
+    getHandler: () => undefined,
+    getClass: () => undefined,
+    switchToHttp: () => ({
+      getRequest: () => ({
+        method: opts.method,
+        user,
+        params: opts.params ?? {},
+        route: { path: opts.path },
+      }),
+    }),
+  };
+  const guard = new ServerAccessGuard(reflector as never, access as never);
+  return { run: () => guard.canActivate(context as never), calls };
+}
+
+describe("ServerAccessGuard bypasses", () => {
+  it("@Public routes skip the check entirely", async () => {
+    const { run, calls } = makeContext({
+      method: "POST",
+      path: "/api/servers/:id/start",
+      params: { id: "s1" },
+      isPublic: true,
+      deny: ["s1"],
+    });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("admins never trigger a check, even with restricted=true", async () => {
+    const { run, calls } = makeContext({
+      method: "POST",
+      path: "/api/servers/:id/start",
+      params: { id: "s1" },
+      user: { role: "admin", restricted: true },
+      deny: ["s1"],
+    });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("legacy tokens without a role count as admin", async () => {
+    const { run, calls } = makeContext({
+      method: "POST",
+      path: "/api/servers",
+      user: { role: undefined, restricted: true },
+    });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("an unrestricted operator never triggers a check", async () => {
+    const { run, calls } = makeContext({
+      method: "DELETE",
+      path: "/api/servers/:id",
+      params: { id: "s1" },
+      user: { role: "operator", restricted: false },
+      deny: ["s1"],
+    });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("ServerAccessGuard for a restricted user", () => {
+  it("checks the server on /api/servers/:id/action", async () => {
+    const { run, calls } = makeContext({ method: "POST", path: "/api/servers/:id/start", params: { id: "s1" } });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual(["server:s1"]);
+  });
+
+  it("checks the server on the bare /api/servers/:id", async () => {
+    const { run, calls } = makeContext({ method: "GET", path: "/api/servers/:id", params: { id: "s1" } });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual(["server:s1"]);
+  });
+
+  it("accepts templates without the /api prefix", async () => {
+    const { run, calls } = makeContext({ method: "GET", path: "/servers/:id", params: { id: "s1" } });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual(["server:s1"]);
+  });
+
+  it("checks the cluster on /api/clusters/:id/action", async () => {
+    const { run, calls } = makeContext({ method: "POST", path: "/api/clusters/:id/start", params: { id: "c1" } });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual(["cluster:c1"]);
+  });
+
+  it("does not check routes without an :id (servers/stats)", async () => {
+    const { run, calls } = makeContext({ method: "GET", path: "/api/servers/stats" });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("leaves non-server routes with an :id to their handlers (schedules)", async () => {
+    const { run, calls } = makeContext({ method: "PATCH", path: "/api/schedules/:id", params: { id: "sch1" } });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("forbids creating servers (POST /servers and /servers/import)", async () => {
+    await expect(makeContext({ method: "POST", path: "/api/servers" }).run()).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    await expect(makeContext({ method: "POST", path: "/api/servers/import" }).run()).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it("allows listing servers with no check", async () => {
+    const { run, calls } = makeContext({ method: "GET", path: "/api/servers" });
+    expect(await run()).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("propagates a denied assertServer as NotFoundException", async () => {
+    const { run, calls } = makeContext({
+      method: "POST",
+      path: "/api/servers/:id/stop",
+      params: { id: "s2" },
+      deny: ["s2"],
+    });
+    await expect(run()).rejects.toBeInstanceOf(NotFoundException);
+    expect(calls).toEqual(["server:s2"]);
+  });
+
+  it("propagates a denied assertCluster as NotFoundException", async () => {
+    const { run } = makeContext({ method: "DELETE", path: "/api/clusters/:id", params: { id: "c2" }, deny: ["c2"] });
+    await expect(run()).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
+describe("ServerAccessGuard.normalize", () => {
+  it("strips only a leading /api segment", () => {
+    expect(ServerAccessGuard.normalize("/api/servers/:id")).toBe("/servers/:id");
+    expect(ServerAccessGuard.normalize("/api")).toBe("");
+    expect(ServerAccessGuard.normalize("/servers/:id")).toBe("/servers/:id");
+    expect(ServerAccessGuard.normalize("/apix/servers")).toBe("/apix/servers");
+    expect(ServerAccessGuard.normalize(undefined)).toBe("");
+  });
+});

--- a/apps/api/src/auth/server-access.guard.ts
+++ b/apps/api/src/auth/server-access.guard.ts
@@ -1,0 +1,63 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { IS_PUBLIC_KEY } from "./public.decorator";
+import { AccessService } from "./access.service";
+import type { AuthUser } from "./auth-user";
+
+interface RequestLike {
+  method: string;
+  user?: AuthUser;
+  params?: Record<string, string | undefined>;
+  /** Express route template, e.g. "/api/servers/:id/start". */
+  route?: { path?: string };
+}
+
+/** Route templates a restricted user may never call: they create servers
+ *  (consuming host ports/disk), which is an admin/unrestricted decision. */
+const CREATE_ROUTES = new Set(["/servers", "/servers/import"]);
+
+/**
+ * Per-user server/cluster scoping, layered after RolesGuard (GH #73).
+ *
+ * Handles the common case from the route template alone: anything under
+ * `servers/:id` checks the server, anything under `clusters/:id` checks the
+ * cluster. Routes that carry the server id elsewhere (schedules by body/query,
+ * `DELETE backups/:snapshotId`, cluster membership bodies, copy targets) and
+ * list endpoints do their own checks with AccessService + @CurrentUser().
+ */
+@Injectable()
+export class ServerAccessGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly access: AccessService,
+  ) {}
+
+  /** Strip the global prefix so tests and the app agree on the template. */
+  static normalize(template: string | undefined): string {
+    if (!template) return "";
+    return template.replace(/^\/api(?=\/|$)/, "");
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) return true;
+
+    const req = context.switchToHttp().getRequest<RequestLike>();
+    if (AccessService.unrestricted(req.user)) return true;
+
+    const path = ServerAccessGuard.normalize(req.route?.path);
+    if (req.method === "POST" && CREATE_ROUTES.has(path)) {
+      throw new ForbiddenException("Restricted users cannot create servers");
+    }
+    const id = req.params?.id;
+    if (id && (path === "/servers/:id" || path.startsWith("/servers/:id/"))) {
+      await this.access.assertServer(req.user, id);
+    } else if (id && (path === "/clusters/:id" || path.startsWith("/clusters/:id/"))) {
+      await this.access.assertCluster(req.user, id);
+    }
+    return true;
+  }
+}

--- a/apps/api/src/auth/users.controller.ts
+++ b/apps/api/src/auth/users.controller.ts
@@ -1,13 +1,20 @@
-import { Body, Controller, Delete, Get, Param, Post } from "@nestjs/common";
-import { IsIn, IsOptional, IsString, MinLength } from "class-validator";
+import { Body, Controller, Delete, Get, Param, Patch, Post } from "@nestjs/common";
+import { IsArray, IsBoolean, IsIn, IsOptional, IsString, MinLength } from "class-validator";
 import { ROLES, type Role } from "@ark/shared";
 import { AuthService } from "./auth.service";
 import { MinRole } from "./min-role.decorator";
 
-class CreateUserBody {
+/** Role + per-server access (GH #73). Grants only matter when `restricted`. */
+class UserAccessBody {
+  @IsOptional() @IsIn(ROLES) role?: Role;
+  @IsOptional() @IsBoolean() restricted?: boolean;
+  @IsOptional() @IsArray() @IsString({ each: true }) serverIds?: string[];
+  @IsOptional() @IsArray() @IsString({ each: true }) clusterIds?: string[];
+}
+
+class CreateUserBody extends UserAccessBody {
   @IsString() username!: string;
   @IsString() @MinLength(8) password!: string;
-  @IsOptional() @IsIn(ROLES) role?: Role;
 }
 
 @MinRole("admin")
@@ -22,7 +29,13 @@ export class UsersController {
 
   @Post()
   create(@Body() body: CreateUserBody) {
-    return this.auth.createUser(body.username, body.password, body.role);
+    const { username, password, ...access } = body;
+    return this.auth.createUser(username, password, access);
+  }
+
+  @Patch(":id")
+  update(@Param("id") id: string, @Body() body: UserAccessBody) {
+    return this.auth.updateUser(id, body);
   }
 
   @Delete(":id")

--- a/apps/api/src/auth/users.test.ts
+++ b/apps/api/src/auth/users.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi } from "vitest";
+import { BadRequestException, UnauthorizedException } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { AuthService } from "./auth.service";
+
+// AuthService user management (GH #73): role defaults to operator, admins are
+// never restricted, grants are replaced wholesale on update, and the panel can
+// never be left without an admin.
+interface Row {
+  id: string;
+  username: string;
+  role: string;
+  restricted: boolean;
+  passwordHash?: string;
+  tokenVersion?: number;
+  createdAt?: Date;
+}
+
+function makeService(seed: Row[] = [], grants: { servers?: [string, string][]; clusters?: [string, string][] } = {}) {
+  let nextId = 1;
+  const users: Required<Row>[] = seed.map((r) => ({
+    passwordHash: "x",
+    tokenVersion: 0,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    ...r,
+  }));
+  const serverAccess = (grants.servers ?? []).map(([userId, serverId]) => ({ userId, serverId }));
+  const clusterAccess = (grants.clusters ?? []).map(([userId, clusterId]) => ({ userId, clusterId }));
+
+  const joined = (u: Required<Row>) => ({
+    ...u,
+    serverAccess: serverAccess.filter((a) => a.userId === u.id).map(({ serverId }) => ({ serverId })),
+    clusterAccess: clusterAccess.filter((a) => a.userId === u.id).map(({ clusterId }) => ({ clusterId })),
+  });
+  const find = (where: { id?: string; username?: string }) =>
+    users.find((u) => (where.id !== undefined ? u.id === where.id : u.username === where.username));
+
+  const prisma = {
+    user: {
+      findMany: async () => users.map(joined),
+      findUnique: async ({ where }: { where: { id?: string; username?: string } }) => {
+        const u = find(where);
+        return u ? joined(u) : null;
+      },
+      count: async (args?: { where?: { role?: string; id?: { not: string } } }) =>
+        users.filter(
+          (u) =>
+            (args?.where?.role === undefined || u.role === args.where.role) &&
+            (args?.where?.id === undefined || u.id !== args.where.id.not),
+        ).length,
+      create: async ({
+        data,
+      }: {
+        data: {
+          username: string;
+          passwordHash: string;
+          role: string;
+          restricted: boolean;
+          serverAccess: { create: { serverId: string }[] };
+          clusterAccess: { create: { clusterId: string }[] };
+        };
+      }) => {
+        const u: Required<Row> = {
+          id: `u${nextId++}`,
+          username: data.username,
+          passwordHash: data.passwordHash,
+          role: data.role,
+          restricted: data.restricted,
+          tokenVersion: 0,
+          createdAt: new Date("2026-02-02T00:00:00Z"),
+        };
+        users.push(u);
+        for (const { serverId } of data.serverAccess.create) serverAccess.push({ userId: u.id, serverId });
+        for (const { clusterId } of data.clusterAccess.create) clusterAccess.push({ userId: u.id, clusterId });
+        return joined(u);
+      },
+      update: async ({ where, data }: { where: { id: string }; data: { role?: string; restricted?: boolean } }) => {
+        const u = find(where)!;
+        if (data.role !== undefined) u.role = data.role;
+        if (data.restricted !== undefined) u.restricted = data.restricted;
+        return joined(u);
+      },
+      delete: async ({ where }: { where: { id: string } }) => {
+        const idx = users.findIndex((u) => u.id === where.id);
+        return users.splice(idx, 1)[0];
+      },
+    },
+    userServerAccess: {
+      deleteMany: async ({ where }: { where: { userId: string } }) => {
+        for (let i = serverAccess.length - 1; i >= 0; i--) if (serverAccess[i]!.userId === where.userId) serverAccess.splice(i, 1);
+      },
+      createMany: async ({ data }: { data: { userId: string; serverId: string }[] }) => {
+        serverAccess.push(...data);
+      },
+    },
+    userClusterAccess: {
+      deleteMany: async ({ where }: { where: { userId: string } }) => {
+        for (let i = clusterAccess.length - 1; i >= 0; i--) if (clusterAccess[i]!.userId === where.userId) clusterAccess.splice(i, 1);
+      },
+      createMany: async ({ data }: { data: { userId: string; clusterId: string }[] }) => {
+        clusterAccess.push(...data);
+      },
+    },
+    $transaction: <T>(fn: (tx: unknown) => Promise<T>) => fn(prisma),
+  };
+  const access = { notifyChanged: vi.fn() };
+  const svc = new AuthService(prisma as never, new JwtService({ secret: "t" }), {} as never, access as never);
+  return { svc, access, users, serverAccess, clusterAccess };
+}
+
+const admin = (id = "a1"): Row => ({ id, username: id, role: "admin", restricted: false });
+const operator = (id = "o1"): Row => ({ id, username: id, role: "operator", restricted: false });
+
+describe("AuthService.createUser", () => {
+  it("defaults the role to operator and stores a bcrypt hash", async () => {
+    const { svc, users } = makeService([admin()]);
+    const dto = await svc.createUser("bob", "password123");
+    expect(dto).toMatchObject({ username: "bob", role: "operator", restricted: false, serverIds: [], clusterIds: [] });
+    expect(dto.createdAt).toBe("2026-02-02T00:00:00.000Z");
+    const row = users.find((u) => u.username === "bob")!;
+    expect(row.passwordHash).toMatch(/^\$2[aby]\$12\$/);
+  });
+
+  it("ignores restricted and grants when creating an admin", async () => {
+    const { svc, users, serverAccess, clusterAccess } = makeService([admin()]);
+    const dto = await svc.createUser("root2", "password123", {
+      role: "admin",
+      restricted: true,
+      serverIds: ["s1"],
+      clusterIds: ["c1"],
+    });
+    expect(dto).toMatchObject({ role: "admin", restricted: false, serverIds: [], clusterIds: [] });
+    expect(users.find((u) => u.username === "root2")!.restricted).toBe(false);
+    expect(serverAccess).toEqual([]);
+    expect(clusterAccess).toEqual([]);
+  });
+
+  it("stores grants for a restricted user", async () => {
+    const { svc, serverAccess, clusterAccess } = makeService([admin()]);
+    const dto = await svc.createUser("carol", "password123", {
+      role: "viewer",
+      restricted: true,
+      serverIds: ["s1", "s2"],
+      clusterIds: ["c1"],
+    });
+    expect(dto).toMatchObject({ role: "viewer", restricted: true, serverIds: ["s1", "s2"], clusterIds: ["c1"] });
+    expect(serverAccess.map((a) => a.serverId)).toEqual(["s1", "s2"]);
+    expect(clusterAccess.map((a) => a.clusterId)).toEqual(["c1"]);
+  });
+
+  it("rejects short passwords, empty usernames and duplicates without hashing", async () => {
+    const { svc } = makeService([admin()]);
+    await expect(svc.createUser("x", "short")).rejects.toBeInstanceOf(BadRequestException);
+    await expect(svc.createUser("", "password123")).rejects.toBeInstanceOf(BadRequestException);
+    await expect(svc.createUser("a1", "password123")).rejects.toBeInstanceOf(BadRequestException);
+  });
+});
+
+describe("AuthService.updateUser", () => {
+  it("replaces grants wholesale, dedupes ids and notifies AccessService", async () => {
+    const { svc, access, serverAccess, clusterAccess } = makeService([admin(), operator()], {
+      servers: [["o1", "old"], ["a1", "keep"]],
+      clusters: [["o1", "oldc"]],
+    });
+    const dto = await svc.updateUser("o1", { restricted: true, serverIds: ["s1", "s1", "s2"], clusterIds: ["c1", "c1"] });
+    expect(dto).toMatchObject({ restricted: true, serverIds: ["s1", "s2"], clusterIds: ["c1"] });
+    expect(serverAccess).toEqual([
+      { userId: "a1", serverId: "keep" },
+      { userId: "o1", serverId: "s1" },
+      { userId: "o1", serverId: "s2" },
+    ]);
+    expect(clusterAccess).toEqual([{ userId: "o1", clusterId: "c1" }]);
+    expect(access.notifyChanged).toHaveBeenCalledWith("o1");
+  });
+
+  it("leaves grants alone when serverIds/clusterIds are omitted", async () => {
+    const { svc, serverAccess } = makeService([admin(), operator()], { servers: [["o1", "s1"]] });
+    const dto = await svc.updateUser("o1", { role: "viewer" });
+    expect(dto).toMatchObject({ role: "viewer", serverIds: ["s1"] });
+    expect(serverAccess).toEqual([{ userId: "o1", serverId: "s1" }]);
+  });
+
+  it("refuses to demote the only admin", async () => {
+    const { svc, access, users } = makeService([admin(), operator()]);
+    await expect(svc.updateUser("a1", { role: "operator" })).rejects.toBeInstanceOf(BadRequestException);
+    expect(users.find((u) => u.id === "a1")!.role).toBe("admin");
+    expect(access.notifyChanged).not.toHaveBeenCalled();
+  });
+
+  it("demotes an admin when another admin remains", async () => {
+    const { svc, users } = makeService([admin("a1"), admin("a2")]);
+    const dto = await svc.updateUser("a1", { role: "operator" });
+    expect(dto.role).toBe("operator");
+    expect(users.find((u) => u.id === "a1")!.role).toBe("operator");
+  });
+
+  it("404s an unknown user", async () => {
+    const { svc } = makeService([admin()]);
+    await expect(svc.updateUser("ghost", { role: "viewer" })).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("AuthService.deleteUser", () => {
+  it("refuses to delete the last user", async () => {
+    const { svc, users } = makeService([admin()]);
+    await expect(svc.deleteUser("a1")).rejects.toBeInstanceOf(BadRequestException);
+    expect(users).toHaveLength(1);
+  });
+
+  it("refuses to delete the only admin", async () => {
+    const { svc, users } = makeService([admin(), operator()]);
+    await expect(svc.deleteUser("a1")).rejects.toBeInstanceOf(BadRequestException);
+    expect(users).toHaveLength(2);
+  });
+
+  it("deletes a non-admin and an admin who is not the last one", async () => {
+    const { svc, users } = makeService([admin("a1"), admin("a2"), operator()]);
+    expect(await svc.deleteUser("o1")).toEqual({ ok: true });
+    expect(await svc.deleteUser("a2")).toEqual({ ok: true });
+    expect(users.map((u) => u.id)).toEqual(["a1"]);
+  });
+});
+
+describe("AuthService.listUsers / me", () => {
+  it("reports restricted=false for admins even when the column is true", async () => {
+    const { svc } = makeService(
+      [
+        { id: "a1", username: "a1", role: "admin", restricted: true },
+        { id: "o1", username: "o1", role: "operator", restricted: true },
+      ],
+      { servers: [["a1", "s1"]] },
+    );
+    const list = await svc.listUsers();
+    expect(list.map((u) => [u.id, u.restricted])).toEqual([
+      ["a1", false],
+      ["o1", true],
+    ]);
+    // Stale grants on an admin row are still surfaced; only the flag is masked.
+    expect(list[0]!.serverIds).toEqual(["s1"]);
+    expect((await svc.me("a1")).restricted).toBe(false);
+  });
+
+  it("me() throws UnauthorizedException for an unknown id", async () => {
+    const { svc } = makeService([admin()]);
+    await expect(svc.me("ghost")).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+});

--- a/apps/api/src/backups/backups.controller.ts
+++ b/apps/api/src/backups/backups.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  NotFoundException,
   Param,
   Post,
   Res,
@@ -12,6 +13,10 @@ import {
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { BackupsService } from "./backups.service";
+import { PrismaService } from "../prisma/prisma.service";
+import { AccessService } from "../auth/access.service";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type { AuthUser } from "../auth/auth-user";
 
 // 1 GB cap — worlds are usually far smaller; huge modded Minecraft worlds may not fit.
 const UPLOAD = { limits: { fileSize: 1024 * 1024 * 1024 } };
@@ -24,7 +29,11 @@ interface HeaderSettable {
 
 @Controller()
 export class BackupsController {
-  constructor(private readonly backups: BackupsService) {}
+  constructor(
+    private readonly backups: BackupsService,
+    private readonly prisma: PrismaService,
+    private readonly access: AccessService,
+  ) {}
 
   @Get("servers/:id/backups")
   list(@Param("id") id: string) {
@@ -62,8 +71,16 @@ export class BackupsController {
     return this.backups.importSaves(id, file.originalname, file.buffer);
   }
 
+  /** Not under servers/:id, so the guard can't scope it: resolve the owning
+   *  server and check that (GH #73). */
   @Delete("backups/:snapshotId")
-  remove(@Param("snapshotId") snapshotId: string) {
+  async remove(@Param("snapshotId") snapshotId: string, @CurrentUser() user: AuthUser) {
+    const snap = await this.prisma.snapshot.findUnique({
+      where: { id: snapshotId },
+      select: { serverId: true },
+    });
+    if (!snap) throw new NotFoundException("Backup not found");
+    await this.access.assertServer(user, snap.serverId);
     return this.backups.remove(snapshotId);
   }
 }

--- a/apps/api/src/backups/backups.module.ts
+++ b/apps/api/src/backups/backups.module.ts
@@ -2,9 +2,10 @@ import { Module } from "@nestjs/common";
 import { BackupsService } from "./backups.service";
 import { BackupsController } from "./backups.controller";
 import { RconModule } from "../rcon/rcon.module";
+import { AuthModule } from "../auth/auth.module";
 
 @Module({
-  imports: [RconModule],
+  imports: [RconModule, AuthModule],
   controllers: [BackupsController],
   providers: [BackupsService],
   exports: [BackupsService],

--- a/apps/api/src/clusters/clusters-list-access.test.ts
+++ b/apps/api/src/clusters/clusters-list-access.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { ClustersService } from "./clusters.service";
+
+/**
+ * GET /clusters for a restricted user (GH #73): a cluster shows when granted
+ * directly or when any member is visible, and a partially visible cluster lists
+ * only the visible members so hidden servers don't leak by name.
+ */
+const clusters = [
+  {
+    id: "c-granted",
+    name: "Granted",
+    servers: [
+      { id: "g1", name: "G1" },
+      { id: "g2", name: "G2" },
+    ],
+  },
+  {
+    id: "c-partial",
+    name: "Partial",
+    servers: [
+      { id: "p1", name: "P1" },
+      { id: "p2", name: "P2" },
+    ],
+  },
+  { id: "c-hidden", name: "Hidden", servers: [{ id: "h1", name: "H1" }] },
+  { id: "c-empty", name: "Empty", servers: [] },
+];
+
+function make() {
+  const prisma = { cluster: { findMany: async () => clusters } };
+  return new ClustersService(prisma as never, {} as never, {} as never);
+}
+
+describe("ClustersService.list visibility (GH #73)", () => {
+  it("unrestricted callers get every cluster untouched", async () => {
+    expect(await make().list()).toBe(clusters);
+    expect(await make().list("all", new Set())).toBe(clusters);
+    expect(await make().list(new Set(), "all")).toBe(clusters);
+  });
+
+  it("granted clusters come back whole; partial ones lose hidden members; others vanish", async () => {
+    // Granted c-granted (so g1/g2 are in allowed via membership) plus p1 directly.
+    const out = await make().list(new Set(["g1", "g2", "p1"]), new Set(["c-granted"]));
+    expect(out.map((c) => c.id)).toEqual(["c-granted", "c-partial"]);
+    expect(out[0]?.servers.map((s) => s.id)).toEqual(["g1", "g2"]);
+    expect(out[1]?.servers.map((s) => s.id)).toEqual(["p1"]);
+  });
+
+  it("a restricted user with no grants sees nothing", async () => {
+    expect(await make().list(new Set(), new Set())).toEqual([]);
+  });
+
+  it("a directly granted cluster is listed even with no visible members computed", async () => {
+    // Defensive: grantedClusterIds and allowedServerIds are fetched separately.
+    const out = await make().list(new Set(), new Set(["c-empty"]));
+    expect(out.map((c) => c.id)).toEqual(["c-empty"]);
+  });
+});

--- a/apps/api/src/clusters/clusters.controller.ts
+++ b/apps/api/src/clusters/clusters.controller.ts
@@ -1,6 +1,9 @@
 import { Body, Controller, Delete, Get, Param, Post } from "@nestjs/common";
 import { IsOptional, IsString } from "class-validator";
 import { ClustersService } from "./clusters.service";
+import { AccessService } from "../auth/access.service";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type { AuthUser } from "../auth/auth-user";
 
 class CreateClusterBody {
   @IsString() name!: string;
@@ -12,11 +15,20 @@ class AddMemberBody {
 
 @Controller("clusters")
 export class ClustersController {
-  constructor(private readonly clusters: ClustersService) {}
+  constructor(
+    private readonly clusters: ClustersService,
+    private readonly access: AccessService,
+  ) {}
 
+  /** Restricted users (GH #73) see a cluster when it was granted to them or any
+   *  member is visible; a partially visible cluster lists only visible members. */
   @Get()
-  list() {
-    return this.clusters.list();
+  async list(@CurrentUser() user: AuthUser) {
+    const [allowed, granted] = await Promise.all([
+      this.access.allowedServerIds(user),
+      this.access.grantedClusterIds(user),
+    ]);
+    return this.clusters.list(allowed, granted);
   }
 
   @Get(":id")
@@ -29,13 +41,21 @@ export class ClustersController {
     return this.clusters.create(body.name, body.clusterId);
   }
 
+  // The guard checked the cluster (:id); the server comes by body/param so
+  // it gets its own check here.
   @Post(":id/members")
-  addMember(@Param("id") id: string, @Body() body: AddMemberBody) {
+  async addMember(@Param("id") id: string, @Body() body: AddMemberBody, @CurrentUser() user: AuthUser) {
+    await this.access.assertServer(user, body.serverId);
     return this.clusters.addMember(id, body.serverId);
   }
 
   @Delete(":id/members/:serverId")
-  removeMember(@Param("id") _id: string, @Param("serverId") serverId: string) {
+  async removeMember(
+    @Param("id") _id: string,
+    @Param("serverId") serverId: string,
+    @CurrentUser() user: AuthUser,
+  ) {
+    await this.access.assertServer(user, serverId);
     return this.clusters.removeMember(serverId);
   }
 

--- a/apps/api/src/clusters/clusters.module.ts
+++ b/apps/api/src/clusters/clusters.module.ts
@@ -2,9 +2,10 @@ import { Module } from "@nestjs/common";
 import { ClustersService } from "./clusters.service";
 import { ClustersController } from "./clusters.controller";
 import { ServersModule } from "../servers/servers.module";
+import { AuthModule } from "../auth/auth.module";
 
 @Module({
-  imports: [ServersModule],
+  imports: [ServersModule, AuthModule],
   controllers: [ClustersController],
   providers: [ClustersService],
   exports: [ClustersService],

--- a/apps/api/src/clusters/clusters.service.ts
+++ b/apps/api/src/clusters/clusters.service.ts
@@ -5,6 +5,7 @@ import { PrismaService } from "../prisma/prisma.service";
 import { EventsService } from "../events/events.service";
 import { ServersService } from "../servers/servers.service";
 import { HostPaths } from "../common/paths";
+import type { AllowedServers } from "../auth/access.service";
 
 function slugify(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "cluster";
@@ -40,10 +41,21 @@ export class ClustersService {
     return cluster;
   }
 
-  list() {
-    return this.prisma.cluster.findMany({
+  /**
+   * Every cluster, or for a restricted user (GH #73) the clusters granted to
+   * them plus any cluster with a visible member. A cluster the user can only
+   * partly see lists just its visible members, so hidden servers don't leak by name.
+   */
+  async list(allowed: AllowedServers = "all", granted: "all" | Set<string> = "all") {
+    const rows = await this.prisma.cluster.findMany({
       include: { servers: { select: { id: true, name: true, map: true, state: true, game: true } } },
       orderBy: { createdAt: "desc" },
+    });
+    if (allowed === "all" || granted === "all") return rows;
+    return rows.flatMap((c) => {
+      if (granted.has(c.id)) return [c];
+      const servers = c.servers.filter((s) => allowed.has(s.id));
+      return servers.length > 0 ? [{ ...c, servers }] : [];
     });
   }
 

--- a/apps/api/src/realtime/realtime.gateway.test.ts
+++ b/apps/api/src/realtime/realtime.gateway.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi } from "vitest";
+import { JwtService } from "@nestjs/jwt";
+import { RealtimeTopic, type RealtimeMessage } from "@ark/shared";
+import { AccessService } from "../auth/access.service";
+import type { AuthUser } from "../auth/auth-user";
+
+// The gateway decorator calls loadEnv() at import time; supply the required
+// secrets before the module is evaluated.
+vi.hoisted(() => {
+  process.env.SECRETS_KEY ??= "a".repeat(64);
+  process.env.JWT_SECRET ??= "test-jwt-secret-1234";
+});
+import { RealtimeGateway } from "./realtime.gateway";
+
+// GH #73: a restricted user's socket must only ever sit in `server:<id>` rooms
+// for servers they may see; unrestricted sockets sit in "all". The two sets are
+// disjoint, so broadcasting to "all" plus `server:<id>` never double-delivers.
+
+interface FakeSocket {
+  id: string;
+  data: { user?: AuthUser };
+  rooms: Set<string>;
+  disconnected: boolean;
+  join(room: string): void;
+  leave(room: string): void;
+  disconnect(close?: boolean): void;
+}
+
+function makeSocket(id: string, user?: AuthUser): FakeSocket {
+  const socket: FakeSocket = {
+    id,
+    data: { user },
+    rooms: new Set([id]),
+    disconnected: false,
+    join: (room) => void socket.rooms.add(room),
+    leave: (room) => void socket.rooms.delete(room),
+    disconnect: () => {
+      socket.disconnected = true;
+      socket.rooms.clear();
+    },
+  };
+  return socket;
+}
+
+function makeServer() {
+  const emitted: Array<{ room: string; event: string; payload: unknown }> = [];
+  const sockets = new Map<string, FakeSocket>();
+  return {
+    emitted,
+    sockets: { sockets },
+    to: (room: string) => ({
+      emit: (event: string, payload: unknown) => void emitted.push({ room, event, payload }),
+    }),
+    use: (_fn: unknown) => undefined,
+  };
+}
+
+/** Users keyed by id: tokenVersion + restricted flag, plus direct server grants
+ *  and cluster grants (the cluster→server mapping is `clusters`). */
+function makeGateway(opts: {
+  users: Record<string, { tokenVersion: number; restricted: boolean; role?: string }>;
+  serverGrants?: Record<string, string[]>;
+  clusterGrants?: Record<string, string[]>;
+  clusters?: Record<string, string[]>;
+}) {
+  const serverGrants = opts.serverGrants ?? {};
+  const clusterGrants = opts.clusterGrants ?? {};
+  const clusters = opts.clusters ?? {};
+  const prisma = {
+    userServerAccess: {
+      findMany: async ({ where }: { where: { userId: string } }) =>
+        (serverGrants[where.userId] ?? []).map((serverId) => ({ serverId })),
+    },
+    userClusterAccess: {
+      findMany: async ({ where }: { where: { userId: string } }) =>
+        (clusterGrants[where.userId] ?? []).map((clusterId) => ({ clusterId })),
+    },
+    server: {
+      findMany: async ({ where }: { where: { clusterId: { in: string[] } } }) =>
+        where.clusterId.in.flatMap((c) => (clusters[c] ?? []).map((id) => ({ id }))),
+    },
+  };
+  const access = new AccessService(prisma as never);
+  const auth = {
+    resolveToken: async (sub: unknown, ver: unknown) => {
+      const user = typeof sub === "string" ? opts.users[sub] : undefined;
+      if (!user || user.tokenVersion !== ver) return null;
+      return { restricted: user.restricted };
+    },
+  };
+  const jwt = new JwtService({ secret: process.env.JWT_SECRET });
+  const gateway = new RealtimeGateway(jwt, auth as never, access);
+  const server = makeServer();
+  gateway.server = server as never;
+  return { gateway, server, access, auth, jwt, users: opts.users, serverGrants };
+}
+
+const user = (sub: string, restricted: boolean, role = "operator"): AuthUser =>
+  ({ sub, username: sub, role, ver: 0, restricted }) as AuthUser;
+
+const scopeRooms = (s: FakeSocket) => [...s.rooms].filter((r) => r === "all" || r.startsWith("server:")).sort();
+
+describe("RealtimeGateway rooms", () => {
+  it("unrestricted socket joins only 'all'", async () => {
+    const { gateway } = makeGateway({ users: { u1: { tokenVersion: 0, restricted: false } } });
+    const socket = makeSocket("s1", user("u1", false));
+    await gateway.scope(socket as never);
+    expect(scopeRooms(socket)).toEqual(["all"]);
+  });
+
+  it("admins are unrestricted even with the flag set", async () => {
+    const { gateway } = makeGateway({ users: { a: { tokenVersion: 0, restricted: true, role: "admin" } } });
+    const socket = makeSocket("s1", user("a", true, "admin"));
+    await gateway.scope(socket as never);
+    expect(scopeRooms(socket)).toEqual(["all"]);
+  });
+
+  it("restricted socket joins exactly its server rooms (direct + cluster members), never 'all'", async () => {
+    const { gateway } = makeGateway({
+      users: { u1: { tokenVersion: 0, restricted: true } },
+      serverGrants: { u1: ["srv-a"] },
+      clusterGrants: { u1: ["c1"] },
+      clusters: { c1: ["srv-b", "srv-c"], c2: ["srv-z"] },
+    });
+    const socket = makeSocket("s1", user("u1", true));
+    await gateway.scope(socket as never);
+    expect(scopeRooms(socket)).toEqual(["server:srv-a", "server:srv-b", "server:srv-c"]);
+  });
+
+  it("restricted socket with no grants joins nothing", async () => {
+    const { gateway } = makeGateway({ users: { u1: { tokenVersion: 0, restricted: true } } });
+    const socket = makeSocket("s1", user("u1", true));
+    await gateway.scope(socket as never);
+    expect(scopeRooms(socket)).toEqual([]);
+  });
+});
+
+describe("RealtimeGateway.broadcast", () => {
+  it("server-scoped message goes to 'all' and 'server:<id>'", () => {
+    const { gateway, server } = makeGateway({ users: {} });
+    const message: RealtimeMessage = { topic: RealtimeTopic.ServerLog, serverId: "srv-a", payload: { line: "x" }, at: "now" };
+    gateway.broadcast(message);
+    expect(server.emitted).toEqual([
+      { room: "all", event: "message", payload: message },
+      { room: "server:srv-a", event: "message", payload: message },
+    ]);
+  });
+
+  it("global message (no serverId) goes only to 'all'", () => {
+    const { gateway, server } = makeGateway({ users: {} });
+    const message: RealtimeMessage = { topic: RealtimeTopic.Event, payload: {}, at: "now" };
+    gateway.broadcast(message);
+    expect(server.emitted).toEqual([{ room: "all", event: "message", payload: message }]);
+  });
+});
+
+describe("RealtimeGateway access changes", () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it("re-scopes a user's connected sockets when their grants change", async () => {
+    const { gateway, server, access, serverGrants } = makeGateway({
+      users: { u1: { tokenVersion: 0, restricted: true }, u2: { tokenVersion: 0, restricted: true } },
+      serverGrants: { u1: ["srv-a"], u2: ["srv-a"] },
+    });
+    const s1 = makeSocket("s1", user("u1", true));
+    const s2 = makeSocket("s2", user("u2", true));
+    server.sockets.sockets.set(s1.id, s1).set(s2.id, s2);
+    await gateway.scope(s1 as never);
+    await gateway.scope(s2 as never);
+
+    serverGrants.u1 = ["srv-b"];
+    access.notifyChanged("u1");
+    await flush();
+
+    expect(scopeRooms(s1)).toEqual(["server:srv-b"]); // left srv-a, joined srv-b
+    expect(scopeRooms(s2)).toEqual(["server:srv-a"]); // untouched
+    expect(s1.disconnected).toBe(false);
+  });
+
+  it("flipping restricted off moves the socket from server rooms to 'all'", async () => {
+    const { gateway, server, access, users } = makeGateway({
+      users: { u1: { tokenVersion: 0, restricted: true } },
+      serverGrants: { u1: ["srv-a"] },
+    });
+    const s1 = makeSocket("s1", user("u1", true));
+    server.sockets.sockets.set(s1.id, s1);
+    await gateway.scope(s1 as never);
+    expect(scopeRooms(s1)).toEqual(["server:srv-a"]);
+
+    users.u1!.restricted = false;
+    access.notifyChanged("u1");
+    await flush();
+
+    expect(scopeRooms(s1)).toEqual(["all"]);
+    expect(s1.data.user?.restricted).toBe(false);
+  });
+
+  it("disconnects a socket whose user no longer resolves (deleted / revoked)", async () => {
+    const { gateway, server, access, users } = makeGateway({
+      users: { u1: { tokenVersion: 0, restricted: false } },
+    });
+    const s1 = makeSocket("s1", user("u1", false));
+    server.sockets.sockets.set(s1.id, s1);
+    await gateway.scope(s1 as never);
+
+    delete users.u1;
+    access.notifyChanged("u1");
+    await flush();
+
+    expect(s1.disconnected).toBe(true);
+  });
+
+  it("stops listening after onModuleDestroy", async () => {
+    const { gateway, server, access, serverGrants } = makeGateway({
+      users: { u1: { tokenVersion: 0, restricted: true } },
+      serverGrants: { u1: ["srv-a"] },
+    });
+    const s1 = makeSocket("s1", user("u1", true));
+    server.sockets.sockets.set(s1.id, s1);
+    await gateway.scope(s1 as never);
+
+    gateway.onModuleDestroy();
+    serverGrants.u1 = ["srv-b"];
+    access.notifyChanged("u1");
+    await flush();
+
+    expect(scopeRooms(s1)).toEqual(["server:srv-a"]);
+  });
+});
+
+describe("RealtimeGateway handshake", () => {
+  type Middleware = (socket: { handshake: { auth?: { token?: string } }; data: Record<string, unknown> }, next: (err?: Error) => void) => Promise<void>;
+
+  async function handshake(gateway: RealtimeGateway, token: string | undefined) {
+    let middleware: Middleware | undefined;
+    gateway.afterInit({ use: (fn: Middleware) => void (middleware = fn) } as never);
+    const socket = { handshake: { auth: token ? { token } : {} }, data: {} as Record<string, unknown> };
+    const err = await new Promise<Error | undefined>((resolve) => void middleware!(socket, resolve));
+    return { err, socket };
+  }
+
+  it("stashes the resolved AuthUser on socket.data.user", async () => {
+    const { gateway, jwt } = makeGateway({ users: { u1: { tokenVersion: 2, restricted: true } } });
+    const token = await jwt.signAsync({ sub: "u1", username: "jo", role: "operator", ver: 2 });
+    const { err, socket } = await handshake(gateway, token);
+    expect(err).toBeUndefined();
+    expect(socket.data.user).toMatchObject({ sub: "u1", username: "jo", role: "operator", ver: 2, restricted: true });
+  });
+
+  it("rejects missing, stale, and unknown-user tokens", async () => {
+    const { gateway, jwt } = makeGateway({ users: { u1: { tokenVersion: 2, restricted: false } } });
+    expect((await handshake(gateway, undefined)).err?.message).toBe("unauthorized");
+    const stale = await jwt.signAsync({ sub: "u1", ver: 1 });
+    expect((await handshake(gateway, stale)).err?.message).toBe("unauthorized");
+    const ghost = await jwt.signAsync({ sub: "nobody", ver: 0 });
+    expect((await handshake(gateway, ghost)).err?.message).toBe("unauthorized");
+  });
+});

--- a/apps/api/src/realtime/realtime.gateway.ts
+++ b/apps/api/src/realtime/realtime.gateway.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@nestjs/common";
+import { Logger, OnModuleDestroy } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import {
   OnGatewayConnection,
@@ -9,12 +9,22 @@ import {
 } from "@nestjs/websockets";
 import { Server, Socket } from "socket.io";
 import type { RealtimeMessage } from "@ark/shared";
+import { AccessService } from "../auth/access.service";
+import type { AuthUser } from "../auth/auth-user";
 import { AuthService } from "../auth/auth.service";
 import { loadEnv } from "../config/env";
 
 /**
  * Socket.IO gateway for live status, log tails, install progress, RCON output,
- * and events. Clients subscribe to a server room to scope traffic.
+ * and events.
+ *
+ * Room model (GH #73, per-user server access): a socket is in EXACTLY ONE of
+ * two shapes of room. Unrestricted users (admins, or accounts with no server
+ * grants) sit in "all". Restricted users sit in one `server:<id>` room per
+ * server they may see, and nothing else. `broadcast()` emits to "all" and, for
+ * server-scoped messages, to `server:<id>` too — the two sets of sockets are
+ * disjoint, so nobody receives a message twice, and global (serverId-less)
+ * events reach only "all".
  */
 // addTrailingSlash:false lets engine.io accept the path after Next's rewrite
 // strips the trailing slash from `/socket.io/`; without it the polling
@@ -29,9 +39,10 @@ import { loadEnv } from "../config/env";
   addTrailingSlash: false,
 })
 export class RealtimeGateway
-  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect, OnModuleDestroy
 {
   private readonly logger = new Logger(RealtimeGateway.name);
+  private readonly unsubscribeAccess: () => void;
 
   @WebSocketServer()
   server!: Server;
@@ -39,19 +50,34 @@ export class RealtimeGateway
   constructor(
     private readonly jwt: JwtService,
     private readonly auth: AuthService,
-  ) {}
+    private readonly access: AccessService,
+  ) {
+    // An admin editing (or deleting) a user must take effect on that user's OPEN
+    // sockets, not just at their next reconnect.
+    this.unsubscribeAccess = this.access.onChanged((userId) => {
+      void this.rescopeUser(userId).catch((err) => {
+        this.logger.warn(`Failed to re-scope sockets for user ${userId}: ${String(err)}`);
+      });
+    });
+  }
+
+  onModuleDestroy(): void {
+    this.unsubscribeAccess();
+  }
 
   /** Realtime traffic includes log tails and RCON output — require a valid,
-   * unrevoked JWT in the socket.io handshake before any message flows. */
+   * unrevoked JWT in the socket.io handshake before any message flows. The
+   * resolved user is kept on `socket.data.user` so the socket can be scoped. */
   afterInit(server: Server): void {
     server.use(async (socket, next) => {
       try {
         const token = socket.handshake.auth?.token as string | undefined;
         if (!token) return next(new Error("unauthorized"));
         const payload = await this.jwt.verifyAsync(token);
-        if (!(await this.auth.isTokenCurrent(payload.sub, payload.ver))) {
-          return next(new Error("unauthorized"));
-        }
+        const resolved = await this.auth.resolveToken(payload.sub, payload.ver);
+        if (resolved === null) return next(new Error("unauthorized"));
+        const user: AuthUser = { ...payload, restricted: resolved.restricted };
+        socket.data.user = user;
         next();
       } catch {
         next(new Error("unauthorized"));
@@ -59,18 +85,67 @@ export class RealtimeGateway
     });
   }
 
-  handleConnection(_client: Socket): void {
-    // No per-server rooms: clients receive every message and filter by
-    // serverId/topic themselves. (Emitting to a room AND globally delivered room
-    // members two copies of each server-scoped message.)
+  handleConnection(client: Socket): void {
+    void this.scope(client).catch((err) => {
+      this.logger.warn(`Failed to scope socket ${client.id}: ${String(err)}`);
+      client.disconnect(true);
+    });
   }
 
   handleDisconnect(_client: Socket): void {
-    // no-op; sockets clean up automatically
+    // no-op; sockets leave their rooms automatically
   }
 
-  /** Broadcast to all clients; each filters by serverId/topic itself. */
+  /**
+   * Put the socket in the rooms its user may see: "all" for unrestricted users,
+   * otherwise one `server:<id>` room per visible server. Safe to re-run — every
+   * previous scope room is left first. The lookup happens BEFORE leaving, so a
+   * re-scope never leaves the socket roomless while the DB is consulted.
+   */
+  async scope(socket: Socket): Promise<void> {
+    const user = socket.data.user as AuthUser | undefined;
+    const allowed = await this.access.allowedServerIds(user);
+    for (const room of [...socket.rooms]) {
+      if (room === "all" || room.startsWith("server:")) socket.leave(room);
+    }
+    if (allowed === "all") {
+      socket.join("all");
+      return;
+    }
+    for (const id of allowed) socket.join(`server:${id}`);
+  }
+
+  /**
+   * Emit to "all" and, for server-scoped messages, to that server's room.
+   * Unrestricted sockets are only in "all" and restricted sockets only in
+   * server rooms, so each socket gets at most one copy. Messages without a
+   * serverId (global events) reach only "all".
+   */
   broadcast(message: RealtimeMessage): void {
-    this.server?.emit("message", message);
+    if (!this.server) return;
+    this.server.to("all").emit("message", message);
+    if (message.serverId) {
+      this.server.to(`server:${message.serverId}`).emit("message", message);
+    }
+  }
+
+  /** Re-read a user's grants onto each of their live sockets; drop sockets whose
+   * token no longer resolves (user deleted or tokens revoked). */
+  private async rescopeUser(userId: string): Promise<void> {
+    const sockets = this.server?.sockets?.sockets;
+    if (!sockets) return;
+    for (const socket of sockets.values()) {
+      const user = socket.data.user as AuthUser | undefined;
+      if (user?.sub !== userId) continue;
+      const resolved = await this.auth.resolveToken(user.sub, user.ver);
+      if (resolved === null) {
+        socket.disconnect(true);
+        continue;
+      }
+      // `restricted` is DB-backed and may have just flipped; refresh it or an
+      // account newly restricted would still scope as unrestricted.
+      socket.data.user = { ...user, restricted: resolved.restricted } satisfies AuthUser;
+      await this.scope(socket);
+    }
   }
 }

--- a/apps/api/src/scheduler/scheduler.module.ts
+++ b/apps/api/src/scheduler/scheduler.module.ts
@@ -7,9 +7,18 @@ import { BackupsModule } from "../backups/backups.module";
 import { PlayersModule } from "../players/players.module";
 import { UpdatesModule } from "../updates/updates.module";
 import { ModUpdatesModule } from "../modupdates/modupdates.module";
+import { AuthModule } from "../auth/auth.module";
 
 @Module({
-  imports: [ServersModule, RconModule, BackupsModule, PlayersModule, UpdatesModule, ModUpdatesModule],
+  imports: [
+    ServersModule,
+    RconModule,
+    BackupsModule,
+    PlayersModule,
+    UpdatesModule,
+    ModUpdatesModule,
+    AuthModule,
+  ],
   controllers: [SchedulesController],
   providers: [SchedulerService],
   exports: [SchedulerService],

--- a/apps/api/src/scheduler/schedules-access.test.ts
+++ b/apps/api/src/scheduler/schedules-access.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { NotFoundException } from "@nestjs/common";
+import { SchedulesController } from "./schedules.controller";
+import { AccessService } from "../auth/access.service";
+import type { AuthUser } from "../auth/auth-user";
+
+/**
+ * Schedules carry their server by body/query, not in the path, so the global
+ * guard can't scope them (GH #73). The controller must filter the list and 404
+ * any create/update/delete that touches a server the caller can't see.
+ *
+ * Real AccessService over a fake Prisma: "u1" is granted srv-a directly and
+ * nothing through clusters.
+ */
+const rows = [
+  { id: "sch-a", serverId: "srv-a", createdAt: new Date(2) },
+  { id: "sch-b", serverId: "srv-b", createdAt: new Date(1) },
+];
+
+function make() {
+  const prisma = {
+    userServerAccess: { findMany: vi.fn(async () => [{ serverId: "srv-a" }]) },
+    userClusterAccess: { findMany: vi.fn(async () => []) },
+    server: { findMany: vi.fn(async () => []) },
+    schedule: {
+      findMany: vi.fn(async ({ where }: { where?: { serverId?: string } }) =>
+        where?.serverId ? rows.filter((r) => r.serverId === where.serverId) : rows,
+      ),
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
+        const r = rows.find((x) => x.id === where.id);
+        return r ? { serverId: r.serverId } : null;
+      }),
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({ id: "new", ...data })),
+      update: vi.fn(async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => ({
+        ...rows.find((x) => x.id === where.id),
+        ...data,
+      })),
+      delete: vi.fn(async () => undefined),
+    },
+  };
+  const scheduler = { registerWithTimezone: vi.fn(async () => undefined), unregister: vi.fn() };
+  const access = new AccessService(prisma as never);
+  const ctl = new SchedulesController(prisma as never, scheduler as never, access);
+  return { ctl, prisma, scheduler };
+}
+
+const restricted: AuthUser = { sub: "u1", role: "operator", ver: 1, restricted: true };
+const unrestricted: AuthUser = { sub: "u2", role: "operator", ver: 1, restricted: false };
+const admin: AuthUser = { sub: "u3", role: "admin", ver: 1, restricted: true };
+
+const body = { serverId: "srv-b", name: "n", cron: "* * * * *", action: "restart" };
+
+describe("SchedulesController access (GH #73)", () => {
+  it("list without serverId narrows to visible servers; unrestricted and admin see all", async () => {
+    const { ctl } = make();
+    expect((await ctl.list(restricted)).map((r) => r.id)).toEqual(["sch-a"]);
+    expect((await ctl.list(unrestricted)).map((r) => r.id)).toEqual(["sch-a", "sch-b"]);
+    expect((await ctl.list(admin)).map((r) => r.id)).toEqual(["sch-a", "sch-b"]);
+  });
+
+  it("list with serverId 404s on a hidden server and passes a visible one through", async () => {
+    const { ctl } = make();
+    await expect(ctl.list(restricted, "srv-b")).rejects.toBeInstanceOf(NotFoundException);
+    expect((await ctl.list(restricted, "srv-a")).map((r) => r.id)).toEqual(["sch-a"]);
+  });
+
+  it("create checks body.serverId", async () => {
+    const { ctl, prisma } = make();
+    await expect(ctl.create(body, restricted)).rejects.toBeInstanceOf(NotFoundException);
+    expect(prisma.schedule.create).not.toHaveBeenCalled();
+    await ctl.create({ ...body, serverId: "srv-a" }, restricted);
+    expect(prisma.schedule.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("update checks the schedule's current server, and the new one when moving", async () => {
+    const { ctl, prisma } = make();
+    // Hidden schedule: 404 before any write.
+    await expect(ctl.update("sch-b", { name: "x" }, restricted)).rejects.toBeInstanceOf(NotFoundException);
+    // Visible schedule moved onto a hidden server: also 404.
+    await expect(ctl.update("sch-a", { serverId: "srv-b" }, restricted)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    expect(prisma.schedule.update).not.toHaveBeenCalled();
+    // Visible schedule, plain edit: goes through.
+    await ctl.update("sch-a", { name: "x" }, restricted);
+    expect(prisma.schedule.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("update/delete of an unknown schedule is a 404 too", async () => {
+    const { ctl } = make();
+    await expect(ctl.update("nope", { name: "x" }, restricted)).rejects.toBeInstanceOf(NotFoundException);
+    await expect(ctl.remove("nope", admin)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("delete checks the schedule's server and leaves the cron job registered on denial", async () => {
+    const { ctl, prisma, scheduler } = make();
+    await expect(ctl.remove("sch-b", restricted)).rejects.toBeInstanceOf(NotFoundException);
+    expect(scheduler.unregister).not.toHaveBeenCalled();
+    expect(prisma.schedule.delete).not.toHaveBeenCalled();
+    await ctl.remove("sch-a", restricted);
+    expect(scheduler.unregister).toHaveBeenCalledWith("sch-a");
+    expect(prisma.schedule.delete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/scheduler/schedules.controller.ts
+++ b/apps/api/src/scheduler/schedules.controller.ts
@@ -1,7 +1,20 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from "@nestjs/common";
 import { IsBoolean, IsDateString, IsIn, IsInt, IsOptional, IsString, Min } from "class-validator";
 import { PrismaService } from "../prisma/prisma.service";
 import { SchedulerService } from "./scheduler.service";
+import { AccessService } from "../auth/access.service";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type { AuthUser } from "../auth/auth-user";
 
 class ScheduleBody {
   @IsString() serverId!: string;
@@ -16,23 +29,33 @@ class ScheduleBody {
   @IsOptional() @IsDateString() runAt?: string;
 }
 
+/**
+ * Schedules carry their server by body/query rather than in the path, so the
+ * global ServerAccessGuard can't scope them; every handler checks the server
+ * itself (GH #73).
+ */
 @Controller("schedules")
 export class SchedulesController {
   constructor(
     private readonly prisma: PrismaService,
     private readonly scheduler: SchedulerService,
+    private readonly access: AccessService,
   ) {}
 
   @Get()
-  list(@Query("serverId") serverId?: string) {
-    return this.prisma.schedule.findMany({
+  async list(@CurrentUser() user: AuthUser, @Query("serverId") serverId?: string) {
+    if (serverId) await this.access.assertServer(user, serverId);
+    const rows = await this.prisma.schedule.findMany({
       where: serverId ? { serverId } : undefined,
       orderBy: { createdAt: "desc" },
     });
+    if (serverId) return rows;
+    return this.access.filterByServer(rows, await this.access.allowedServerIds(user));
   }
 
   @Post()
-  async create(@Body() body: ScheduleBody) {
+  async create(@Body() body: ScheduleBody, @CurrentUser() user: AuthUser) {
+    await this.access.assertServer(user, body.serverId);
     const created = await this.prisma.schedule.create({
       data: {
         serverId: body.serverId,
@@ -53,7 +76,14 @@ export class SchedulesController {
   }
 
   @Patch(":id")
-  async update(@Param("id") id: string, @Body() body: Partial<ScheduleBody>) {
+  async update(
+    @Param("id") id: string,
+    @Body() body: Partial<ScheduleBody>,
+    @CurrentUser() user: AuthUser,
+  ) {
+    const current = await this.owned(id, user);
+    // Moving a schedule onto another server needs that server too.
+    if (body.serverId && body.serverId !== current) await this.access.assertServer(user, body.serverId);
     const data = { ...body, runAt: body.runAt !== undefined ? new Date(body.runAt) : undefined };
     const updated = await this.prisma.schedule.update({ where: { id }, data });
     this.scheduler.unregister(id);
@@ -64,9 +94,19 @@ export class SchedulesController {
   }
 
   @Delete(":id")
-  async remove(@Param("id") id: string) {
+  async remove(@Param("id") id: string, @CurrentUser() user: AuthUser) {
+    await this.owned(id, user);
     this.scheduler.unregister(id);
     await this.prisma.schedule.delete({ where: { id } });
     return { ok: true };
+  }
+
+  /** The schedule's server id, after checking the caller may see that server.
+   *  A missing schedule and a hidden one both 404. */
+  private async owned(id: string, user: AuthUser): Promise<string> {
+    const row = await this.prisma.schedule.findUnique({ where: { id }, select: { serverId: true } });
+    if (!row) throw new NotFoundException("Schedule not found");
+    await this.access.assertServer(user, row.serverId);
+    return row.serverId;
   }
 }

--- a/apps/api/src/servers/servers-list-access.test.ts
+++ b/apps/api/src/servers/servers-list-access.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { ServersService } from "./servers.service";
+import { CatalogService } from "../catalog/catalog.service";
+
+/**
+ * GET /servers and /servers/stats hand the service the caller's allowed set
+ * (GH #73). The service must push the narrowing into the Prisma `where` (not
+ * post-filter), return nothing for an empty set without asking the DB, and
+ * leave the query unfiltered for "all".
+ */
+beforeAll(() => {
+  process.env.SECRETS_KEY = "a".repeat(64);
+  process.env.JWT_SECRET = "test-jwt-secret-1234";
+  process.env.DATA_DIR = "/tmp/palisade-list-access-test";
+});
+
+const base = {
+  name: "Srv",
+  game: "ASA",
+  map: "TheIsland_WP",
+  state: "Stopped",
+  clusterId: null,
+  cluster: null,
+  gamePort: 7777,
+  rawSocketPort: 7778,
+  queryPort: 7779,
+  rconPort: 7780,
+  installedBuildId: null,
+  updateAvailable: false,
+  configDirty: false,
+  maxPlayers: 10,
+  modIds: "[]",
+  ramLimitMb: null,
+  cpuLimit: null,
+  adminPasswordEnc: null,
+  serverPasswordEnc: null,
+  spectatorPasswordEnc: null,
+  configJson: JSON.stringify({ values: {} }),
+  containerId: null,
+  artworkJson: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+};
+const rows = ["s1", "s2", "s3"].map((id) => ({ ...base, id }));
+
+function makeSvc() {
+  const findMany = vi.fn(async (args?: { where?: { id?: { in: string[] } } }) => {
+    const ids = args?.where?.id?.in;
+    return ids ? rows.filter((r) => ids.includes(r.id)) : rows;
+  });
+  const prisma = { server: { findMany } };
+  const docker = { imageExists: async () => false, stats: async () => null };
+  const players = { cached: () => null, count: async () => null };
+  const svc = new ServersService(
+    prisma as never,
+    { decrypt: (s: string) => s } as never,
+    {} as never,
+    {} as never,
+    docker as never,
+    new CatalogService(),
+    {} as never,
+    {} as never,
+    {} as never,
+    {
+      getTimezone: async () => "UTC",
+      get: async () => null,
+      getGameHostNetwork: async () => null,
+      getPublicBaseUrl: async () => null,
+    } as never,
+    {} as never,
+    {} as never,
+    players as never,
+    { addressingNote: () => null } as never,
+    {} as never,
+    { getAll: async () => ({}) } as never,
+  );
+  return { svc, findMany };
+}
+
+describe("ServersService.list / statsAll visibility (GH #73)", () => {
+  it("'all' (and the default) leaves the query unfiltered", async () => {
+    const { svc, findMany } = makeSvc();
+    expect((await svc.list()).map((s) => s.id)).toEqual(["s1", "s2", "s3"]);
+    expect((await svc.list("all")).map((s) => s.id)).toEqual(["s1", "s2", "s3"]);
+    for (const call of findMany.mock.calls) expect(call[0]?.where).toBeUndefined();
+  });
+
+  it("a Set narrows the Prisma where to those ids", async () => {
+    const { svc, findMany } = makeSvc();
+    expect((await svc.list(new Set(["s2", "ghost"]))).map((s) => s.id)).toEqual(["s2"]);
+    expect(findMany.mock.calls[0]?.[0]?.where).toEqual({ id: { in: ["s2", "ghost"] } });
+  });
+
+  it("an empty Set returns [] without touching the DB", async () => {
+    const { svc, findMany } = makeSvc();
+    expect(await svc.list(new Set())).toEqual([]);
+    expect(await svc.statsAll(new Set())).toEqual([]);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("statsAll applies the same narrowing", async () => {
+    const { svc, findMany } = makeSvc();
+    expect((await svc.statsAll(new Set(["s1", "s3"]))).map((s) => s.id)).toEqual(["s1", "s3"]);
+    expect(findMany.mock.calls[0]?.[0]?.where).toEqual({ id: { in: ["s1", "s3"] } });
+    expect((await svc.statsAll()).map((s) => s.id)).toEqual(["s1", "s2", "s3"]);
+  });
+});

--- a/apps/api/src/servers/servers.controller.ts
+++ b/apps/api/src/servers/servers.controller.ts
@@ -33,6 +33,9 @@ import { EventsService } from "../events/events.service";
 import { UpdatesService } from "../updates/updates.service";
 import { CreateServerBody, UpdateServerBody, ExtraEnvBody } from "./servers.dto";
 import { MinRole } from "../auth/min-role.decorator";
+import { AccessService } from "../auth/access.service";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type { AuthUser } from "../auth/auth-user";
 
 class CopyServerBody {
   @IsArray() @IsString({ each: true }) targetIds!: string[];
@@ -54,17 +57,19 @@ export class ServersController {
     private readonly events: EventsService,
     private readonly history: HistoryService,
     private readonly updates: UpdatesService,
+    private readonly access: AccessService,
   ) {}
 
+  /** Restricted users (GH #73) only see the servers granted to them. */
   @Get()
-  list() {
-    return this.servers.list();
+  async list(@CurrentUser() user: AuthUser) {
+    return this.servers.list(await this.access.allowedServerIds(user));
   }
 
   // Must precede @Get(":id") so "/servers/stats" isn't captured as id="stats".
   @Get("stats")
-  statsAll() {
-    return this.servers.statsAll();
+  async statsAll(@CurrentUser() user: AuthUser) {
+    return this.servers.statsAll(await this.access.allowedServerIds(user));
   }
 
   /** Whole-machine stats (for the dashboard disk-space warning). Must also
@@ -178,7 +183,9 @@ export class ServersController {
 
   /** Copy this server's settings/mods onto the given (same-game) targets. */
   @Post(":id/copy")
-  copy(@Param("id") id: string, @Body() body: CopyServerBody) {
+  async copy(@Param("id") id: string, @Body() body: CopyServerBody, @CurrentUser() user: AuthUser) {
+    // The guard checked the source; the targets arrive by body so check them here.
+    await this.access.assertServers(user, body.targetIds);
     return this.servers.copyTo(id, body);
   }
 

--- a/apps/api/src/servers/servers.module.ts
+++ b/apps/api/src/servers/servers.module.ts
@@ -10,9 +10,18 @@ import { BackupsModule } from "../backups/backups.module";
 import { PlayersModule } from "../players/players.module";
 import { UpdatesModule } from "../updates/updates.module";
 import { PortForwardsModule } from "../portforwards/portforwards.module";
+import { AuthModule } from "../auth/auth.module";
 
 @Module({
-  imports: [RconModule, BackupsModule, PlayersModule, ArtworkModule, UpdatesModule, PortForwardsModule],
+  imports: [
+    RconModule,
+    BackupsModule,
+    PlayersModule,
+    ArtworkModule,
+    UpdatesModule,
+    PortForwardsModule,
+    AuthModule,
+  ],
   controllers: [ServersController],
   providers: [ServersService, ServerConfigWriter, StateMachineService, HistoryService],
   exports: [ServersService, StateMachineService],

--- a/apps/api/src/servers/servers.service.ts
+++ b/apps/api/src/servers/servers.service.ts
@@ -37,6 +37,7 @@ import {
   type EnvVar,
 } from "@ark/shared";
 import { PrismaService } from "../prisma/prisma.service";
+import type { AllowedServers } from "../auth/access.service";
 import { CryptoService } from "../crypto/crypto.service";
 import { EventsService } from "../events/events.service";
 import { RealtimeGateway } from "../realtime/realtime.gateway";
@@ -487,9 +488,20 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
     return p;
   }
 
+  /** Prisma `where` for a user's visible servers: undefined = no filter, null =
+   *  nothing visible (skip the query; Prisma's `in: []` would work but why ask). */
+  private static visibleWhere(allowed: AllowedServers): { id: { in: string[] } } | undefined | null {
+    if (allowed === "all") return undefined;
+    if (allowed.size === 0) return null;
+    return { id: { in: [...allowed] } };
+  }
+
   // ── CRUD ─────────────────────────────────────────────────────────────────--
-  async list(): Promise<ServerSummary[]> {
-    const rows = await this.prisma.server.findMany({ include: { cluster: true } });
+  /** `allowed` narrows the result for a restricted user (GH #73); omit for all. */
+  async list(allowed: AllowedServers = "all"): Promise<ServerSummary[]> {
+    const where = ServersService.visibleWhere(allowed);
+    if (where === null) return [];
+    const rows = await this.prisma.server.findMany({ where, include: { cluster: true } });
     // One image-presence check per distinct game (image is shared per game).
     const games = [...new Set(rows.map((r) => r.game as Game))];
     const ready = new Map<Game, boolean>();
@@ -530,8 +542,13 @@ export class ServersService implements OnApplicationBootstrap, OnApplicationShut
   }
 
   /** Stats for every server, keyed by id (for the servers list). */
-  async statsAll(): Promise<ServerStatsById[]> {
-    const servers = await this.prisma.server.findMany({ select: { id: true, containerId: true } });
+  async statsAll(allowed: AllowedServers = "all"): Promise<ServerStatsById[]> {
+    const where = ServersService.visibleWhere(allowed);
+    if (where === null) return [];
+    const servers = await this.prisma.server.findMany({
+      where,
+      select: { id: true, containerId: true },
+    });
     return Promise.all(
       servers.map(async (s) => ({ id: s.id, ...(await this.statsFor(s.id, s.containerId)) })),
     );

--- a/apps/web/app/clusters/page.tsx
+++ b/apps/web/app/clusters/page.tsx
@@ -4,6 +4,7 @@ import { Boxes, Plus, Play, Square, Trash2, UserPlus, X } from "lucide-react";
 import { mapLabel, type ServerSummary } from "@ark/shared";
 import { apiDelete, apiGet, apiPost } from "@/lib/api";
 import { StateBadge } from "@/components/state-badge";
+import { useMe } from "@/lib/use-me";
 
 interface ClusterMember {
   id: string;
@@ -24,6 +25,10 @@ export default function ClustersPage() {
   const [clusters, setClusters] = useState<Cluster[]>([]);
   const [servers, setServers] = useState<ServerSummary[]>([]);
   const [name, setName] = useState("");
+  // Cluster changes touch servers a restricted user may not see, so the
+  // create / add / remove / delete controls are hidden for restricted users.
+  const me = useMe();
+  const canEdit = !me?.restricted;
 
   const refresh = useCallback(() => {
     apiGet<Cluster[]>("/clusters").then(setClusters).catch(() => undefined);
@@ -64,17 +69,19 @@ export default function ClustersPage() {
         <Boxes className="h-5 w-5 text-ark-accent" /> Clusters
       </h1>
 
-      <form onSubmit={create} className="card flex gap-2">
-        <input
-          className="input"
-          placeholder="New cluster name (e.g. The Archipelago)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <button className="btn-primary">
-          <Plus className="h-4 w-4" /> Create
-        </button>
-      </form>
+      {canEdit && (
+        <form onSubmit={create} className="card flex gap-2">
+          <input
+            className="input"
+            placeholder="New cluster name (e.g. The Archipelago)"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <button className="btn-primary">
+            <Plus className="h-4 w-4" /> Create
+          </button>
+        </form>
+      )}
 
       {clusters.length === 0 && <div className="card text-slate-400">No clusters yet.</div>}
 
@@ -95,12 +102,14 @@ export default function ClustersPage() {
               <button className="btn-secondary" onClick={() => runOnCluster(`/clusters/${c.id}/stop`)}>
                 <Square className="h-4 w-4" /> Stop all
               </button>
-              <button
-                className="btn-danger"
-                onClick={() => apiDelete(`/clusters/${c.id}`).then(refresh)}
-              >
-                <Trash2 className="h-4 w-4" />
-              </button>
+              {canEdit && (
+                <button
+                  className="btn-danger"
+                  onClick={() => apiDelete(`/clusters/${c.id}`).then(refresh)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
             </div>
           </div>
 
@@ -120,19 +129,22 @@ export default function ClustersPage() {
                       {m.game} · {mapLabel(m.map)}
                     </span>
                   </div>
-                  <button
-                    className="btn-secondary px-2"
-                    title="Remove from cluster (restarts the server if it's running)"
-                    onClick={() => apiDelete(`/clusters/${c.id}/members/${m.id}`).then(refresh)}
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
+                  {canEdit && (
+                    <button
+                      className="btn-secondary px-2"
+                      title="Remove from cluster (restarts the server if it's running)"
+                      onClick={() => apiDelete(`/clusters/${c.id}/members/${m.id}`).then(refresh)}
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
                 </div>
               ))
             )}
           </div>
 
           {(() => {
+            if (!canEdit) return null;
             const addable = servers.filter((s) => s.clusterId !== c.id);
             if (addable.length === 0) return null;
             return (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -54,6 +54,7 @@ import { ConnectCommand } from "@/components/connect-command";
 import { UnofficialListHelp } from "@/components/unofficial-list-help";
 import { useStartGuard } from "@/components/start-guard";
 import { useArtwork } from "@/lib/use-artwork";
+import { useMe } from "@/lib/use-me";
 
 interface ClusterLite {
   id: string;
@@ -76,6 +77,10 @@ export default function DashboardPage() {
 
   const { start: guardedStart, dialog: startDialog } = useStartGuard(refresh);
   const artwork = useArtwork();
+  // Restricted users only see their granted servers and can't create or adopt
+  // new ones (the API returns 403), so don't offer the entry points.
+  const me = useMe();
+  const canCreate = !me?.restricted;
   const clusterName = (id?: string | null) => clusters.find((c) => c.id === id)?.name;
 
   useEffect(() => refresh(), [refresh]);
@@ -158,14 +163,16 @@ export default function DashboardPage() {
       <SetupWarnings />
       <div className="flex items-center justify-between gap-2">
         <h1 className="text-xl font-semibold">Servers</h1>
-        <div className="flex gap-2">
-          <button className="btn-secondary" onClick={() => { setAdopting((v) => !v); setCreating(false); }}>
-            <Import className="h-4 w-4" /> Adopt existing
-          </button>
-          <button className="btn-primary" onClick={() => { setCreating((v) => !v); setAdopting(false); }}>
-            <Plus className="h-4 w-4" /> New server
-          </button>
-        </div>
+        {canCreate && (
+          <div className="flex gap-2">
+            <button className="btn-secondary" onClick={() => { setAdopting((v) => !v); setCreating(false); }}>
+              <Import className="h-4 w-4" /> Adopt existing
+            </button>
+            <button className="btn-primary" onClick={() => { setCreating((v) => !v); setAdopting(false); }}>
+              <Plus className="h-4 w-4" /> New server
+            </button>
+          </div>
+        )}
       </div>
 
       {creating && <CreateServerForm onDone={() => { setCreating(false); refresh(); }} />}
@@ -173,7 +180,13 @@ export default function DashboardPage() {
 
       {servers.length === 0 && !creating && (
         <div className="card text-center text-slate-400">
-          No servers yet. Click <span className="text-slate-200">New server</span> to create one.
+          {canCreate ? (
+            <>
+              No servers yet. Click <span className="text-slate-200">New server</span> to create one.
+            </>
+          ) : (
+            "No servers to show. Ask an admin to grant you access."
+          )}
         </div>
       )}
 

--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -12,7 +12,7 @@ import {
   type ServerConfigValues,
   type UpdateGameResult,
 } from "@ark/shared";
-import { apiGet, apiPost, apiPatch, apiDelete, apiDownload } from "@/lib/api";
+import { ApiError, apiGet, apiPost, apiPatch, apiDelete, apiDownload } from "@/lib/api";
 import { useRealtime } from "@/lib/socket";
 import { StateBadge } from "@/components/state-badge";
 import { GuideTab } from "@/components/guide-tab";
@@ -44,6 +44,7 @@ import { ValheimModsTab } from "@/components/valheim-mods-tab";
 import { useStartGuard } from "@/components/start-guard";
 import { useArtwork } from "@/lib/use-artwork";
 import { useRole } from "@/lib/use-role";
+import { useMe } from "@/lib/use-me";
 import { ArtworkPicker } from "@/components/artwork-picker";
 import { BackupsTab } from "@/components/backups-tab";
 import { PlayersTab } from "@/components/players-tab";
@@ -58,7 +59,12 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
   const [server, setServer] = useState<ServerSummary | null>(null);
   const artwork = useArtwork();
   const role = useRole();
+  const me = useMe();
   const [pickingArt, setPickingArt] = useState(false);
+  // 404 from GET /servers/:id: deleted, a bad link, or a server this user
+  // isn't granted (restricted users get 404, not 403). Show a real message
+  // instead of a spinner that never ends.
+  const [notFound, setNotFound] = useState(false);
   const [config, setConfig] = useState<ServerConfigValues | null>(null);
   const [configKey, setConfigKey] = useState(0); // bump to remount the editor on copy-in
   const [tab, setTab] = useState<Tab>("Overview");
@@ -89,7 +95,12 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
   };
 
   const refresh = useCallback(
-    () => apiGet<ServerSummary>(`/servers/${id}`).then(setServer).catch(() => undefined),
+    () =>
+      apiGet<ServerSummary>(`/servers/${id}`)
+        .then(setServer)
+        .catch((e) => {
+          if (e instanceof ApiError && e.status === 404) setNotFound(true);
+        }),
     [id],
   );
 
@@ -183,6 +194,19 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
     }
   };
 
+  if (notFound && !server) {
+    return (
+      <div className="card space-y-3">
+        <h1 className="text-xl font-semibold">Server not found</h1>
+        <p className="text-sm text-slate-400">
+          It may have been deleted, or your account does not have access to it.
+        </p>
+        <Link href="/" className="btn-secondary inline-flex">
+          <ArrowLeft className="h-4 w-4" /> Back to servers
+        </Link>
+      </div>
+    );
+  }
   if (!server) return <div className="text-slate-400">Loading…</div>;
 
   // Onscreen art = per-server override winning over the game-wide default.
@@ -332,7 +356,7 @@ export default function ServerDetailPage({ params }: { params: Promise<{ id: str
           {server.updateAvailable && <UpdateBadge />}
         </div>
         <div className="flex flex-wrap gap-2">
-          <CopyMenu server={server} onAfterCopyIn={reload} />
+          {!me?.restricted && <CopyMenu server={server} onAfterCopyIn={reload} />}
           {/* One slot, two honest actions: pull the image while it's missing, then
               update the GAME once it's there. The old combined "Install / Update"
               button only ever pulled the image — which Start does anyway — so it

--- a/apps/web/components/users-card.tsx
+++ b/apps/web/components/users-card.tsx
@@ -1,45 +1,246 @@
 "use client";
 import { useEffect, useState } from "react";
-import { Plus, Trash2, Users } from "lucide-react";
-import { ROLES, type Role } from "@ark/shared";
-import { apiDelete, apiGet, apiPost } from "@/lib/api";
+import { Check, Pencil, Plus, Trash2, Users, X } from "lucide-react";
+import { ROLES, type Role, type ServerSummary, type UserAccessDto, type UserDto } from "@ark/shared";
+import { apiDelete, apiGet, apiPatch, apiPost } from "@/lib/api";
 
-interface UserRow {
+interface ClusterLite {
   id: string;
-  username: string;
-  role: string;
-  createdAt: string;
+  name: string;
 }
 
 const ROLE_HINTS: Record<Role, string> = {
   viewer: "Read-only: dashboards, players, logs.",
   operator: "Day-to-day ops: start/stop, console, backups, mods, schedules.",
-  admin: "Everything, including settings, users, and deletes.",
+  admin: "Everything, including settings, users, and deletes. Admins always see every server.",
 };
 
-/** Settings card: manage panel accounts and their roles. */
+/** Editable access fields, shared by the add form and the per-user editor. */
+interface AccessDraft {
+  role: Role;
+  restricted: boolean;
+  serverIds: string[];
+  clusterIds: string[];
+}
+
+const toggle = (list: string[], id: string, on: boolean) =>
+  on ? (list.includes(id) ? list : [...list, id]) : list.filter((x) => x !== id);
+
+/** One-line summary of what a user can see, for the list row. */
+function accessLabel(u: UserDto): string | null {
+  if (u.role === "admin") return null;
+  if (!u.restricted) return "All servers";
+  const parts: string[] = [];
+  parts.push(`${u.serverIds.length} server${u.serverIds.length === 1 ? "" : "s"}`);
+  parts.push(`${u.clusterIds.length} cluster${u.clusterIds.length === 1 ? "" : "s"}`);
+  return parts.join(", ");
+}
+
+/**
+ * Role + "restrict to selected servers" + a server picker grouped by cluster.
+ * Ticking a cluster grants every current and future member, so its members
+ * show ticked and disabled rather than as separate grants.
+ */
+function AccessFields({
+  draft,
+  onChange,
+  servers,
+  clusters,
+}: {
+  draft: AccessDraft;
+  onChange: (next: AccessDraft) => void;
+  servers: ServerSummary[];
+  clusters: ClusterLite[];
+}) {
+  const isAdmin = draft.role === "admin";
+  const restricted = draft.restricted && !isAdmin;
+  const groups = [
+    ...clusters.map((c) => ({ cluster: c as ClusterLite | null, servers: servers.filter((s) => s.clusterId === c.id) })),
+    { cluster: null, servers: servers.filter((s) => !s.clusterId || !clusters.some((c) => c.id === s.clusterId)) },
+  ].filter((g) => g.cluster || g.servers.length > 0);
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <select
+          className="input"
+          value={draft.role}
+          onChange={(e) => onChange({ ...draft, role: e.target.value as Role })}
+        >
+          {ROLES.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+        <label className="flex items-center gap-2 text-sm text-slate-200">
+          <input
+            type="checkbox"
+            className="h-4 w-4"
+            checked={restricted}
+            disabled={isAdmin}
+            onChange={(e) => onChange({ ...draft, restricted: e.target.checked })}
+          />
+          Restrict to selected servers
+        </label>
+      </div>
+      <p className="text-xs text-slate-500">{ROLE_HINTS[draft.role]}</p>
+
+      {restricted && (
+        <div className="space-y-2 rounded border border-slate-700/60 p-3">
+          <p className="text-xs text-slate-500">
+            Tick a cluster to grant every server in it, now and in future. The role above still
+            decides what they can do on those servers.
+          </p>
+          {servers.length === 0 && clusters.length === 0 && (
+            <p className="text-xs text-slate-500">No servers or clusters yet.</p>
+          )}
+          <div className="max-h-64 space-y-2 overflow-auto">
+            {groups.map((g) => {
+              const clusterOn = g.cluster ? draft.clusterIds.includes(g.cluster.id) : false;
+              return (
+                <div key={g.cluster?.id ?? "none"} className="space-y-0.5">
+                  {g.cluster ? (
+                    <label className="flex items-center gap-2 text-sm font-medium text-slate-200">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4"
+                        checked={clusterOn}
+                        onChange={(e) =>
+                          onChange({ ...draft, clusterIds: toggle(draft.clusterIds, g.cluster!.id, e.target.checked) })
+                        }
+                      />
+                      {g.cluster.name}
+                      <span className="text-xs font-normal text-slate-500">cluster</span>
+                    </label>
+                  ) : (
+                    <div className="text-xs font-medium uppercase tracking-wide text-slate-500">Not in a cluster</div>
+                  )}
+                  {g.servers.length === 0 && g.cluster && (
+                    <p className="pl-6 text-xs text-slate-500">No members yet.</p>
+                  )}
+                  {g.servers.map((s) => (
+                    <label
+                      key={s.id}
+                      className={`flex items-center gap-2 pl-6 text-sm ${clusterOn ? "text-slate-500" : "text-slate-300"}`}
+                    >
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4"
+                        checked={clusterOn || draft.serverIds.includes(s.id)}
+                        disabled={clusterOn}
+                        onChange={(e) => onChange({ ...draft, serverIds: toggle(draft.serverIds, s.id, e.target.checked) })}
+                      />
+                      {s.name}
+                      {clusterOn && <span className="text-xs">via cluster</span>}
+                    </label>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Body sent to POST/PATCH /users. Admins are never restricted. */
+function toAccessBody(d: AccessDraft): UserAccessDto {
+  const restricted = d.restricted && d.role !== "admin";
+  return {
+    role: d.role,
+    restricted,
+    serverIds: restricted ? d.serverIds : [],
+    clusterIds: restricted ? d.clusterIds : [],
+  };
+}
+
+/** Inline editor for one user's role and access. */
+function UserEditor({
+  user,
+  servers,
+  clusters,
+  onSaved,
+  onCancel,
+}: {
+  user: UserDto;
+  servers: ServerSummary[];
+  clusters: ClusterLite[];
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const [draft, setDraft] = useState<AccessDraft>({
+    role: user.role,
+    restricted: user.restricted,
+    serverIds: user.serverIds,
+    clusterIds: user.clusterIds,
+  });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const save = async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      await apiPatch(`/users/${user.id}`, toAccessBody(draft));
+      onSaved();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 border-t border-slate-700/60 pt-3">
+      <AccessFields draft={draft} onChange={setDraft} servers={servers} clusters={clusters} />
+      <div className="flex items-center gap-2">
+        <button type="button" className="btn-primary" onClick={save} disabled={busy}>
+          <Check className="h-4 w-4" /> Save
+        </button>
+        <button type="button" className="btn-secondary" onClick={onCancel} disabled={busy}>
+          <X className="h-4 w-4" /> Cancel
+        </button>
+        {err && <p className="text-sm text-amber-400">{err}</p>}
+      </div>
+    </div>
+  );
+}
+
+const NEW_USER: AccessDraft = { role: "operator", restricted: false, serverIds: [], clusterIds: [] };
+
+/** Settings card: manage panel accounts, their roles, and which servers they can see. */
 export function UsersCard() {
-  const [users, setUsers] = useState<UserRow[]>([]);
+  const [users, setUsers] = useState<UserDto[]>([]);
+  const [servers, setServers] = useState<ServerSummary[]>([]);
+  const [clusters, setClusters] = useState<ClusterLite[]>([]);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [role, setRole] = useState<Role>("operator");
+  const [draft, setDraft] = useState<AccessDraft>(NEW_USER);
+  const [editing, setEditing] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
 
   const load = () => {
-    apiGet<UserRow[]>("/users")
+    apiGet<UserDto[]>("/users")
       .then(setUsers)
       .catch(() => undefined);
   };
-  useEffect(load, []);
+  useEffect(() => {
+    load();
+    apiGet<ServerSummary[]>("/servers").then(setServers).catch(() => undefined);
+    apiGet<ClusterLite[]>("/clusters").then(setClusters).catch(() => undefined);
+  }, []);
 
   const add = async () => {
     setBusy(true);
     setMsg(null);
     try {
-      await apiPost("/users", { username, password, role });
+      await apiPost("/users", { username, password, ...toAccessBody(draft) });
       setUsername("");
       setPassword("");
+      setDraft(NEW_USER);
       load();
     } catch (err) {
       setMsg((err as Error).message);
@@ -48,7 +249,7 @@ export function UsersCard() {
     }
   };
 
-  const remove = async (u: UserRow) => {
+  const remove = async (u: UserDto) => {
     if (!window.confirm(`Delete user "${u.username}"? Their tokens stop working immediately.`)) return;
     try {
       await apiDelete(`/users/${u.id}`);
@@ -65,44 +266,70 @@ export function UsersCard() {
       </h2>
       <p className="text-xs text-slate-500">
         Give friends their own logins. Viewers can look, operators can run servers, admins can
-        change anything. The API enforces roles server-side.
+        change anything. A viewer or operator can also be limited to chosen servers or clusters;
+        everything else is hidden from them, and they cannot create or import servers. The API
+        enforces all of this server-side.
       </p>
 
       <ul className="space-y-1">
-        {users.map((u) => (
-          <li key={u.id} className="flex items-center gap-3 rounded border border-slate-700/60 px-3 py-2 text-sm">
-            <span className="font-medium text-slate-200">{u.username}</span>
-            <span className="rounded bg-slate-700/60 px-2 py-0.5 text-xs uppercase tracking-wide text-slate-300">
-              {u.role}
-            </span>
-            <button
-              type="button"
-              className="btn-secondary ml-auto"
-              onClick={() => remove(u)}
-              disabled={users.length <= 1}
-              title={users.length <= 1 ? "The last user can't be deleted" : "Delete user"}
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
-          </li>
-        ))}
+        {users.map((u) => {
+          const access = accessLabel(u);
+          return (
+            <li key={u.id} className="rounded border border-slate-700/60 px-3 py-2 text-sm">
+              <div className="flex items-center gap-3">
+                <span className="font-medium text-slate-200">{u.username}</span>
+                <span className="rounded bg-slate-700/60 px-2 py-0.5 text-xs uppercase tracking-wide text-slate-300">
+                  {u.role}
+                </span>
+                {access && <span className="text-xs text-slate-500">{access}</span>}
+                <button
+                  type="button"
+                  className="btn-secondary ml-auto"
+                  onClick={() => setEditing(editing === u.id ? null : u.id)}
+                  title="Edit role and access"
+                >
+                  <Pencil className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={() => remove(u)}
+                  disabled={users.length <= 1}
+                  title={users.length <= 1 ? "The last user can't be deleted" : "Delete user"}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+              {editing === u.id && (
+                <div className="mt-3">
+                  <UserEditor
+                    user={u}
+                    servers={servers}
+                    clusters={clusters}
+                    onSaved={() => {
+                      setEditing(null);
+                      load();
+                    }}
+                    onCancel={() => setEditing(null)}
+                  />
+                </div>
+              )}
+            </li>
+          );
+        })}
       </ul>
 
-      <div className="grid gap-3 sm:grid-cols-3">
-        <input className="input" placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
-        <input type="password" className="input" placeholder="Password (8+ chars)" value={password} onChange={(e) => setPassword(e.target.value)} />
-        <select className="input" value={role} onChange={(e) => setRole(e.target.value as Role)}>
-          {ROLES.map((r) => (
-            <option key={r} value={r}>
-              {r}
-            </option>
-          ))}
-        </select>
+      <div className="space-y-3 border-t border-slate-700/60 pt-4">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">Add user</h3>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <input className="input" placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+          <input type="password" className="input" placeholder="Password (8+ chars)" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        <AccessFields draft={draft} onChange={setDraft} servers={servers} clusters={clusters} />
+        <button type="button" className="btn-secondary" onClick={add} disabled={busy || !username || password.length < 8}>
+          <Plus className="h-4 w-4" /> Add user
+        </button>
       </div>
-      <p className="text-xs text-slate-500">{ROLE_HINTS[role]}</p>
-      <button type="button" className="btn-secondary" onClick={add} disabled={busy || !username || password.length < 8}>
-        <Plus className="h-4 w-4" /> Add user
-      </button>
       {msg && <p className="text-sm text-amber-400">{msg}</p>}
     </div>
   );

--- a/apps/web/lib/use-me.ts
+++ b/apps/web/lib/use-me.ts
@@ -1,0 +1,33 @@
+"use client";
+import { useEffect, useState } from "react";
+import type { UserDto } from "@ark/shared";
+import { apiGet } from "./api";
+import { useAuth } from "./auth";
+
+/**
+ * The signed-in user as the API sees them (GET /auth/me), or null until it
+ * loads. Re-fetched whenever the auth token changes, for the same reason
+ * useRole keys off the token: the header mounts once on /login, before there
+ * is a token, and logging out and back in as someone else must not keep the
+ * old answer. Display gating only. The API filters and refuses for real.
+ */
+export function useMe(): UserDto | null {
+  const [me, setMe] = useState<UserDto | null>(null);
+  const { token } = useAuth();
+  useEffect(() => {
+    if (!token) {
+      setMe(null);
+      return;
+    }
+    let cancelled = false;
+    apiGet<UserDto>("/auth/me")
+      .then((u) => {
+        if (!cancelled) setMe(u);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+  return me;
+}

--- a/packages/shared/src/dto.ts
+++ b/packages/shared/src/dto.ts
@@ -298,6 +298,27 @@ export type Role = "viewer" | "operator" | "admin";
 export const ROLE_RANK: Record<Role, number> = { viewer: 0, operator: 1, admin: 2 };
 export const ROLES: Role[] = ["viewer", "operator", "admin"];
 
+/** A panel account as returned by /users and /auth/me (GH #73). Admins are never
+ *  restricted; `serverIds`/`clusterIds` only mean something when `restricted`. */
+export interface UserDto {
+  id: string;
+  username: string;
+  role: Role;
+  /** Only the granted servers (plus members of granted clusters) are visible. */
+  restricted: boolean;
+  serverIds: string[];
+  clusterIds: string[];
+  createdAt?: string;
+}
+
+/** Fields an admin may set when creating or editing a user. */
+export interface UserAccessDto {
+  role?: Role;
+  restricted?: boolean;
+  serverIds?: string[];
+  clusterIds?: string[];
+}
+
 /** Per-game artwork resolved from SteamGridDB (all URLs on their CDN; null = none found). */
 export interface GameArtwork {
   /** 600x900 portrait cover ("grid"). */


### PR DESCRIPTION
Closes #73.

Operators and viewers can now be limited to specific servers and clusters. Admins always see everything. Nothing changes on upgrade until an admin restricts a user.

## Semantics

- A non-admin user gets a `restricted` flag. Unrestricted users behave exactly as before.
- A restricted user sees servers granted directly plus every current and future member of any granted cluster. Their role still decides what they may do on those servers.
- A cluster is listed when granted or when any member is visible, with hidden members stripped. Cluster-wide actions (start/stop all, membership, delete) need the cluster granted or every member visible.
- Restricted users cannot create, adopt, or import servers. Copy works when the source and every target are visible.
- Denied servers and clusters return 404, not 403, so hidden ids can't be probed.

## Backend

- `User.restricted` plus `UserServerAccess` and `UserClusterAccess` join tables (migration `20260911000000_user_server_access`), cascading with the user, server, or cluster.
- `AccessService` resolves visibility. `ServerAccessGuard` runs after `RolesGuard` and checks every `servers/:id` and `clusters/:id` route from the route template. `JwtAuthGuard` reads `restricted` alongside `tokenVersion`, so edits apply on the next request.
- Lists are filtered: `/servers`, `/servers/stats`, `/clusters`, `/schedules`. Routes carrying the server id outside the path check explicitly: schedules (body, query, and by schedule id), `DELETE /backups/:snapshotId`, cluster membership, copy targets.
- Realtime: the gateway keeps the user on the socket and joins an `all` room or one room per visible server. `broadcast` emits to `all` plus the server room, so restricted users stop receiving other servers' logs and RCON output. Editing or deleting a user re-scopes or disconnects their open sockets.
- Users API: `PATCH /users/:id` for role and access, grants returned on `GET /users` and `/auth/me`, last-admin protection on demote and delete. New users default to operator instead of admin.

## Web

- Settings > Users: per-row editor with role, a restrict toggle, and a server picker grouped by cluster. Ticking a cluster covers its members, shown as "via cluster". Same fields on the add form.
- Restricted users lose the New server, Adopt existing, copy menu, and cluster-edit controls. A hidden server renders a not-found page instead of an endless spinner.
- README gains a "Users and access" section.

## Tests

72 new tests across the access service, guard, user management, schedules, server and cluster list filtering, and gateway room routing. Full API suite: 647 passing. Typecheck and web lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)